### PR TITLE
[SERV-528] Temporarily comment out Helm GA stuff

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,19 +47,19 @@ jobs:
             -Ddocker.registry.username=${{ secrets.DOCKER_USERNAME }}
             -Ddocker.registry.account=${{ secrets.DOCKER_REGISTRY_ACCOUNT}}
             -Ddocker.registry.password=${{ secrets.DOCKER_PASSWORD }}
-      - name: Detect New Helm Chart
-        run: |
-          CURRENT_CHART_VERSION=$(cat pom.xml | grep -oPm1 "(?<=<prl-harvester.helm.chart.version>)[^<]+")
-          HTTP_RESP=$(curl -s -w "%{http_code}" -o /dev/null https://chartmuseum.library.ucla.edu/api/charts/prl-harvester/${CURRENT_CHART_VERSION})
-          echo "CM_HTTP_RESP=${HTTP_RESP}" >> $GITHUB_ENV
-      - name: Deploy Helm Chart
-        if: env.CM_HTTP_RESP == 404
-        uses: samuelmeuli/action-maven-publish@201a45a3f311b2ee888f252ba9f4194257545709 # v1.4.0
-        with:
-          maven_goals_phases: "com.deviceinsight.helm:helm-maven-plugin:2.10.0:deploy"
-          maven_profiles: default
-          maven_args: >
-            -Drevision=${{ github.event.release.tag_name }}
-            -Dhelm.maven.repo.publish.url=${{ secrets.UCLALIB_HELM_CM_PUBLISH_URL }}
-            -Dhelm.maven.repo.username=${{ secrets.UCLALIB_HELM_CM_USERNAME }}
-            -Dhelm.maven.repo.password=${{ secrets.UCLALIB_HELM_CM_PASSWORD }}
+#      - name: Detect New Helm Chart
+#        run: |
+#          CURRENT_CHART_VERSION=$(cat pom.xml | grep -oPm1 "(?<=<prl-harvester.helm.chart.version>)[^<]+")
+#          HTTP_RESP=$(curl -s -w "%{http_code}" -o /dev/null https://chartmuseum.library.ucla.edu/api/charts/prl-harvester/${CURRENT_CHART_VERSION})
+#          echo "CM_HTTP_RESP=${HTTP_RESP}" >> $GITHUB_ENV
+#      - name: Deploy Helm Chart
+#        if: env.CM_HTTP_RESP == 404
+#        uses: samuelmeuli/action-maven-publish@201a45a3f311b2ee888f252ba9f4194257545709 # v1.4.0
+#        with:
+#          maven_goals_phases: "com.deviceinsight.helm:helm-maven-plugin:2.10.0:deploy"
+#          maven_profiles: default
+#          maven_args: >
+#            -Drevision=${{ github.event.release.tag_name }}
+#            -Dhelm.maven.repo.publish.url=${{ secrets.UCLALIB_HELM_CM_PUBLISH_URL }}
+#            -Dhelm.maven.repo.username=${{ secrets.UCLALIB_HELM_CM_USERNAME }}
+#            -Dhelm.maven.repo.password=${{ secrets.UCLALIB_HELM_CM_PASSWORD }}


### PR DESCRIPTION
We're not using Helm with this project yet and we need to test the workflow (up to the point of using Helm).

_Note:_ everything up to the Helm stuff worked in the last release attempt (i.e. Docker image was pushed to [DockerHub](https://hub.docker.com/repository/docker/uclalibrary/prl-harvester/general))