### PR TITLE
[SERV-534] Define institution and harvest job types

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <vertx.version>4.3.3</vertx.version>
     <freelib.utils.version>3.2.0</freelib.utils.version>
     <freelib.maven.version>0.3.3</freelib.maven.version>
-    <quartz.version>2.3.2<quartz.version>
+    <quartz.version>2.3.2</quartz.version>
     <javax.mail.version>1.6.2</javax.mail.version>
     <libphonenumber.version>8.12.54</libphonenumber.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
     <vertx.version>4.3.3</vertx.version>
     <freelib.utils.version>3.2.0</freelib.utils.version>
     <freelib.maven.version>0.3.3</freelib.maven.version>
+    <quartz.version>2.3.2<quartz.version>
     <javax.mail.version>1.6.2</javax.mail.version>
     <libphonenumber.version>8.12.54</libphonenumber.version>
 
@@ -138,7 +139,7 @@
     <dependency>
       <groupId>org.quartz-scheduler</groupId>
       <artifactId>quartz</artifactId>
-      <version>2.3.2</version>
+      <version>${quartz.version}</version>
     </dependency>
     <dependency>
       <groupId>com.sun.mail</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,8 @@
     <vertx.version>4.3.3</vertx.version>
     <freelib.utils.version>3.2.0</freelib.utils.version>
     <freelib.maven.version>0.3.3</freelib.maven.version>
+    <javax.mail.version>1.6.2</javax.mail.version>
+    <libphonenumber.version>8.12.54</libphonenumber.version>
 
     <!-- Build plugin versions -->
     <vertx.plugin.version>1.0.28</vertx.plugin.version>
@@ -128,6 +130,28 @@
       <groupId>io.vertx</groupId>
       <artifactId>vertx-config</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-codegen</artifactId>
+      <classifier>processor</classifier>
+    </dependency>
+    <dependency>
+      <groupId>org.quartz-scheduler</groupId>
+      <artifactId>quartz</artifactId>
+      <version>2.3.2</version>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.mail</groupId>
+      <artifactId>javax.mail</artifactId>
+      <version>${javax.mail.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.googlecode.libphonenumber</groupId>
+      <artifactId>libphonenumber</artifactId>
+      <version>${libphonenumber.version}</version>
+    </dependency>
+
+
 
     <!-- Below dependencies only used for testing -->
     <dependency>

--- a/src/main/java/edu/ucla/library/prl/harvester/Constants.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/Constants.java
@@ -1,0 +1,19 @@
+
+package edu.ucla.library.prl.harvester;
+
+/**
+ * Constant values.
+ */
+public final class Constants {
+
+    /**
+     * The metadata prefix for OAI-PMH harvesting (currently we only support Dublin Core).
+     */
+    static final String OAI_DC = "oai_dc";
+
+    /**
+     * Constant classes should have private constructors.
+     */
+    private Constants() {
+    }
+}

--- a/src/main/java/edu/ucla/library/prl/harvester/Institution.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/Institution.java
@@ -135,7 +135,7 @@ public final class Institution {
      * Instantiates an institution from its JSON representation.
      * <p>
      * <b>This constructor is meant to be used only by generated service proxy code!</b>
-     * {@link #Institution(String, String, String, ContactMethods, URL)} should be used everywhere else.
+     * {@link #Institution(String, String, String, Optional, Optional, Optional, URL)} should be used everywhere else.
      *
      * @param aJsonObject An institution represented as JSON
      * @throws InvalidInstitutionJsonException If the JSON representation is invalid

--- a/src/main/java/edu/ucla/library/prl/harvester/Institution.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/Institution.java
@@ -1,0 +1,253 @@
+
+package edu.ucla.library.prl.harvester;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Objects;
+import java.util.Optional;
+
+import javax.mail.internet.AddressException;
+import javax.mail.internet.InternetAddress;
+
+import com.google.i18n.phonenumbers.NumberParseException;
+import com.google.i18n.phonenumbers.PhoneNumberUtil;
+import com.google.i18n.phonenumbers.PhoneNumberUtil.PhoneNumberFormat;
+import com.google.i18n.phonenumbers.Phonenumber.PhoneNumber;
+
+import info.freelibrary.util.Logger;
+import info.freelibrary.util.LoggerFactory;
+
+import io.vertx.codegen.annotations.DataObject;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Represents a provider institution.
+ */
+@DataObject
+@SuppressWarnings("PMD.DataClass")
+public final class Institution {
+
+    /**
+     * The JSON key for the name.
+     */
+    static final String NAME = "name";
+
+    /**
+     * The JSON key for the description.
+     */
+    static final String DESCRIPTION = "description";
+
+    /**
+     * The JSON key for the location.
+     */
+    static final String LOCATION = "location";
+
+    /**
+     * The JSON key for the email.
+     */
+    static final String EMAIL = "email";
+
+    /**
+     * The JSON key for the phone.
+     */
+    static final String PHONE = "phone";
+
+    /**
+     * The JSON key for the web contact.
+     */
+    static final String WEB_CONTACT = "webContact";
+
+    /**
+     * The JSON key for the website.
+     */
+    static final String WEBSITE = "website";
+
+    /**
+     * The logger.
+     */
+    private static final Logger LOGGER = LoggerFactory.getLogger(Institution.class, MessageCodes.BUNDLE);
+
+    /**
+     * Parses and formats phone numbers.
+     */
+    private static final PhoneNumberUtil PHONE_NUMBER_UTIL = PhoneNumberUtil.getInstance();
+
+    /**
+     * The institution's name.
+     */
+    private final String myName;
+
+    /**
+     * The institution's description.
+     */
+    private final String myDescription;
+
+    /**
+     * The institution's human-readable location.
+     */
+    private final String myLocation;
+
+    /**
+     * The optional email address contact of the institution.
+     */
+    private final Optional<InternetAddress> myEmail;
+
+    /**
+     * The optional phone number contact of the institution.
+     */
+    private final Optional<PhoneNumber> myPhone;
+
+    /**
+     * The optional web contact of the institution.
+     */
+    private final Optional<URL> myWebContact;
+
+    /**
+     * The institiution's website.
+     */
+    private final URL myWebsite;
+
+    /**
+     * Instantiates an institution.
+     * <p>
+     * At least one of {@code anEmail}, {@code aPhone}, or {@code aWebContact} must be provided.
+     *
+     * @param aName The institution's name
+     * @param aDescription The institution's description
+     * @param aLocation The institution's human-readable location
+     * @param anEmail The optional email address contact of the institution
+     * @param aPhone The optional phone number contact of the institution
+     * @param aWebContact The optional web contact of the institution
+     * @param aWebsite The institiution's website
+     */
+    @SuppressWarnings("PMD.AvoidThrowingNullPointerException")
+    public Institution(final String aName, final String aDescription, final String aLocation,
+            final InternetAddress anEmail, final PhoneNumber aPhone, final URL aWebContact, final URL aWebsite) {
+        myName = Objects.requireNonNull(aName);
+        myDescription = Objects.requireNonNull(aDescription);
+        myLocation = Objects.requireNonNull(aLocation);
+
+        if (anEmail == null && aPhone == null && aWebContact == null) {
+            throw new NullPointerException(LOGGER.getMessage(MessageCodes.PRL_002));
+        } else {
+            myEmail = Optional.ofNullable(anEmail);
+            myPhone = Optional.ofNullable(aPhone);
+            myWebContact = Optional.ofNullable(aWebContact);
+        }
+
+        myWebsite = Objects.requireNonNull(aWebsite);
+    }
+
+    /**
+     * Instantiates an institution from its JSON representation.
+     * <p>
+     * <b>This constructor is meant to be used only by generated service proxy code!</b>
+     * {@link #Institution(String, String, String, InternetAddress, PhoneNumber, URL, URL)} should be used everywhere
+     * else.
+     *
+     * @param aJsonObject An institution represented as JSON
+     * @throws IllegalArgumentException If the JSON representation is invalid
+     */
+    @SuppressWarnings({ "PMD.AvoidCatchingNPE", "PMD.AvoidCatchingGenericException" })
+    public Institution(final JsonObject aJsonObject) {
+        try {
+            myName = Objects.requireNonNull(aJsonObject.getString(NAME));
+            myDescription = Objects.requireNonNull(aJsonObject.getString(DESCRIPTION));
+            myLocation = Objects.requireNonNull(aJsonObject.getString(LOCATION));
+            myEmail = Optional.ofNullable(aJsonObject.getString(EMAIL)).map(email -> {
+                try {
+                    return new InternetAddress(email, true);
+                } catch (final AddressException details) {
+                    throw new IllegalArgumentException(details.getMessage(), details);
+                }
+            });
+            myPhone = Optional.ofNullable(aJsonObject.getString(PHONE)).map(phone -> {
+                try {
+                    return PHONE_NUMBER_UTIL.parse(phone, null);
+                } catch (NumberParseException details) {
+                    throw new IllegalArgumentException(details.getMessage(), details);
+                }
+            });
+            myWebContact = Optional.ofNullable(aJsonObject.getString(WEB_CONTACT)).map(webContact -> {
+                try {
+                    return new URL(webContact);
+                } catch (MalformedURLException details) {
+                    throw new IllegalArgumentException(details.getMessage(), details);
+                }
+            });
+
+            if (myEmail.isEmpty() && myPhone.isEmpty() && myWebContact.isEmpty()) {
+                throw new IllegalArgumentException(LOGGER.getMessage(MessageCodes.PRL_002));
+            }
+
+            myWebsite = new URL(Objects.requireNonNull(aJsonObject.getString(WEBSITE)));
+        } catch (final MalformedURLException | NullPointerException details) {
+            throw new IllegalArgumentException(details.getMessage(), details);
+        }
+    }
+
+    /**
+     * @return The JSON representation of the institution
+     */
+    public JsonObject toJson() {
+        return new JsonObject() //
+                .put(NAME, getName()) //
+                .put(DESCRIPTION, getDescription()) //
+                .put(LOCATION, getLocation()) //
+                .put(EMAIL, getEmail().map(InternetAddress::toString).orElse(null)) //
+                .put(PHONE, getPhone() //
+                        .map(phone -> PHONE_NUMBER_UTIL.format(phone, PhoneNumberFormat.INTERNATIONAL)) //
+                        .orElse(null)) //
+                .put(WEB_CONTACT, getWebContact().map(URL::toString).orElse(null)) //
+                .put(WEBSITE, myWebsite.toString());
+    }
+
+    /**
+     * @return The name
+     */
+    public String getName() {
+        return myName;
+    }
+
+    /**
+     * @return The description
+     */
+    public String getDescription() {
+        return myDescription;
+    }
+
+    /**
+     * @return The location
+     */
+    public String getLocation() {
+        return myLocation;
+    }
+
+    /**
+     * @return The optional email
+     */
+    public Optional<InternetAddress> getEmail() {
+        return myEmail;
+    }
+
+    /**
+     * @return The optional phone
+     */
+    public Optional<PhoneNumber> getPhone() {
+        return myPhone;
+    }
+
+    /**
+     * @return The optional web contact
+     */
+    public Optional<URL> getWebContact() {
+        return myWebContact;
+    }
+
+    /**
+     * @return The website
+     */
+    public URL getWebsite() {
+        return myWebsite;
+    }
+}

--- a/src/main/java/edu/ucla/library/prl/harvester/Institution.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/Institution.java
@@ -277,13 +277,9 @@ public final class Institution {
          * @param aWebContact A web contact URL
          */
         public ContactMethods(final InternetAddress anEmail, final PhoneNumber aPhone, final URL aWebContact) {
-            Objects.requireNonNull(anEmail);
-            Objects.requireNonNull(aPhone);
-            Objects.requireNonNull(aWebContact);
-
-            myEmail = Optional.of(anEmail);
-            myPhone = Optional.of(aPhone);
-            myWebContact = Optional.of(aWebContact);
+            myEmail = Optional.of(Objects.requireNonNull(anEmail));
+            myPhone = Optional.of(Objects.requireNonNull(aPhone));
+            myWebContact = Optional.of(Objects.requireNonNull(aWebContact));
         }
 
         /**
@@ -293,11 +289,8 @@ public final class Institution {
          * @param aPhone A phone number
          */
         public ContactMethods(final InternetAddress anEmail, final PhoneNumber aPhone) {
-            Objects.requireNonNull(anEmail);
-            Objects.requireNonNull(aPhone);
-
-            myEmail = Optional.of(anEmail);
-            myPhone = Optional.of(aPhone);
+            myEmail = Optional.of(Objects.requireNonNull(anEmail));
+            myPhone = Optional.of(Objects.requireNonNull(aPhone));
             myWebContact = Optional.empty();
         }
 
@@ -308,12 +301,9 @@ public final class Institution {
          * @param aWebContact A web contact URL
          */
         public ContactMethods(final InternetAddress anEmail, final URL aWebContact) {
-            Objects.requireNonNull(anEmail);
-            Objects.requireNonNull(aWebContact);
-
-            myEmail = Optional.of(anEmail);
+            myEmail = Optional.of(Objects.requireNonNull(anEmail));
             myPhone = Optional.empty();
-            myWebContact = Optional.of(aWebContact);
+            myWebContact = Optional.of(Objects.requireNonNull(aWebContact));
         }
 
         /**
@@ -323,12 +313,9 @@ public final class Institution {
          * @param aWebContact A web contact URL
          */
         public ContactMethods(final PhoneNumber aPhone, final URL aWebContact) {
-            Objects.requireNonNull(aPhone);
-            Objects.requireNonNull(aWebContact);
-
             myEmail = Optional.empty();
-            myPhone = Optional.of(aPhone);
-            myWebContact = Optional.of(aWebContact);
+            myPhone = Optional.of(Objects.requireNonNull(aPhone));
+            myWebContact = Optional.of(Objects.requireNonNull(aWebContact));
         }
 
         /**
@@ -337,9 +324,7 @@ public final class Institution {
          * @param anEmail An email address
          */
         public ContactMethods(final InternetAddress anEmail) {
-            Objects.requireNonNull(anEmail);
-
-            myEmail = Optional.of(anEmail);
+            myEmail = Optional.of(Objects.requireNonNull(anEmail));
             myPhone = Optional.empty();
             myWebContact = Optional.empty();
         }
@@ -350,10 +335,8 @@ public final class Institution {
          * @param aPhone A phone number
          */
         public ContactMethods(final PhoneNumber aPhone) {
-            Objects.requireNonNull(aPhone);
-
             myEmail = Optional.empty();
-            myPhone = Optional.of(aPhone);
+            myPhone = Optional.of(Objects.requireNonNull(aPhone));
             myWebContact = Optional.empty();
         }
 
@@ -363,11 +346,9 @@ public final class Institution {
          * @param aWebContact A web contact URL
          */
         public ContactMethods(final URL aWebContact) {
-            Objects.requireNonNull(aWebContact);
-
             myEmail = Optional.empty();
             myPhone = Optional.empty();
-            myWebContact = Optional.of(aWebContact);
+            myWebContact = Optional.of(Objects.requireNonNull(aWebContact));
         }
 
         /**

--- a/src/main/java/edu/ucla/library/prl/harvester/Institution.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/Institution.java
@@ -124,7 +124,8 @@ public final class Institution {
      * @param aJsonObject An institution represented as JSON
      * @throws IllegalArgumentException If the JSON representation is invalid
      */
-    @SuppressWarnings({ "PMD.AvoidCatchingNPE", "PMD.AvoidCatchingGenericException" })
+    @SuppressWarnings({ "PMD.AvoidCatchingGenericException", "PMD.AvoidCatchingNPE", "PMD.CognitiveComplexity",
+        "PMD.CyclomaticComplexity" })
     public Institution(final JsonObject aJsonObject) {
         Objects.requireNonNull(aJsonObject);
         try {

--- a/src/main/java/edu/ucla/library/prl/harvester/Institution.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/Institution.java
@@ -150,6 +150,7 @@ public final class Institution {
      */
     @SuppressWarnings({ "PMD.AvoidCatchingNPE", "PMD.AvoidCatchingGenericException" })
     public Institution(final JsonObject aJsonObject) {
+        Objects.requireNonNull(aJsonObject);
         try {
             myName = Objects.requireNonNull(aJsonObject.getString(NAME));
             myDescription = Objects.requireNonNull(aJsonObject.getString(DESCRIPTION));

--- a/src/main/java/edu/ucla/library/prl/harvester/Institution.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/Institution.java
@@ -88,19 +88,9 @@ public final class Institution {
     private final String myLocation;
 
     /**
-     * The optional email address contact of the institution.
+     * The institution's contact methods.
      */
-    private final Optional<InternetAddress> myEmail;
-
-    /**
-     * The optional phone number contact of the institution.
-     */
-    private final Optional<PhoneNumber> myPhone;
-
-    /**
-     * The optional web contact of the institution.
-     */
-    private final Optional<URL> myWebContact;
+    private final ContactMethods myContactMethods;
 
     /**
      * The institiution's website.
@@ -109,32 +99,19 @@ public final class Institution {
 
     /**
      * Instantiates an institution.
-     * <p>
-     * At least one of {@code anEmail}, {@code aPhone}, or {@code aWebContact} must be provided.
      *
      * @param aName The institution's name
      * @param aDescription The institution's description
      * @param aLocation The institution's human-readable location
-     * @param anEmail The optional email address contact of the institution
-     * @param aPhone The optional phone number contact of the institution
-     * @param aWebContact The optional web contact of the institution
+     * @param aContactMethods The institution's contact methods
      * @param aWebsite The institiution's website
      */
-    @SuppressWarnings("PMD.AvoidThrowingNullPointerException")
     public Institution(final String aName, final String aDescription, final String aLocation,
-            final InternetAddress anEmail, final PhoneNumber aPhone, final URL aWebContact, final URL aWebsite) {
+            final ContactMethods aContactMethods, final URL aWebsite) {
         myName = Objects.requireNonNull(aName);
         myDescription = Objects.requireNonNull(aDescription);
         myLocation = Objects.requireNonNull(aLocation);
-
-        if (anEmail == null && aPhone == null && aWebContact == null) {
-            throw new NullPointerException(LOGGER.getMessage(MessageCodes.PRL_002));
-        } else {
-            myEmail = Optional.ofNullable(anEmail);
-            myPhone = Optional.ofNullable(aPhone);
-            myWebContact = Optional.ofNullable(aWebContact);
-        }
-
+        myContactMethods = Objects.requireNonNull(aContactMethods);
         myWebsite = Objects.requireNonNull(aWebsite);
     }
 
@@ -152,32 +129,51 @@ public final class Institution {
     public Institution(final JsonObject aJsonObject) {
         Objects.requireNonNull(aJsonObject);
         try {
+            final Optional<InternetAddress> email;
+            final Optional<PhoneNumber> phone;
+            final Optional<URL> webContact;
+
             myName = Objects.requireNonNull(aJsonObject.getString(NAME));
             myDescription = Objects.requireNonNull(aJsonObject.getString(DESCRIPTION));
             myLocation = Objects.requireNonNull(aJsonObject.getString(LOCATION));
-            myEmail = Optional.ofNullable(aJsonObject.getString(EMAIL)).map(email -> {
+
+            email = Optional.ofNullable(aJsonObject.getString(EMAIL)).map(rawEmail -> {
                 try {
-                    return new InternetAddress(email, true);
+                    return new InternetAddress(rawEmail, true);
                 } catch (final AddressException details) {
                     throw new IllegalArgumentException(details.getMessage(), details);
                 }
             });
-            myPhone = Optional.ofNullable(aJsonObject.getString(PHONE)).map(phone -> {
+            phone = Optional.ofNullable(aJsonObject.getString(PHONE)).map(rawPhone -> {
                 try {
-                    return PHONE_NUMBER_UTIL.parse(phone, null);
+                    return PHONE_NUMBER_UTIL.parse(rawPhone, null);
                 } catch (NumberParseException details) {
                     throw new IllegalArgumentException(details.getMessage(), details);
                 }
             });
-            myWebContact = Optional.ofNullable(aJsonObject.getString(WEB_CONTACT)).map(webContact -> {
+            webContact = Optional.ofNullable(aJsonObject.getString(WEB_CONTACT)).map(rawWebContact -> {
                 try {
-                    return new URL(webContact);
+                    return new URL(rawWebContact);
                 } catch (MalformedURLException details) {
                     throw new IllegalArgumentException(details.getMessage(), details);
                 }
             });
 
-            if (myEmail.isEmpty() && myPhone.isEmpty() && myWebContact.isEmpty()) {
+            if (email.isPresent() && phone.isPresent() && webContact.isPresent()) {
+                myContactMethods = new ContactMethods(email.get(), phone.get(), webContact.get());
+            } else if (email.isPresent() && phone.isPresent()) {
+                myContactMethods = new ContactMethods(email.get(), phone.get());
+            } else if (email.isPresent() && webContact.isPresent()) {
+                myContactMethods = new ContactMethods(email.get(), webContact.get());
+            } else if (phone.isPresent() && webContact.isPresent()) {
+                myContactMethods = new ContactMethods(phone.get(), webContact.get());
+            } else if (email.isPresent()) {
+                myContactMethods = new ContactMethods(email.get());
+            } else if (phone.isPresent()) {
+                myContactMethods = new ContactMethods(phone.get());
+            } else if (webContact.isPresent()) {
+                myContactMethods = new ContactMethods(webContact.get());
+            } else {
                 throw new IllegalArgumentException(LOGGER.getMessage(MessageCodes.PRL_002));
             }
 
@@ -195,11 +191,11 @@ public final class Institution {
                 .put(NAME, getName()) //
                 .put(DESCRIPTION, getDescription()) //
                 .put(LOCATION, getLocation()) //
-                .put(EMAIL, getEmail().map(InternetAddress::toString).orElse(null)) //
-                .put(PHONE, getPhone() //
+                .put(EMAIL, getContactMethods().getEmail().map(InternetAddress::toString).orElse(null)) //
+                .put(PHONE, getContactMethods().getPhone() //
                         .map(phone -> PHONE_NUMBER_UTIL.format(phone, PhoneNumberFormat.INTERNATIONAL)) //
                         .orElse(null)) //
-                .put(WEB_CONTACT, getWebContact().map(URL::toString).orElse(null)) //
+                .put(WEB_CONTACT, getContactMethods().getWebContact().map(URL::toString).orElse(null)) //
                 .put(WEBSITE, myWebsite.toString());
     }
 
@@ -225,24 +221,10 @@ public final class Institution {
     }
 
     /**
-     * @return The optional email
+     * @return The contact methods
      */
-    public Optional<InternetAddress> getEmail() {
-        return myEmail;
-    }
-
-    /**
-     * @return The optional phone
-     */
-    public Optional<PhoneNumber> getPhone() {
-        return myPhone;
-    }
-
-    /**
-     * @return The optional web contact
-     */
-    public Optional<URL> getWebContact() {
-        return myWebContact;
+    public ContactMethods getContactMethods() {
+        return myContactMethods;
     }
 
     /**
@@ -250,5 +232,148 @@ public final class Institution {
      */
     public URL getWebsite() {
         return myWebsite;
+    }
+
+    /**
+     * Contact methods.
+     */
+    public static final class ContactMethods {
+
+        /**
+         * The optional email address contact of the institution.
+         */
+        private final Optional<InternetAddress> myEmail;
+
+        /**
+         * The optional phone number contact of the institution.
+         */
+        private final Optional<PhoneNumber> myPhone;
+
+        /**
+         * The optional web contact of the institution.
+         */
+        private final Optional<URL> myWebContact;
+
+        /**
+         * Instantiates a set of contact methods.
+         *
+         * @param anEmail An email address
+         * @param aPhone A phone number
+         * @param aWebContact A web contact URL
+         */
+        public ContactMethods(final InternetAddress anEmail, final PhoneNumber aPhone, final URL aWebContact) {
+            Objects.requireNonNull(anEmail);
+            Objects.requireNonNull(aPhone);
+            Objects.requireNonNull(aWebContact);
+
+            myEmail = Optional.of(anEmail);
+            myPhone = Optional.of(aPhone);
+            myWebContact = Optional.of(aWebContact);
+        }
+
+        /**
+         * Instantiates a set of contact methods.
+         *
+         * @param anEmail An email address
+         * @param aPhone A phone number
+         */
+        public ContactMethods(final InternetAddress anEmail, final PhoneNumber aPhone) {
+            Objects.requireNonNull(anEmail);
+            Objects.requireNonNull(aPhone);
+
+            myEmail = Optional.of(anEmail);
+            myPhone = Optional.of(aPhone);
+            myWebContact = Optional.empty();
+        }
+
+        /**
+         * Instantiates a set of contact methods.
+         *
+         * @param anEmail An email address
+         * @param aWebContact A web contact URL
+         */
+        public ContactMethods(final InternetAddress anEmail, final URL aWebContact) {
+            Objects.requireNonNull(anEmail);
+            Objects.requireNonNull(aWebContact);
+
+            myEmail = Optional.of(anEmail);
+            myPhone = Optional.empty();
+            myWebContact = Optional.of(aWebContact);
+        }
+
+        /**
+         * Instantiates a set of contact methods.
+         *
+         * @param aPhone A phone number
+         * @param aWebContact A web contact URL
+         */
+        public ContactMethods(final PhoneNumber aPhone, final URL aWebContact) {
+            Objects.requireNonNull(aPhone);
+            Objects.requireNonNull(aWebContact);
+
+            myEmail = Optional.empty();
+            myPhone = Optional.of(aPhone);
+            myWebContact = Optional.of(aWebContact);
+        }
+
+        /**
+         * Instantiates a set of contact methods.
+         *
+         * @param anEmail An email address
+         */
+        public ContactMethods(final InternetAddress anEmail) {
+            Objects.requireNonNull(anEmail);
+
+            myEmail = Optional.of(anEmail);
+            myPhone = Optional.empty();
+            myWebContact = Optional.empty();
+        }
+
+        /**
+         * Instantiates a set of contact methods.
+         *
+         * @param aPhone A phone number
+         */
+        public ContactMethods(final PhoneNumber aPhone) {
+            Objects.requireNonNull(aPhone);
+
+            myEmail = Optional.empty();
+            myPhone = Optional.of(aPhone);
+            myWebContact = Optional.empty();
+        }
+
+        /**
+         * Instantiates a set of contact methods.
+         *
+         * @param aWebContact A web contact URL
+         */
+        public ContactMethods(final URL aWebContact) {
+            Objects.requireNonNull(aWebContact);
+
+            myEmail = Optional.empty();
+            myPhone = Optional.empty();
+            myWebContact = Optional.of(aWebContact);
+        }
+
+        /**
+         * @return The optional email
+         */
+        public Optional<InternetAddress> getEmail() {
+            return myEmail;
+        }
+
+        /**
+         * @return The optional phone
+         */
+        public Optional<PhoneNumber> getPhone() {
+            return myPhone;
+        }
+
+        /**
+         * @return The optional web contact
+         */
+        public Optional<URL> getWebContact() {
+            return myWebContact;
+        }
     }
 }

--- a/src/main/java/edu/ucla/library/prl/harvester/Institution.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/Institution.java
@@ -122,7 +122,7 @@ public final class Institution {
      * {@link #Institution(String, String, String, ContactMethods, URL)} should be used everywhere else.
      *
      * @param aJsonObject An institution represented as JSON
-     * @throws IllegalArgumentException If the JSON representation is invalid
+     * @throws InvalidInstitutionJsonException If the JSON representation is invalid
      */
     @SuppressWarnings({ "PMD.AvoidCatchingGenericException", "PMD.AvoidCatchingNPE", "PMD.CognitiveComplexity",
         "PMD.CyclomaticComplexity" })
@@ -141,21 +141,21 @@ public final class Institution {
                 try {
                     return new InternetAddress(rawEmail, true);
                 } catch (final AddressException details) {
-                    throw new IllegalArgumentException(details.getMessage(), details);
+                    throw new InvalidInstitutionJsonException(details);
                 }
             });
             phone = Optional.ofNullable(aJsonObject.getString(PHONE)).map(rawPhone -> {
                 try {
                     return PHONE_NUMBER_UTIL.parse(rawPhone, null);
                 } catch (NumberParseException details) {
-                    throw new IllegalArgumentException(details.getMessage(), details);
+                    throw new InvalidInstitutionJsonException(details);
                 }
             });
             webContact = Optional.ofNullable(aJsonObject.getString(WEB_CONTACT)).map(rawWebContact -> {
                 try {
                     return new URL(rawWebContact);
                 } catch (MalformedURLException details) {
-                    throw new IllegalArgumentException(details.getMessage(), details);
+                    throw new InvalidInstitutionJsonException(details);
                 }
             });
 
@@ -174,12 +174,12 @@ public final class Institution {
             } else if (webContact.isPresent()) {
                 myContactMethods = new ContactMethods(webContact.get());
             } else {
-                throw new IllegalArgumentException(LOGGER.getMessage(MessageCodes.PRL_002));
+                throw new InvalidInstitutionJsonException(LOGGER.getMessage(MessageCodes.PRL_002));
             }
 
             myWebsite = new URL(Objects.requireNonNull(aJsonObject.getString(WEBSITE)));
         } catch (final MalformedURLException | NullPointerException details) {
-            throw new IllegalArgumentException(details.getMessage(), details);
+            throw new InvalidInstitutionJsonException(details);
         }
     }
 

--- a/src/main/java/edu/ucla/library/prl/harvester/Institution.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/Institution.java
@@ -119,8 +119,7 @@ public final class Institution {
      * Instantiates an institution from its JSON representation.
      * <p>
      * <b>This constructor is meant to be used only by generated service proxy code!</b>
-     * {@link #Institution(String, String, String, InternetAddress, PhoneNumber, URL, URL)} should be used everywhere
-     * else.
+     * {@link #Institution(String, String, String, ContactMethods, URL)} should be used everywhere else.
      *
      * @param aJsonObject An institution represented as JSON
      * @throws IllegalArgumentException If the JSON representation is invalid
@@ -235,7 +234,7 @@ public final class Institution {
     }
 
     /**
-     * Contact methods.
+     * Represents a valid set of contact methods.
      */
     public static final class ContactMethods {
 

--- a/src/main/java/edu/ucla/library/prl/harvester/InvalidInstitutionJsonException.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/InvalidInstitutionJsonException.java
@@ -30,7 +30,7 @@ public class InvalidInstitutionJsonException extends IllegalArgumentException {
      * @param aMessage The detail message
      */
     public InvalidInstitutionJsonException(final String aMessage) {
-        super(StringUtils.format("{}: {}", MESSAGE, aMessage));
+        this(aMessage, null);
     }
 
     /**

--- a/src/main/java/edu/ucla/library/prl/harvester/InvalidInstitutionJsonException.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/InvalidInstitutionJsonException.java
@@ -8,6 +8,11 @@ import info.freelibrary.util.StringUtils;
 public class InvalidInstitutionJsonException extends IllegalArgumentException {
 
     /**
+     * The <code>serialVersionUID</code> for this class.
+     */
+    private static final long serialVersionUID = 1269493839347809483L;
+
+    /**
      * The message unique to this exception.
      */
     private static final String MESSAGE = "The supplied JsonObject does not represent a valid Institution";

--- a/src/main/java/edu/ucla/library/prl/harvester/InvalidInstitutionJsonException.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/InvalidInstitutionJsonException.java
@@ -1,11 +1,12 @@
+
 package edu.ucla.library.prl.harvester;
 
-import info.freelibrary.util.StringUtils;
+import info.freelibrary.util.I18nRuntimeException;
 
 /**
  * Represents an error in the JSON representation of an {@link Institution}.
  */
-public class InvalidInstitutionJsonException extends IllegalArgumentException {
+public class InvalidInstitutionJsonException extends I18nRuntimeException {
 
     /**
      * The <code>serialVersionUID</code> for this class.
@@ -13,42 +14,32 @@ public class InvalidInstitutionJsonException extends IllegalArgumentException {
     private static final long serialVersionUID = 1269493839347809483L;
 
     /**
-     * The message unique to this exception.
-     */
-    private static final String MESSAGE = "The supplied JsonObject does not represent a valid Institution";
-
-    /**
      * Instantiates an exception.
+     *
+     * @param aMessageKey The message key
      */
-    public InvalidInstitutionJsonException() {
-        super();
+    public InvalidInstitutionJsonException(final String aMessageKey) {
+        super(MessageCodes.BUNDLE, aMessageKey);
     }
 
     /**
      * Instantiates an exception.
      *
-     * @param aMessage The detail message
+     * @param aMessageKey The message key
+     * @param aVarArgs The message details
      */
-    public InvalidInstitutionJsonException(final String aMessage) {
-        this(aMessage, null);
-    }
-
-    /**
-     * Instantiates an exception.
-     *
-     * @param aMessage The detail message
-     * @param aCause The cause
-     */
-    public InvalidInstitutionJsonException(final String aMessage, final Throwable aCause) {
-        super(StringUtils.format("{}: {}", MESSAGE, aMessage), aCause);
+    public InvalidInstitutionJsonException(final String aMessageKey, final Object... aVarArgs) {
+        super(MessageCodes.BUNDLE, aMessageKey, aVarArgs);
     }
 
     /**
      * Instantiates an exception.
      *
      * @param aCause The cause
+     * @param aMessageKey The message key
+     * @param aVarArgs The message details
      */
-    public InvalidInstitutionJsonException(final Throwable aCause) {
-        super(MESSAGE, aCause);
+    public InvalidInstitutionJsonException(final Throwable aCause, final String aMessageKey, final Object... aVarArgs) {
+        super(aCause, MessageCodes.BUNDLE, aMessageKey, aVarArgs);
     }
 }

--- a/src/main/java/edu/ucla/library/prl/harvester/InvalidInstitutionJsonException.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/InvalidInstitutionJsonException.java
@@ -1,0 +1,49 @@
+package edu.ucla.library.prl.harvester;
+
+import info.freelibrary.util.StringUtils;
+
+/**
+ * Represents an error in the JSON representation of an {@link Institution}.
+ */
+public class InvalidInstitutionJsonException extends IllegalArgumentException {
+
+    /**
+     * The message unique to this exception.
+     */
+    private static final String MESSAGE = "The supplied JsonObject does not represent a valid Institution";
+
+    /**
+     * Instantiates an exception.
+     */
+    public InvalidInstitutionJsonException() {
+        super();
+    }
+
+    /**
+     * Instantiates an exception.
+     *
+     * @param aMessage The detail message
+     */
+    public InvalidInstitutionJsonException(final String aMessage) {
+        super(StringUtils.format("{}: {}", MESSAGE, aMessage));
+    }
+
+    /**
+     * Instantiates an exception.
+     *
+     * @param aMessage The detail message
+     * @param aCause The cause
+     */
+    public InvalidInstitutionJsonException(final String aMessage, final Throwable aCause) {
+        super(StringUtils.format("{}: {}", MESSAGE, aMessage), aCause);
+    }
+
+    /**
+     * Instantiates an exception.
+     *
+     * @param aCause The cause
+     */
+    public InvalidInstitutionJsonException(final Throwable aCause) {
+        super(MESSAGE, aCause);
+    }
+}

--- a/src/main/java/edu/ucla/library/prl/harvester/InvalidJobJsonException.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/InvalidJobJsonException.java
@@ -30,7 +30,7 @@ public class InvalidJobJsonException extends IllegalArgumentException {
      * @param aMessage The detail message
      */
     public InvalidJobJsonException(final String aMessage) {
-        super(StringUtils.format("{}: {}", MESSAGE, aMessage));
+        this(aMessage, null);
     }
 
     /**

--- a/src/main/java/edu/ucla/library/prl/harvester/InvalidJobJsonException.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/InvalidJobJsonException.java
@@ -8,6 +8,11 @@ import info.freelibrary.util.StringUtils;
 public class InvalidJobJsonException extends IllegalArgumentException {
 
     /**
+     * The <code>serialVersionUID</code> for this class.
+     */
+    private static final long serialVersionUID = -5482785987411340970L;
+
+    /**
      * The message unique to this exception.
      */
     private static final String MESSAGE = "The supplied JsonObject does not represent a valid Job";

--- a/src/main/java/edu/ucla/library/prl/harvester/InvalidJobJsonException.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/InvalidJobJsonException.java
@@ -1,0 +1,49 @@
+package edu.ucla.library.prl.harvester;
+
+import info.freelibrary.util.StringUtils;
+
+/**
+ * Represents an error in the JSON representation of a {@link Job}.
+ */
+public class InvalidJobJsonException extends IllegalArgumentException {
+
+    /**
+     * The message unique to this exception.
+     */
+    private static final String MESSAGE = "The supplied JsonObject does not represent a valid Job";
+
+    /**
+     * Instantiates an exception.
+     */
+    public InvalidJobJsonException() {
+        super();
+    }
+
+    /**
+     * Instantiates an exception.
+     *
+     * @param aMessage The detail message
+     */
+    public InvalidJobJsonException(final String aMessage) {
+        super(StringUtils.format("{}: {}", MESSAGE, aMessage));
+    }
+
+    /**
+     * Instantiates an exception.
+     *
+     * @param aMessage The detail message
+     * @param aCause The cause
+     */
+    public InvalidJobJsonException(final String aMessage, final Throwable aCause) {
+        super(StringUtils.format("{}: {}", MESSAGE, aMessage), aCause);
+    }
+
+    /**
+     * Instantiates an exception.
+     *
+     * @param aCause The cause
+     */
+    public InvalidJobJsonException(final Throwable aCause) {
+        super(MESSAGE, aCause);
+    }
+}

--- a/src/main/java/edu/ucla/library/prl/harvester/InvalidJobJsonException.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/InvalidJobJsonException.java
@@ -1,11 +1,12 @@
+
 package edu.ucla.library.prl.harvester;
 
-import info.freelibrary.util.StringUtils;
+import info.freelibrary.util.I18nRuntimeException;
 
 /**
  * Represents an error in the JSON representation of a {@link Job}.
  */
-public class InvalidJobJsonException extends IllegalArgumentException {
+public class InvalidJobJsonException extends I18nRuntimeException {
 
     /**
      * The <code>serialVersionUID</code> for this class.
@@ -13,42 +14,32 @@ public class InvalidJobJsonException extends IllegalArgumentException {
     private static final long serialVersionUID = -5482785987411340970L;
 
     /**
-     * The message unique to this exception.
-     */
-    private static final String MESSAGE = "The supplied JsonObject does not represent a valid Job";
-
-    /**
      * Instantiates an exception.
+     *
+     * @param aMessageKey The message key
      */
-    public InvalidJobJsonException() {
-        super();
+    public InvalidJobJsonException(final String aMessageKey) {
+        super(MessageCodes.BUNDLE, aMessageKey);
     }
 
     /**
      * Instantiates an exception.
      *
-     * @param aMessage The detail message
+     * @param aMessageKey The message key
+     * @param aVarArgs The message details
      */
-    public InvalidJobJsonException(final String aMessage) {
-        this(aMessage, null);
-    }
-
-    /**
-     * Instantiates an exception.
-     *
-     * @param aMessage The detail message
-     * @param aCause The cause
-     */
-    public InvalidJobJsonException(final String aMessage, final Throwable aCause) {
-        super(StringUtils.format("{}: {}", MESSAGE, aMessage), aCause);
+    public InvalidJobJsonException(final String aMessageKey, final Object... aVarArgs) {
+        super(MessageCodes.BUNDLE, aMessageKey, aVarArgs);
     }
 
     /**
      * Instantiates an exception.
      *
      * @param aCause The cause
+     * @param aMessageKey The message key
+     * @param aVarArgs The message details
      */
-    public InvalidJobJsonException(final Throwable aCause) {
-        super(MESSAGE, aCause);
+    public InvalidJobJsonException(final Throwable aCause, final String aMessageKey, final Object... aVarArgs) {
+        super(aCause, MessageCodes.BUNDLE, aMessageKey, aVarArgs);
     }
 }

--- a/src/main/java/edu/ucla/library/prl/harvester/Job.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/Job.java
@@ -107,6 +107,7 @@ public final class Job {
      */
     @SuppressWarnings({ "PMD.AvoidCatchingNPE", "PMD.AvoidCatchingGenericException" })
     public Job(final JsonObject aJsonObject) {
+        Objects.requireNonNull(aJsonObject);
         try {
             myInstitutionId = Objects.requireNonNull(aJsonObject.getInteger(INSTITUTION_ID));
             myRepositoryBaseUrl = new URL(Objects.requireNonNull(aJsonObject.getString(REPOSITORY_BASE_URL)));

--- a/src/main/java/edu/ucla/library/prl/harvester/Job.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/Job.java
@@ -103,7 +103,7 @@ public final class Job {
      * {@link #Job(int, URL, List, CronExpression, ZonedDateTime)} should be used everywhere else.
      *
      * @param aJsonObject A job represented as JSON
-     * @throws IllegalArgumentException If the JSON representation is invalid
+     * @throws InvalidJobJsonException If the JSON representation is invalid
      */
     @SuppressWarnings({ "PMD.AvoidCatchingNPE", "PMD.AvoidCatchingGenericException" })
     public Job(final JsonObject aJsonObject) {
@@ -118,7 +118,7 @@ public final class Job {
                     .map(datetime -> ZonedDateTime.parse(datetime));
         } catch (final DateTimeParseException | MalformedURLException | NullPointerException | ParseException details) {
             // Catch-all because generated event bus proxy code doesn't appreciate checked exceptions
-            throw new IllegalArgumentException(details.getMessage(), details);
+            throw new InvalidJobJsonException(details);
         }
     }
 

--- a/src/main/java/edu/ucla/library/prl/harvester/Job.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/Job.java
@@ -56,12 +56,12 @@ public final class Job {
     /**
      * The identifier of the institution that this job should be associated with.
      */
-    private final int myInstitutionId;
+    private final int myInstitutionID;
 
     /**
      * The base URL of the OAI-PMH repository.
      */
-    private final URL myRepositoryBaseUrl;
+    private final URL myRepositoryBaseURL;
 
     /**
      * The list of sets to harvest.
@@ -81,16 +81,16 @@ public final class Job {
     /**
      * Instantiates a job.
      *
-     * @param anInstitutionId The identifier of the institution that this job should be associated with
-     * @param aRepositoryBaseUrl The base URL of the OAI-PMH repository
+     * @param anInstitutionID The identifier of the institution that this job should be associated with
+     * @param aRepositoryBaseURL The base URL of the OAI-PMH repository
      * @param aSets The list of sets to harvest; if empty, assume all sets should be harvested
      * @param aScheduleCronExpression The schedule on which this job should be run
      * @param aLastSuccessfulRun The timestamp of the last successful run of this job; will be null at first
      */
-    public Job(final int anInstitutionId, final URL aRepositoryBaseUrl, final List<String> aSets,
+    public Job(final int anInstitutionID, final URL aRepositoryBaseURL, final List<String> aSets,
             final CronExpression aScheduleCronExpression, final ZonedDateTime aLastSuccessfulRun) {
-        myInstitutionId = anInstitutionId;
-        myRepositoryBaseUrl = Objects.requireNonNull(aRepositoryBaseUrl);
+        myInstitutionID = anInstitutionID;
+        myRepositoryBaseURL = Objects.requireNonNull(aRepositoryBaseURL);
         mySets = Optional.ofNullable(aSets);
         myScheduleCronExpression = Objects.requireNonNull(aScheduleCronExpression);
         myLastSuccessfulRun = Optional.ofNullable(aLastSuccessfulRun);
@@ -109,8 +109,8 @@ public final class Job {
     public Job(final JsonObject aJsonObject) {
         Objects.requireNonNull(aJsonObject);
         try {
-            myInstitutionId = Objects.requireNonNull(aJsonObject.getInteger(INSTITUTION_ID));
-            myRepositoryBaseUrl = new URL(Objects.requireNonNull(aJsonObject.getString(REPOSITORY_BASE_URL)));
+            myInstitutionID = Objects.requireNonNull(aJsonObject.getInteger(INSTITUTION_ID));
+            myRepositoryBaseURL = new URL(Objects.requireNonNull(aJsonObject.getString(REPOSITORY_BASE_URL)));
             mySets = Optional.ofNullable(aJsonObject.getJsonArray(SETS)).map(JsonArray::getList);
             myScheduleCronExpression =
                     new CronExpression(Objects.requireNonNull(aJsonObject.getString(SCHEDULE_CRON_EXPRESSION)));
@@ -127,8 +127,8 @@ public final class Job {
      */
     public JsonObject toJson() {
         return new JsonObject() //
-                .put(INSTITUTION_ID, getInstitutionId()) //
-                .put(REPOSITORY_BASE_URL, getRepositoryBaseUrl().toString()).put(METADATA_PREFIX, getMetadataPrefix())//
+                .put(INSTITUTION_ID, getInstitutionID()) //
+                .put(REPOSITORY_BASE_URL, getRepositoryBaseURL().toString()).put(METADATA_PREFIX, getMetadataPrefix())//
                 .put(SETS, getSets().orElse(null)) //
                 .put(SCHEDULE_CRON_EXPRESSION, getScheduleCronExpression().getCronExpression()) //
                 .put(LAST_SUCCESSFUL_RUN, getLastSuccessfulRun().map(ZonedDateTime::toString).orElse(null));
@@ -137,15 +137,15 @@ public final class Job {
     /**
      * @return The institution ID
      */
-    public int getInstitutionId() {
-        return myInstitutionId;
+    public int getInstitutionID() {
+        return myInstitutionID;
     }
 
     /**
      * @return The repository base URL
      */
-    public URL getRepositoryBaseUrl() {
-        return myRepositoryBaseUrl;
+    public URL getRepositoryBaseURL() {
+        return myRepositoryBaseURL;
     }
 
     /**

--- a/src/main/java/edu/ucla/library/prl/harvester/Job.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/Job.java
@@ -1,0 +1,177 @@
+
+package edu.ucla.library.prl.harvester;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.text.ParseException;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeParseException;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.quartz.CronExpression;
+
+import io.vertx.codegen.annotations.DataObject;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Represents an OAI-PMH harvest job.
+ */
+@DataObject
+@SuppressWarnings("PMD.DataClass")
+public final class Job {
+
+    /**
+     * The JSON key for the institution ID.
+     */
+    static final String INSTITUTION_ID = "institutionId";
+
+    /**
+     * The JSON key for the repository base URL.
+     */
+    static final String REPOSITORY_BASE_URL = "repositoryBaseUrl";
+
+    /**
+     * JSON key for the metadata prefix.
+     */
+    static final String METADATA_PREFIX = "metadataPrefix";
+
+    /**
+     * JSON key for the list of sets.
+     */
+    static final String SETS = "sets";
+
+    /**
+     * JSON key for the schedule.
+     */
+    static final String SCHEDULE_CRON_EXPRESSION = "scheduleCronExpression";
+
+    /**
+     * JSON key for the last successful run.
+     */
+    static final String LAST_SUCCESSFUL_RUN = "lastSuccessfulRun";
+
+    /**
+     * The identifier of the institution that this job should be associated with.
+     */
+    private final int myInstitutionId;
+
+    /**
+     * The base URL of the OAI-PMH repository.
+     */
+    private final URL myRepositoryBaseUrl;
+
+    /**
+     * The list of sets to harvest.
+     */
+    private final Optional<List<String>> mySets;
+
+    /**
+     * The schedule on which this job should be run.
+     */
+    private final CronExpression myScheduleCronExpression;
+
+    /**
+     * The timestamp of the last successful run of this job; will be empty at first.
+     */
+    private final Optional<ZonedDateTime> myLastSuccessfulRun;
+
+    /**
+     * Instantiates a job.
+     *
+     * @param anInstitutionId The identifier of the institution that this job should be associated with
+     * @param aRepositoryBaseUrl The base URL of the OAI-PMH repository
+     * @param aSets The list of sets to harvest; if empty, assume all sets should be harvested
+     * @param aScheduleCronExpression The schedule on which this job should be run
+     * @param aLastSuccessfulRun The timestamp of the last successful run of this job; will be null at first
+     */
+    public Job(final int anInstitutionId, final URL aRepositoryBaseUrl, final List<String> aSets,
+            final CronExpression aScheduleCronExpression, final ZonedDateTime aLastSuccessfulRun) {
+        myInstitutionId = anInstitutionId;
+        myRepositoryBaseUrl = Objects.requireNonNull(aRepositoryBaseUrl);
+        mySets = Optional.ofNullable(aSets);
+        myScheduleCronExpression = Objects.requireNonNull(aScheduleCronExpression);
+        myLastSuccessfulRun = Optional.ofNullable(aLastSuccessfulRun);
+    }
+
+    /**
+     * Instantiates a job from its JSON representation.
+     * <p>
+     * <b>This constructor is meant to be used only by generated service proxy code!</b>
+     * {@link #Job(int, URL, List, CronExpression, ZonedDateTime)} should be used everywhere else.
+     *
+     * @param aJsonObject A job represented as JSON
+     * @throws IllegalArgumentException If the JSON representation is invalid
+     */
+    @SuppressWarnings({ "PMD.AvoidCatchingNPE", "PMD.AvoidCatchingGenericException" })
+    public Job(final JsonObject aJsonObject) {
+        try {
+            myInstitutionId = Objects.requireNonNull(aJsonObject.getInteger(INSTITUTION_ID));
+            myRepositoryBaseUrl = new URL(Objects.requireNonNull(aJsonObject.getString(REPOSITORY_BASE_URL)));
+            mySets = Optional.ofNullable(aJsonObject.getJsonArray(SETS)).map(JsonArray::getList);
+            myScheduleCronExpression =
+                    new CronExpression(Objects.requireNonNull(aJsonObject.getString(SCHEDULE_CRON_EXPRESSION)));
+            myLastSuccessfulRun = Optional.ofNullable(aJsonObject.getString(LAST_SUCCESSFUL_RUN))
+                    .map(datetime -> ZonedDateTime.parse(datetime));
+        } catch (final DateTimeParseException | MalformedURLException | NullPointerException | ParseException details) {
+            // Catch-all because generated event bus proxy code doesn't appreciate checked exceptions
+            throw new IllegalArgumentException(details.getMessage(), details);
+        }
+    }
+
+    /**
+     * @return The JSON representation of the job
+     */
+    public JsonObject toJson() {
+        return new JsonObject() //
+                .put(INSTITUTION_ID, getInstitutionId()) //
+                .put(REPOSITORY_BASE_URL, getRepositoryBaseUrl().toString()).put(METADATA_PREFIX, getMetadataPrefix())//
+                .put(SETS, getSets().orElse(null)) //
+                .put(SCHEDULE_CRON_EXPRESSION, getScheduleCronExpression().getCronExpression()) //
+                .put(LAST_SUCCESSFUL_RUN, getLastSuccessfulRun().map(ZonedDateTime::toString).orElse(null));
+    }
+
+    /**
+     * @return The institution ID
+     */
+    public int getInstitutionId() {
+        return myInstitutionId;
+    }
+
+    /**
+     * @return The repository base URL
+     */
+    public URL getRepositoryBaseUrl() {
+        return myRepositoryBaseUrl;
+    }
+
+    /**
+     * @return The metadata prefix
+     */
+    public String getMetadataPrefix() {
+        return Constants.OAI_DC;
+    }
+
+    /**
+     * @return The optional list of sets
+     */
+    public Optional<List<String>> getSets() {
+        return mySets;
+    }
+
+    /**
+     * @return The schedule
+     */
+    public CronExpression getScheduleCronExpression() {
+        return myScheduleCronExpression;
+    }
+
+    /**
+     * @return The optional last successful run
+     */
+    public Optional<ZonedDateTime> getLastSuccessfulRun() {
+        return myLastSuccessfulRun;
+    }
+}

--- a/src/main/java/edu/ucla/library/prl/harvester/package-info.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Package info required for handling generated sources.
+ */
+
+@ModuleGen(groupPackage = "edu.ucla.library.prl.harvester", name = "harvester")
+package edu.ucla.library.prl.harvester;
+
+import io.vertx.codegen.annotations.ModuleGen;

--- a/src/main/resources/prl-harvester_messages.xml
+++ b/src/main/resources/prl-harvester_messages.xml
@@ -6,7 +6,8 @@
   <entry key="message-class-name">edu.ucla.library.prl.harvester.MessageCodes</entry>
 
   <entry key="PRL_001">Server started at port: {}</entry>
-  <entry key="PRL_002">The JSON representation of an Institution must contain at least one of 'email', 'phone', or 'webContact'</entry>
-  <entry key="PRL_003"></entry>
+  <entry key="PRL_002">Missing value for field '{}'</entry>
+  <entry key="PRL_003">Missing at least one of 'email', 'phone', or 'webContact'</entry>
+  <entry key="PRL_004">Invalid value for field '{}': {}</entry>
 
 </properties>

--- a/src/main/resources/prl-harvester_messages.xml
+++ b/src/main/resources/prl-harvester_messages.xml
@@ -5,6 +5,7 @@
 <properties>
   <entry key="message-class-name">edu.ucla.library.prl.harvester.MessageCodes</entry>
 
+  <entry key="PRL_000">{}</entry>
   <entry key="PRL_001">Server started at port: {}</entry>
   <entry key="PRL_002">Missing value for field '{}'</entry>
   <entry key="PRL_003">Missing at least one of 'email', 'phone', or 'webContact'</entry>

--- a/src/main/resources/prl-harvester_messages.xml
+++ b/src/main/resources/prl-harvester_messages.xml
@@ -6,7 +6,7 @@
   <entry key="message-class-name">edu.ucla.library.prl.harvester.MessageCodes</entry>
 
   <entry key="PRL_001">Server started at port: {}</entry>
-  <entry key="PRL_002">The JSON representation of an Institution must contain at one of 'email', 'phone', or 'webContact'</entry>
+  <entry key="PRL_002">The JSON representation of an Institution must contain at least one of 'email', 'phone', or 'webContact'</entry>
   <entry key="PRL_003"></entry>
 
 </properties>

--- a/src/main/resources/prl-harvester_messages.xml
+++ b/src/main/resources/prl-harvester_messages.xml
@@ -6,7 +6,7 @@
   <entry key="message-class-name">edu.ucla.library.prl.harvester.MessageCodes</entry>
 
   <entry key="PRL_001">Server started at port: {}</entry>
-  <entry key="PRL_002">At least one contact method must be provided</entry>
+  <entry key="PRL_002">The JSON representation of an Institution must contain at one of 'email', 'phone', or 'webContact'</entry>
   <entry key="PRL_003"></entry>
 
 </properties>

--- a/src/main/resources/prl-harvester_messages.xml
+++ b/src/main/resources/prl-harvester_messages.xml
@@ -6,7 +6,7 @@
   <entry key="message-class-name">edu.ucla.library.prl.harvester.MessageCodes</entry>
 
   <entry key="PRL_001">Server started at port: {}</entry>
-  <entry key="PRL_002"></entry>
+  <entry key="PRL_002">At least one contact method must be provided</entry>
   <entry key="PRL_003"></entry>
 
 </properties>

--- a/src/test/java/edu/ucla/library/prl/harvester/InstitutionTest.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/InstitutionTest.java
@@ -73,7 +73,8 @@ public class InstitutionTest {
         assertEquals(institution.getLocation(), institutionFromJson.getLocation());
         assertEquals(institution.getContactMethods().getEmail(), institutionFromJson.getContactMethods().getEmail());
         assertEquals(institution.getContactMethods().getPhone(), institutionFromJson.getContactMethods().getPhone());
-        assertEquals(institution.getContactMethods().getWebContact(), institutionFromJson.getContactMethods().getWebContact());
+        assertEquals(institution.getContactMethods().getWebContact(),
+                institutionFromJson.getContactMethods().getWebContact());
         assertEquals(institution.getWebsite(), institutionFromJson.getWebsite());
     }
 

--- a/src/test/java/edu/ucla/library/prl/harvester/InstitutionTest.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/InstitutionTest.java
@@ -1,0 +1,228 @@
+
+package edu.ucla.library.prl.harvester;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import javax.mail.internet.AddressException;
+import javax.mail.internet.InternetAddress;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.google.i18n.phonenumbers.NumberParseException;
+import com.google.i18n.phonenumbers.PhoneNumberUtil;
+import com.google.i18n.phonenumbers.PhoneNumberUtil.PhoneNumberFormat;
+import com.google.i18n.phonenumbers.Phonenumber.PhoneNumber;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.junit5.VertxExtension;
+
+/**
+ * Tests {@link Institution}.
+ */
+@ExtendWith(VertxExtension.class)
+public class InstitutionTest {
+
+    /**
+     * Parses and formats phone numbers.
+     */
+    private static final PhoneNumberUtil PHONE_NUMBER_UTIL = PhoneNumberUtil.getInstance();
+
+    /**
+     * Tests that an {@link Institution} can be instantiated from a {@link JsonObject} and serialized back to one.
+     *
+     * @param aName The institution's name
+     * @param aDescription The institution's description
+     * @param aLocation The institution's human-readable location
+     * @param anEmail The optional email address contact of the institution
+     * @param aPhone The optional phone number contact of the institution
+     * @param aWebContact The optional web contact of the institution
+     * @param aWebsite The institiution's website
+     */
+    @ParameterizedTest
+    @MethodSource
+    void testInstitutionSerDe(final String aName, final String aDescription, final String aLocation,
+            final InternetAddress anEmail, final PhoneNumber aPhone, final URL aWebContact, final URL aWebsite) {
+        final Institution institution =
+                new Institution(aName, aDescription, aLocation, anEmail, aPhone, aWebContact, aWebsite);
+        final JsonObject json = new JsonObject() //
+                .put(Institution.NAME, aName) //
+                .put(Institution.DESCRIPTION, aDescription) //
+                .put(Institution.LOCATION, aLocation) //
+                .put(Institution.EMAIL, Optional.ofNullable(anEmail).map(InternetAddress::toString).orElse(null)) //
+                .put(Institution.PHONE, Optional.ofNullable(aPhone) //
+                        .map(phone -> PHONE_NUMBER_UTIL.format(phone, PhoneNumberFormat.INTERNATIONAL)) //
+                        .orElse(null)) //
+                .put(Institution.WEB_CONTACT, Optional.ofNullable(aWebContact).map(URL::toString).orElse(null)) //
+                .put(Institution.WEBSITE, aWebsite.toString());
+        final Institution institutionFromJson = new Institution(json);
+
+        assertEquals(json, institution.toJson());
+        assertEquals(institution.toJson(), institutionFromJson.toJson());
+
+        assertEquals(institution.getName(), institutionFromJson.getName());
+        assertEquals(institution.getDescription(), institutionFromJson.getDescription());
+        assertEquals(institution.getLocation(), institutionFromJson.getLocation());
+        assertEquals(institution.getEmail(), institutionFromJson.getEmail());
+        assertEquals(institution.getPhone(), institutionFromJson.getPhone());
+        assertEquals(institution.getWebContact(), institutionFromJson.getWebContact());
+        assertEquals(institution.getWebsite(), institutionFromJson.getWebsite());
+    }
+
+    /**
+     * @return The arguments for the corresponding {@link ParameterizedTest}
+     * @throws AddressException
+     * @throws MalformedURLException
+     * @throws NumberParseException
+     */
+    static Stream<Arguments> testInstitutionSerDe()
+            throws AddressException, MalformedURLException, NumberParseException {
+        final String exampleName = "Name 1";
+        final String exampleDescription = "Description 1";
+        final String exampleLocation = "Location 1";
+        final InternetAddress exampleEmail = new InternetAddress("test0@example.com");
+        final PhoneNumber examplePhone = PHONE_NUMBER_UTIL.parse("+1 888 200 1000", null);
+        final URL exampleWebContact = new URL("http://example.com/1/contact");
+        final URL exampleWebsite = new URL("http://example.com/1");
+
+        return Stream.of( //
+                Arguments.of(exampleName, exampleDescription, exampleLocation, exampleEmail, examplePhone,
+                        exampleWebContact, exampleWebsite), //
+                Arguments.of(exampleName, exampleDescription, exampleLocation, exampleEmail, examplePhone, null,
+                        exampleWebsite), //
+                Arguments.of(exampleName, exampleDescription, exampleLocation, exampleEmail, null, exampleWebContact,
+                        exampleWebsite), //
+                Arguments.of(exampleName, exampleDescription, exampleLocation, null, examplePhone, exampleWebContact,
+                        exampleWebsite), //
+                Arguments.of(exampleName, exampleDescription, exampleLocation, exampleEmail, null, null,
+                        exampleWebsite), //
+                Arguments.of(exampleName, exampleDescription, exampleLocation, null, examplePhone, null,
+                        exampleWebsite), //
+                Arguments.of(exampleName, exampleDescription, exampleLocation, null, null, exampleWebContact,
+                        exampleWebsite));
+    }
+
+    /**
+     * Tests that an {@link Institution} cannot be instantiated from an invalid JSON representation.
+     *
+     * @param aName The institution's name
+     * @param aDescription The institution's description
+     * @param aLocation The institution's human-readable location
+     * @param anEmail The optional email address contact of the institution
+     * @param aPhone The optional phone number contact of the institution
+     * @param aWebContact The optional web contact of the institution
+     * @param aWebsite The institiution's website
+     * @param anErrorClass The class of error that we expect instantiation with the above arguments to throw
+     */
+    @ParameterizedTest
+    @MethodSource
+    void testInstitutionInvalidJsonRepresentation(final String aName, final String aDescription, final String aLocation,
+            final String anEmail, final String aPhone, final String aWebContact, final String aWebsite,
+            final Class<Exception> anErrorClass) {
+        final JsonObject json = new JsonObject() //
+                .put(Institution.NAME, aName) //
+                .put(Institution.DESCRIPTION, aDescription) //
+                .put(Institution.LOCATION, aLocation) //
+                .put(Institution.EMAIL, anEmail) //
+                .put(Institution.PHONE, aPhone) //
+                .put(Institution.WEB_CONTACT, aWebContact) //
+                .put(Institution.WEBSITE, aWebsite);
+        final Exception error = assertThrows(IllegalArgumentException.class, () -> new Institution(json));
+
+        assertEquals(anErrorClass, error.getCause().getClass());
+    }
+
+    /**
+     * @return The arguments for the corresponding {@link ParameterizedTest}
+     * @throws AddressException
+     * @throws MalformedURLException
+     * @throws NumberParseException
+     */
+    static Stream<Arguments> testInstitutionInvalidJsonRepresentation()
+            throws AddressException, MalformedURLException, NumberParseException {
+        final String validName = "Name 2";
+        final String validDescription = "Description 2";
+        final String validLocation = "Location 2";
+
+        final String validEmail = new InternetAddress("test1@example.com", true).toString();
+        final String invalidEmail = "@example.com"; // Missing username
+
+        final String validPhone = PHONE_NUMBER_UTIL.format(PHONE_NUMBER_UTIL.parse("+1 888 200 2000", null),
+                PhoneNumberFormat.INTERNATIONAL);
+        final String invalidPhone1 = "888 200 2000"; // Missing country code
+        final String invalidPhone2 = "911";
+
+        final String validWebContact = new URL("http://example.com/2/contact").toString();
+        final String invalidWebContact = "example.com/2/contact"; // Missing protocol
+
+        final String validWebsite = new URL("http://example.com/2").toString();
+        final String invalidWebsite = "example.com/2"; // Missing protocol
+
+        return Stream.of( //
+                Arguments.of(validName, validDescription, validLocation, invalidEmail, validPhone, validWebContact,
+                        validWebsite, AddressException.class), //
+                Arguments.of(validName, validDescription, validLocation, validEmail, invalidPhone1, validWebContact,
+                        validWebsite, NumberParseException.class), //
+                Arguments.of(validName, validDescription, validLocation, validEmail, invalidPhone2, validWebContact,
+                        validWebsite, NumberParseException.class), //
+                Arguments.of(validName, validDescription, validLocation, validEmail, validPhone, invalidWebContact,
+                        validWebsite, MalformedURLException.class), //
+                Arguments.of(validName, validDescription, validLocation, validEmail, validPhone, validWebContact,
+                        invalidWebsite, MalformedURLException.class));
+    }
+
+    /**
+     * Tests that the more strongly-typed constructor can't be called with certain combinations of null arguments.
+     *
+     * @param aName The institution's name
+     * @param aDescription The institution's description
+     * @param aLocation The institution's human-readable location
+     * @param anEmail The optional email address contact of the institution
+     * @param aPhone The optional phone number contact of the institution
+     * @param aWebContact The optional web contact of the institution
+     * @param aWebsite The institiution's website
+     */
+    @ParameterizedTest
+    @MethodSource
+    void testInstitutionNullArguments(final String aName, final String aDescription, final String aLocation,
+            final InternetAddress anEmail, final PhoneNumber aPhone, final URL aWebContact, final URL aWebsite) {
+        assertThrows(NullPointerException.class, () -> {
+            new Institution(aName, aDescription, aLocation, anEmail, aPhone, aWebContact, aWebsite);
+        });
+    }
+
+    /**
+     * @return The arguments for the corresponding {@link ParameterizedTest}
+     * @throws AddressException
+     * @throws MalformedURLException
+     * @throws NumberParseException
+     */
+    static Stream<Arguments> testInstitutionNullArguments()
+            throws AddressException, MalformedURLException, NumberParseException {
+        final String validName = "Name 3";
+        final String validDescription = "Description 3";
+        final String validLocation = "Location 3";
+        final InternetAddress validEmail = new InternetAddress("test2@example.com");
+        final PhoneNumber validPhone = PHONE_NUMBER_UTIL.parse("+1 888 200 3000", null);
+        final URL validWebContact = new URL("http://example.com/3/contact");
+        final URL validWebsite = new URL("http://example.com/3");
+
+        return Stream.of( //
+                Arguments.of(null, validDescription, validLocation, validEmail, validPhone, validWebContact,
+                        validWebsite), //
+                Arguments.of(validName, null, validLocation, validEmail, validPhone, validWebContact, validWebsite), //
+                Arguments.of(validName, validDescription, null, validEmail, validPhone, validWebContact,
+                        validWebsite), //
+                Arguments.of(validName, validDescription, validLocation, null, null, null, validWebsite), //
+                Arguments.of(validName, validDescription, validLocation, validEmail, validPhone, validWebContact,
+                        null));
+    }
+}

--- a/src/test/java/edu/ucla/library/prl/harvester/InstitutionTest.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/InstitutionTest.java
@@ -65,9 +65,11 @@ public class InstitutionTest {
                 .put(Institution.WEBSITE, aWebsite.toString());
         final Institution institutionFromJson = new Institution(json);
 
+        // If the JSON representations are equal, then serialization works
         assertEquals(json, institution.toJson());
         assertEquals(institution.toJson(), institutionFromJson.toJson());
 
+        // If the objects are equal, then deserialization works
         assertEquals(institution.getName(), institutionFromJson.getName());
         assertEquals(institution.getDescription(), institutionFromJson.getDescription());
         assertEquals(institution.getLocation(), institutionFromJson.getLocation());

--- a/src/test/java/edu/ucla/library/prl/harvester/InstitutionTest.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/InstitutionTest.java
@@ -196,8 +196,8 @@ public class InstitutionTest {
                         validWebsite, NumberParseException.class), //
                 Arguments.of(validName, validDescription, validLocation, validEmail, validPhone, invalidWebContact,
                         validWebsite, MalformedURLException.class), //
-                Arguments.of(validName, validDescription, validLocation, validEmail, validPhone, validWebContact,
-                        null, null),
+                Arguments.of(validName, validDescription, validLocation, validEmail, validPhone, validWebContact, null,
+                        null),
                 Arguments.of(validName, validDescription, validLocation, validEmail, validPhone, validWebContact,
                         invalidWebsite, MalformedURLException.class));
     }

--- a/src/test/java/edu/ucla/library/prl/harvester/InstitutionTest.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/InstitutionTest.java
@@ -24,6 +24,9 @@ import com.google.i18n.phonenumbers.Phonenumber.PhoneNumber;
 
 import edu.ucla.library.prl.harvester.Institution.ContactMethods;
 
+import info.freelibrary.util.Logger;
+import info.freelibrary.util.LoggerFactory;
+
 import io.vertx.core.json.JsonObject;
 import io.vertx.junit5.VertxExtension;
 
@@ -32,6 +35,11 @@ import io.vertx.junit5.VertxExtension;
  */
 @ExtendWith(VertxExtension.class)
 public class InstitutionTest {
+
+    /**
+     * The logger.
+     */
+    private static final Logger LOGGER = LoggerFactory.getLogger(InstitutionTest.class, MessageCodes.BUNDLE);
 
     /**
      * Parses and formats phone numbers.
@@ -51,8 +59,7 @@ public class InstitutionTest {
     @MethodSource
     void testInstitutionSerDe(final String aName, final String aDescription, final String aLocation,
             final ContactMethods aContactMethods, final URL aWebsite) {
-        final Institution institution =
-                new Institution(aName, aDescription, aLocation, aContactMethods, aWebsite);
+        final Institution institution = new Institution(aName, aDescription, aLocation, aContactMethods, aWebsite);
         final JsonObject json = new JsonObject() //
                 .put(Institution.NAME, aName) //
                 .put(Institution.DESCRIPTION, aDescription) //
@@ -143,6 +150,8 @@ public class InstitutionTest {
         if (error.getCause() != null) {
             assertEquals(anErrorClass, error.getCause().getClass());
         }
+
+        LOGGER.debug(LOGGER.getMessage(MessageCodes.PRL_000, error));
     }
 
     /**

--- a/src/test/java/edu/ucla/library/prl/harvester/InstitutionTest.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/InstitutionTest.java
@@ -211,7 +211,9 @@ public class InstitutionTest {
      * @param aName The institution's name
      * @param aDescription The institution's description
      * @param aLocation The institution's human-readable location
-     * @param aContactMethods The institution's contact methods
+     * @param anEmail The institution's optional email contact
+     * @param aPhone The institution's optional phone contact
+     * @param aWebContact The institution's optional web contact
      * @param aWebsite The institiution's website
      */
     @ParameterizedTest
@@ -244,7 +246,8 @@ public class InstitutionTest {
                 Arguments.of(null, validDescription, validLocation, validEmail, validPhone, validWebContact,
                         validWebsite), //
                 Arguments.of(validName, null, validLocation, validEmail, validPhone, validWebContact, validWebsite), //
-                Arguments.of(validName, validDescription, null, validEmail, validPhone, validWebContact, validWebsite), //
+                Arguments.of(validName, validDescription, null, validEmail, validPhone, validWebContact,
+                        validWebsite), //
                 Arguments.of(validName, validDescription, validLocation, null, validPhone, validWebContact,
                         validWebsite), //
                 Arguments.of(validName, validDescription, validLocation, validEmail, null, validWebContact,

--- a/src/test/java/edu/ucla/library/prl/harvester/InstitutionTest.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/InstitutionTest.java
@@ -138,7 +138,7 @@ public class InstitutionTest {
                 .put(Institution.PHONE, aPhone) //
                 .put(Institution.WEB_CONTACT, aWebContact) //
                 .put(Institution.WEBSITE, aWebsite);
-        final Exception error = assertThrows(IllegalArgumentException.class, () -> new Institution(json));
+        final Exception error = assertThrows(InvalidInstitutionJsonException.class, () -> new Institution(json));
 
         if (error.getCause() != null) {
             assertEquals(anErrorClass, error.getCause().getClass());

--- a/src/test/java/edu/ucla/library/prl/harvester/InstitutionTest.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/InstitutionTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.Optional;
 import java.util.stream.Stream;
 
 import javax.mail.internet.AddressException;
@@ -22,6 +21,8 @@ import com.google.i18n.phonenumbers.NumberParseException;
 import com.google.i18n.phonenumbers.PhoneNumberUtil;
 import com.google.i18n.phonenumbers.PhoneNumberUtil.PhoneNumberFormat;
 import com.google.i18n.phonenumbers.Phonenumber.PhoneNumber;
+
+import edu.ucla.library.prl.harvester.Institution.ContactMethods;
 
 import io.vertx.core.json.JsonObject;
 import io.vertx.junit5.VertxExtension;
@@ -43,26 +44,24 @@ public class InstitutionTest {
      * @param aName The institution's name
      * @param aDescription The institution's description
      * @param aLocation The institution's human-readable location
-     * @param anEmail The optional email address contact of the institution
-     * @param aPhone The optional phone number contact of the institution
-     * @param aWebContact The optional web contact of the institution
+     * @param aContactMethods The institution's contact methods
      * @param aWebsite The institiution's website
      */
     @ParameterizedTest
     @MethodSource
     void testInstitutionSerDe(final String aName, final String aDescription, final String aLocation,
-            final InternetAddress anEmail, final PhoneNumber aPhone, final URL aWebContact, final URL aWebsite) {
+            final ContactMethods aContactMethods, final URL aWebsite) {
         final Institution institution =
-                new Institution(aName, aDescription, aLocation, anEmail, aPhone, aWebContact, aWebsite);
+                new Institution(aName, aDescription, aLocation, aContactMethods, aWebsite);
         final JsonObject json = new JsonObject() //
                 .put(Institution.NAME, aName) //
                 .put(Institution.DESCRIPTION, aDescription) //
                 .put(Institution.LOCATION, aLocation) //
-                .put(Institution.EMAIL, Optional.ofNullable(anEmail).map(InternetAddress::toString).orElse(null)) //
-                .put(Institution.PHONE, Optional.ofNullable(aPhone) //
+                .put(Institution.EMAIL, aContactMethods.getEmail().map(InternetAddress::toString).orElse(null)) //
+                .put(Institution.PHONE, aContactMethods.getPhone() //
                         .map(phone -> PHONE_NUMBER_UTIL.format(phone, PhoneNumberFormat.INTERNATIONAL)) //
                         .orElse(null)) //
-                .put(Institution.WEB_CONTACT, Optional.ofNullable(aWebContact).map(URL::toString).orElse(null)) //
+                .put(Institution.WEB_CONTACT, aContactMethods.getWebContact().map(URL::toString).orElse(null)) //
                 .put(Institution.WEBSITE, aWebsite.toString());
         final Institution institutionFromJson = new Institution(json);
 
@@ -72,9 +71,9 @@ public class InstitutionTest {
         assertEquals(institution.getName(), institutionFromJson.getName());
         assertEquals(institution.getDescription(), institutionFromJson.getDescription());
         assertEquals(institution.getLocation(), institutionFromJson.getLocation());
-        assertEquals(institution.getEmail(), institutionFromJson.getEmail());
-        assertEquals(institution.getPhone(), institutionFromJson.getPhone());
-        assertEquals(institution.getWebContact(), institutionFromJson.getWebContact());
+        assertEquals(institution.getContactMethods().getEmail(), institutionFromJson.getContactMethods().getEmail());
+        assertEquals(institution.getContactMethods().getPhone(), institutionFromJson.getContactMethods().getPhone());
+        assertEquals(institution.getContactMethods().getWebContact(), institutionFromJson.getContactMethods().getWebContact());
         assertEquals(institution.getWebsite(), institutionFromJson.getWebsite());
     }
 
@@ -92,23 +91,23 @@ public class InstitutionTest {
         final InternetAddress exampleEmail = new InternetAddress("test0@example.com");
         final PhoneNumber examplePhone = PHONE_NUMBER_UTIL.parse("+1 888 200 1000", null);
         final URL exampleWebContact = new URL("http://example.com/1/contact");
+        final ContactMethods exampleContactMethods1 = new ContactMethods(exampleEmail, examplePhone, exampleWebContact);
+        final ContactMethods exampleContactMethods2 = new ContactMethods(exampleEmail, examplePhone);
+        final ContactMethods exampleContactMethods3 = new ContactMethods(exampleEmail, exampleWebContact);
+        final ContactMethods exampleContactMethods4 = new ContactMethods(examplePhone, exampleWebContact);
+        final ContactMethods exampleContactMethods6 = new ContactMethods(exampleEmail);
+        final ContactMethods exampleContactMethods5 = new ContactMethods(examplePhone);
+        final ContactMethods exampleContactMethods7 = new ContactMethods(exampleWebContact);
         final URL exampleWebsite = new URL("http://example.com/1");
 
         return Stream.of( //
-                Arguments.of(exampleName, exampleDescription, exampleLocation, exampleEmail, examplePhone,
-                        exampleWebContact, exampleWebsite), //
-                Arguments.of(exampleName, exampleDescription, exampleLocation, exampleEmail, examplePhone, null,
-                        exampleWebsite), //
-                Arguments.of(exampleName, exampleDescription, exampleLocation, exampleEmail, null, exampleWebContact,
-                        exampleWebsite), //
-                Arguments.of(exampleName, exampleDescription, exampleLocation, null, examplePhone, exampleWebContact,
-                        exampleWebsite), //
-                Arguments.of(exampleName, exampleDescription, exampleLocation, exampleEmail, null, null,
-                        exampleWebsite), //
-                Arguments.of(exampleName, exampleDescription, exampleLocation, null, examplePhone, null,
-                        exampleWebsite), //
-                Arguments.of(exampleName, exampleDescription, exampleLocation, null, null, exampleWebContact,
-                        exampleWebsite));
+                Arguments.of(exampleName, exampleDescription, exampleLocation, exampleContactMethods1, exampleWebsite),
+                Arguments.of(exampleName, exampleDescription, exampleLocation, exampleContactMethods2, exampleWebsite),
+                Arguments.of(exampleName, exampleDescription, exampleLocation, exampleContactMethods3, exampleWebsite),
+                Arguments.of(exampleName, exampleDescription, exampleLocation, exampleContactMethods4, exampleWebsite),
+                Arguments.of(exampleName, exampleDescription, exampleLocation, exampleContactMethods5, exampleWebsite),
+                Arguments.of(exampleName, exampleDescription, exampleLocation, exampleContactMethods6, exampleWebsite),
+                Arguments.of(exampleName, exampleDescription, exampleLocation, exampleContactMethods7, exampleWebsite));
     }
 
     /**
@@ -138,7 +137,9 @@ public class InstitutionTest {
                 .put(Institution.WEBSITE, aWebsite);
         final Exception error = assertThrows(IllegalArgumentException.class, () -> new Institution(json));
 
-        assertEquals(anErrorClass, error.getCause().getClass());
+        if (error.getCause() != null) {
+            assertEquals(anErrorClass, error.getCause().getClass());
+        }
     }
 
     /**
@@ -176,6 +177,7 @@ public class InstitutionTest {
                         validWebsite, NumberParseException.class), //
                 Arguments.of(validName, validDescription, validLocation, validEmail, validPhone, invalidWebContact,
                         validWebsite, MalformedURLException.class), //
+                Arguments.of(validName, validDescription, validLocation, null, null, null, validWebsite, null), //
                 Arguments.of(validName, validDescription, validLocation, validEmail, validPhone, validWebContact,
                         invalidWebsite, MalformedURLException.class));
     }
@@ -186,17 +188,15 @@ public class InstitutionTest {
      * @param aName The institution's name
      * @param aDescription The institution's description
      * @param aLocation The institution's human-readable location
-     * @param anEmail The optional email address contact of the institution
-     * @param aPhone The optional phone number contact of the institution
-     * @param aWebContact The optional web contact of the institution
+     * @param aContactMethods The institution's contact methods
      * @param aWebsite The institiution's website
      */
     @ParameterizedTest
     @MethodSource
     void testInstitutionNullArguments(final String aName, final String aDescription, final String aLocation,
-            final InternetAddress anEmail, final PhoneNumber aPhone, final URL aWebContact, final URL aWebsite) {
+            final ContactMethods aContactMethods, final URL aWebsite) {
         assertThrows(NullPointerException.class, () -> {
-            new Institution(aName, aDescription, aLocation, anEmail, aPhone, aWebContact, aWebsite);
+            new Institution(aName, aDescription, aLocation, aContactMethods, aWebsite);
         });
     }
 
@@ -214,17 +214,15 @@ public class InstitutionTest {
         final InternetAddress validEmail = new InternetAddress("test2@example.com");
         final PhoneNumber validPhone = PHONE_NUMBER_UTIL.parse("+1 888 200 3000", null);
         final URL validWebContact = new URL("http://example.com/3/contact");
+        final ContactMethods validContactMethods = new ContactMethods(validEmail, validPhone, validWebContact);
         final URL validWebsite = new URL("http://example.com/3");
 
         return Stream.of( //
-                Arguments.of(null, validDescription, validLocation, validEmail, validPhone, validWebContact,
-                        validWebsite), //
-                Arguments.of(validName, null, validLocation, validEmail, validPhone, validWebContact, validWebsite), //
-                Arguments.of(validName, validDescription, null, validEmail, validPhone, validWebContact, //
-                        validWebsite), //
-                Arguments.of(validName, validDescription, validLocation, null, null, null, validWebsite), //
-                Arguments.of(validName, validDescription, validLocation, validEmail, validPhone, validWebContact,
-                        null));
+                Arguments.of(null, validDescription, validLocation, validContactMethods, validWebsite), //
+                Arguments.of(validName, null, validLocation, validContactMethods, validWebsite), //
+                Arguments.of(validName, validDescription, null, validContactMethods, validWebsite), //
+                Arguments.of(validName, validDescription, validLocation, null, validWebsite), //
+                Arguments.of(validName, validDescription, validLocation, validContactMethods, null));
     }
 
     /**

--- a/src/test/java/edu/ucla/library/prl/harvester/InstitutionTest.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/InstitutionTest.java
@@ -246,8 +246,7 @@ public class InstitutionTest {
                 Arguments.of(null, validDescription, validLocation, validEmail, validPhone, validWebContact,
                         validWebsite), //
                 Arguments.of(validName, null, validLocation, validEmail, validPhone, validWebContact, validWebsite), //
-                Arguments.of(validName, validDescription, null, validEmail, validPhone, validWebContact,
-                        validWebsite), //
+                Arguments.of(validName, validDescription, null, validEmail, validPhone, validWebContact, validWebsite),
                 Arguments.of(validName, validDescription, validLocation, null, validPhone, validWebContact,
                         validWebsite), //
                 Arguments.of(validName, validDescription, validLocation, validEmail, null, validWebContact,

--- a/src/test/java/edu/ucla/library/prl/harvester/InstitutionTest.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/InstitutionTest.java
@@ -12,7 +12,6 @@ import javax.mail.internet.AddressException;
 import javax.mail.internet.InternetAddress;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -28,12 +27,10 @@ import info.freelibrary.util.Logger;
 import info.freelibrary.util.LoggerFactory;
 
 import io.vertx.core.json.JsonObject;
-import io.vertx.junit5.VertxExtension;
 
 /**
  * Tests {@link Institution}.
  */
-@ExtendWith(VertxExtension.class)
 public class InstitutionTest {
 
     /**

--- a/src/test/java/edu/ucla/library/prl/harvester/InstitutionTest.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/InstitutionTest.java
@@ -12,6 +12,7 @@ import java.util.stream.Stream;
 import javax.mail.internet.AddressException;
 import javax.mail.internet.InternetAddress;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -224,5 +225,13 @@ public class InstitutionTest {
                 Arguments.of(validName, validDescription, validLocation, null, null, null, validWebsite), //
                 Arguments.of(validName, validDescription, validLocation, validEmail, validPhone, validWebContact,
                         null));
+    }
+
+    /**
+     * Tests that passing a null {@link JsonObject} throws a {@link NullPointerException}.
+     */
+    @Test
+    void testInstitutionNullJsonObject() {
+        assertThrows(NullPointerException.class, () -> new Institution(null));
     }
 }

--- a/src/test/java/edu/ucla/library/prl/harvester/InstitutionTest.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/InstitutionTest.java
@@ -219,7 +219,7 @@ public class InstitutionTest {
                 Arguments.of(null, validDescription, validLocation, validEmail, validPhone, validWebContact,
                         validWebsite), //
                 Arguments.of(validName, null, validLocation, validEmail, validPhone, validWebContact, validWebsite), //
-                Arguments.of(validName, validDescription, null, validEmail, validPhone, validWebContact,
+                Arguments.of(validName, validDescription, null, validEmail, validPhone, validWebContact, //
                         validWebsite), //
                 Arguments.of(validName, validDescription, validLocation, null, null, null, validWebsite), //
                 Arguments.of(validName, validDescription, validLocation, validEmail, validPhone, validWebContact,

--- a/src/test/java/edu/ucla/library/prl/harvester/InstitutionTest.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/InstitutionTest.java
@@ -12,6 +12,8 @@ import javax.mail.internet.AddressException;
 import javax.mail.internet.InternetAddress;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -31,6 +33,7 @@ import io.vertx.core.json.JsonObject;
 /**
  * Tests {@link Institution}.
  */
+@Execution(ExecutionMode.CONCURRENT)
 public class InstitutionTest {
 
     /**

--- a/src/test/java/edu/ucla/library/prl/harvester/InstitutionTest.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/InstitutionTest.java
@@ -186,7 +186,7 @@ public class InstitutionTest {
     }
 
     /**
-     * Tests that the more strongly-typed constructor can't be called with certain combinations of null arguments.
+     * Tests that the more strongly-typed constructor can't be called with null arguments.
      *
      * @param aName The institution's name
      * @param aDescription The institution's description

--- a/src/test/java/edu/ucla/library/prl/harvester/InstitutionTest.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/InstitutionTest.java
@@ -181,6 +181,12 @@ public class InstitutionTest {
         final String invalidWebsite = "example.com/2"; // Missing protocol
 
         return Stream.of( //
+                Arguments.of(null, validDescription, validLocation, validEmail, validPhone, validWebContact,
+                        validWebsite, null), //
+                Arguments.of(validName, null, validLocation, validEmail, validPhone, validWebContact, validWebsite,
+                        null), //
+                Arguments.of(validName, validDescription, null, validEmail, validPhone, validWebContact, validWebsite,
+                        null), //
                 Arguments.of(validName, validDescription, validLocation, invalidEmail, validPhone, validWebContact,
                         validWebsite, AddressException.class), //
                 Arguments.of(validName, validDescription, validLocation, validEmail, invalidPhone1, validWebContact,
@@ -190,6 +196,8 @@ public class InstitutionTest {
                 Arguments.of(validName, validDescription, validLocation, validEmail, validPhone, invalidWebContact,
                         validWebsite, MalformedURLException.class), //
                 Arguments.of(validName, validDescription, validLocation, null, null, null, validWebsite, null), //
+                Arguments.of(validName, validDescription, validLocation, validEmail, validPhone, validWebContact,
+                        null, null),
                 Arguments.of(validName, validDescription, validLocation, validEmail, validPhone, validWebContact,
                         invalidWebsite, MalformedURLException.class));
     }

--- a/src/test/java/edu/ucla/library/prl/harvester/InstitutionTest.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/InstitutionTest.java
@@ -187,6 +187,7 @@ public class InstitutionTest {
                         null), //
                 Arguments.of(validName, validDescription, null, validEmail, validPhone, validWebContact, validWebsite,
                         null), //
+                Arguments.of(validName, validDescription, validLocation, null, null, null, validWebsite, null), //
                 Arguments.of(validName, validDescription, validLocation, invalidEmail, validPhone, validWebContact,
                         validWebsite, AddressException.class), //
                 Arguments.of(validName, validDescription, validLocation, validEmail, invalidPhone1, validWebContact,
@@ -195,7 +196,6 @@ public class InstitutionTest {
                         validWebsite, NumberParseException.class), //
                 Arguments.of(validName, validDescription, validLocation, validEmail, validPhone, invalidWebContact,
                         validWebsite, MalformedURLException.class), //
-                Arguments.of(validName, validDescription, validLocation, null, null, null, validWebsite, null), //
                 Arguments.of(validName, validDescription, validLocation, validEmail, validPhone, validWebContact,
                         null, null),
                 Arguments.of(validName, validDescription, validLocation, validEmail, validPhone, validWebContact,

--- a/src/test/java/edu/ucla/library/prl/harvester/JobTest.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/JobTest.java
@@ -107,7 +107,7 @@ public class JobTest {
                 .put(Job.SETS, aSets) //
                 .put(Job.SCHEDULE_CRON_EXPRESSION, aScheduleCronExpression) //
                 .put(Job.LAST_SUCCESSFUL_RUN, aLastSuccessfulRun);
-        final Exception error = assertThrows(IllegalArgumentException.class, () -> new Job(json));
+        final Exception error = assertThrows(InvalidJobJsonException.class, () -> new Job(json));
 
         assertEquals(anErrorClass, error.getCause().getClass());
     }

--- a/src/test/java/edu/ucla/library/prl/harvester/JobTest.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/JobTest.java
@@ -15,6 +15,8 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -28,6 +30,7 @@ import io.vertx.core.json.JsonObject;
 /**
  * Tests {@link Job}.
  */
+@Execution(ExecutionMode.CONCURRENT)
 public class JobTest {
 
     /**

--- a/src/test/java/edu/ucla/library/prl/harvester/JobTest.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/JobTest.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -167,5 +168,13 @@ public class JobTest {
         return Stream.of( //
                 Arguments.of(1, null, validSets, validSchedule, validTimestamp), //
                 Arguments.of(2, validUrl, validSets, null, validTimestamp));
+    }
+
+    /**
+     * Tests that passing a null {@link JsonObject} throws a {@link NullPointerException}.
+     */
+    @Test
+    void testJobNullJsonObject() {
+        assertThrows(NullPointerException.class, () -> new Job(null));
     }
 }

--- a/src/test/java/edu/ucla/library/prl/harvester/JobTest.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/JobTest.java
@@ -169,7 +169,8 @@ public class JobTest {
 
         return Stream.of( //
                 Arguments.of(1, null, validSets, validSchedule, validTimestamp), //
-                Arguments.of(2, validURL, validSets, null, validTimestamp));
+                Arguments.of(2, validURL, validSets, null, validTimestamp), //
+                Arguments.of(3, null, validSets, null, validTimestamp));
     }
 
     /**

--- a/src/test/java/edu/ucla/library/prl/harvester/JobTest.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/JobTest.java
@@ -33,21 +33,21 @@ public class JobTest {
     /**
      * Tests that a {@link Job} can be instantiated from a {@link JsonObject} and serialized back to one.
      *
-     * @param anInstitutionId The identifier of the institution that this job should be associated with
-     * @param aRepositoryBaseUrl The base URL of the OAI-PMH repository
+     * @param anInstitutionID The identifier of the institution that this job should be associated with
+     * @param aRepositoryBaseURL The base URL of the OAI-PMH repository
      * @param aSets The list of sets to harvest; if empty, assume all sets should be harvested
      * @param aScheduleCronExpression The schedule on which this job should be run
      * @param aLastSuccessfulRun The timestamp of the last successful run of this job; will be null at first
      */
     @ParameterizedTest
     @MethodSource
-    void testJobSerDe(final int anInstitutionId, final URL aRepositoryBaseUrl, final List<String> aSets,
+    void testJobSerDe(final int anInstitutionID, final URL aRepositoryBaseURL, final List<String> aSets,
             final CronExpression aScheduleCronExpression, final ZonedDateTime aLastSuccessfulRun) {
         final Job job =
-                new Job(anInstitutionId, aRepositoryBaseUrl, aSets, aScheduleCronExpression, aLastSuccessfulRun);
+                new Job(anInstitutionID, aRepositoryBaseURL, aSets, aScheduleCronExpression, aLastSuccessfulRun);
         final JsonObject json = new JsonObject() //
-                .put(Job.INSTITUTION_ID, anInstitutionId) //
-                .put(Job.REPOSITORY_BASE_URL, aRepositoryBaseUrl.toString()) //
+                .put(Job.INSTITUTION_ID, anInstitutionID) //
+                .put(Job.REPOSITORY_BASE_URL, aRepositoryBaseURL.toString()) //
                 .put(Job.SETS, Optional.ofNullable(aSets).orElse(null)) //
                 .put(Job.SCHEDULE_CRON_EXPRESSION, aScheduleCronExpression.getCronExpression()) //
                 .put(Job.LAST_SUCCESSFUL_RUN,
@@ -57,8 +57,8 @@ public class JobTest {
         assertEquals(json.copy().put(Job.METADATA_PREFIX, Constants.OAI_DC), job.toJson());
         assertEquals(job.toJson(), jobFromJson.toJson());
 
-        assertEquals(job.getInstitutionId(), jobFromJson.getInstitutionId());
-        assertEquals(job.getRepositoryBaseUrl(), jobFromJson.getRepositoryBaseUrl());
+        assertEquals(job.getInstitutionID(), jobFromJson.getInstitutionID());
+        assertEquals(job.getRepositoryBaseURL(), jobFromJson.getRepositoryBaseURL());
         assertEquals(job.getSets(), jobFromJson.getSets());
         assertEquals(job.getMetadataPrefix(), jobFromJson.getMetadataPrefix());
         assertEquals(job.getScheduleCronExpression().toString(), jobFromJson.getScheduleCronExpression().toString());
@@ -71,24 +71,24 @@ public class JobTest {
      * @throws ParseException
      */
     static Stream<Arguments> testJobSerDe() throws MalformedURLException, ParseException {
-        final URL exampleUrl = new URL("http://example.com/1/oai");
+        final URL exampleURL = new URL("http://example.com/1/oai");
         final List<String> exampleSets = List.of("set1:subset1", "set1:subset2");
         final CronExpression exampleSchedule = new CronExpression("0 0 3 1 * ?");
         final ZonedDateTime exampleTimestamp = ZonedDateTime.parse("2000-01-01T00:00Z");
 
         return Stream.of( //
-                Arguments.of(1, exampleUrl, null, exampleSchedule, null), //
-                Arguments.of(2, exampleUrl, null, exampleSchedule, exampleTimestamp), //
-                Arguments.of(3, exampleUrl, List.of(), exampleSchedule, exampleTimestamp), //
-                Arguments.of(4, exampleUrl, exampleSets, exampleSchedule, null), //
-                Arguments.of(5, exampleUrl, exampleSets, exampleSchedule, exampleTimestamp));
+                Arguments.of(1, exampleURL, null, exampleSchedule, null), //
+                Arguments.of(2, exampleURL, null, exampleSchedule, exampleTimestamp), //
+                Arguments.of(3, exampleURL, List.of(), exampleSchedule, exampleTimestamp), //
+                Arguments.of(4, exampleURL, exampleSets, exampleSchedule, null), //
+                Arguments.of(5, exampleURL, exampleSets, exampleSchedule, exampleTimestamp));
     }
 
     /**
      * Tests that a {@link Job} cannot be instantiated from an invalid JSON representation.
      *
-     * @param anInstitutionId The identifier of the institution that this job should be associated with
-     * @param aRepositoryBaseUrl The base URL of the OAI-PMH repository
+     * @param anInstitutionID The identifier of the institution that this job should be associated with
+     * @param aRepositoryBaseURL The base URL of the OAI-PMH repository
      * @param aSets The list of sets to harvest; if empty, assume all sets should be harvested
      * @param aScheduleCronExpression The schedule on which this job should be run
      * @param aLastSuccessfulRun The timestamp of the last successful run of this job; will be null at first
@@ -96,12 +96,12 @@ public class JobTest {
      */
     @ParameterizedTest
     @MethodSource
-    void testJobInvalidJsonRepresentation(final Integer anInstitutionId, final String aRepositoryBaseUrl,
+    void testJobInvalidJsonRepresentation(final Integer anInstitutionID, final String aRepositoryBaseURL,
             final List<String> aSets, final String aScheduleCronExpression, final String aLastSuccessfulRun,
             final Class<Exception> anErrorClass) {
         final JsonObject json = new JsonObject() //
-                .put(Job.INSTITUTION_ID, anInstitutionId) //
-                .put(Job.REPOSITORY_BASE_URL, aRepositoryBaseUrl) //
+                .put(Job.INSTITUTION_ID, anInstitutionID) //
+                .put(Job.REPOSITORY_BASE_URL, aRepositoryBaseURL) //
                 .put(Job.SETS, aSets) //
                 .put(Job.SCHEDULE_CRON_EXPRESSION, aScheduleCronExpression) //
                 .put(Job.LAST_SUCCESSFUL_RUN, aLastSuccessfulRun);
@@ -116,8 +116,8 @@ public class JobTest {
      * @throws ParseException
      */
     static Stream<Arguments> testJobInvalidJsonRepresentation() throws MalformedURLException, ParseException {
-        final String validUrl = new URL("http://example.com/2/oai").toString();
-        final String invalidUrl = "example.com/oai"; // Missing protocol
+        final String validURL = new URL("http://example.com/2/oai").toString();
+        final String invalidURL = "example.com/oai"; // Missing protocol
 
         final List<String> validSets = List.of();
 
@@ -128,29 +128,29 @@ public class JobTest {
         final String invalidTimestamp = LocalDate.of(2020, 1, 1).toString(); // Missing time component
 
         return Stream.of( //
-                Arguments.of(null, validUrl, validSets, validSchedule, validTimestamp, NullPointerException.class), //
+                Arguments.of(null, validURL, validSets, validSchedule, validTimestamp, NullPointerException.class), //
                 Arguments.of(2, null, validSets, validSchedule, validTimestamp, NullPointerException.class), //
-                Arguments.of(3, invalidUrl, validSets, validSchedule, validTimestamp, MalformedURLException.class), //
-                Arguments.of(4, validUrl, validSets, null, validTimestamp, NullPointerException.class), //
-                Arguments.of(5, validUrl, validSets, invalidSchedule, validTimestamp, ParseException.class), //
-                Arguments.of(6, validUrl, validSets, validSchedule, invalidTimestamp, DateTimeParseException.class));
+                Arguments.of(3, invalidURL, validSets, validSchedule, validTimestamp, MalformedURLException.class), //
+                Arguments.of(4, validURL, validSets, null, validTimestamp, NullPointerException.class), //
+                Arguments.of(5, validURL, validSets, invalidSchedule, validTimestamp, ParseException.class), //
+                Arguments.of(6, validURL, validSets, validSchedule, invalidTimestamp, DateTimeParseException.class));
     }
 
     /**
      * Tests that the more strongly-typed constructor can't be called with certain combinations of null arguments.
      *
-     * @param anInstitutionId The identifier of the institution that this job should be associated with
-     * @param aRepositoryBaseUrl The base URL of the OAI-PMH repository
+     * @param anInstitutionID The identifier of the institution that this job should be associated with
+     * @param aRepositoryBaseURL The base URL of the OAI-PMH repository
      * @param aSets The list of sets to harvest; if empty, assume all sets should be harvested
      * @param aScheduleCronExpression The schedule on which this job should be run
      * @param aLastSuccessfulRun The timestamp of the last successful run of this job; will be null at first
      */
     @ParameterizedTest
     @MethodSource
-    void testJobNullArguments(final int anInstitutionId, final URL aRepositoryBaseUrl, final List<String> aSets,
+    void testJobNullArguments(final int anInstitutionID, final URL aRepositoryBaseURL, final List<String> aSets,
             final CronExpression aScheduleCronExpression, final ZonedDateTime aLastSuccessfulRun) {
         assertThrows(NullPointerException.class, () -> {
-            new Job(anInstitutionId, aRepositoryBaseUrl, aSets, aScheduleCronExpression, aLastSuccessfulRun);
+            new Job(anInstitutionID, aRepositoryBaseURL, aSets, aScheduleCronExpression, aLastSuccessfulRun);
         });
     }
 
@@ -160,14 +160,14 @@ public class JobTest {
      * @throws ParseException
      */
     static Stream<Arguments> testJobNullArguments() throws MalformedURLException, ParseException {
-        final URL validUrl = new URL("http://example.com/3/oai");
+        final URL validURL = new URL("http://example.com/3/oai");
         final List<String> validSets = List.of();
         final CronExpression validSchedule = new CronExpression("0 0 * * * ?");
         final ZonedDateTime validTimestamp = ZonedDateTime.parse("2020-01-01T00:00Z");
 
         return Stream.of( //
                 Arguments.of(1, null, validSets, validSchedule, validTimestamp), //
-                Arguments.of(2, validUrl, validSets, null, validTimestamp));
+                Arguments.of(2, validURL, validSets, null, validTimestamp));
     }
 
     /**

--- a/src/test/java/edu/ucla/library/prl/harvester/JobTest.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/JobTest.java
@@ -21,6 +21,9 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.quartz.CronExpression;
 
+import info.freelibrary.util.Logger;
+import info.freelibrary.util.LoggerFactory;
+
 import io.vertx.core.json.JsonObject;
 import io.vertx.junit5.VertxExtension;
 
@@ -29,6 +32,11 @@ import io.vertx.junit5.VertxExtension;
  */
 @ExtendWith(VertxExtension.class)
 public class JobTest {
+
+    /**
+     * The logger.
+     */
+    private static final Logger LOGGER = LoggerFactory.getLogger(JobTest.class, MessageCodes.BUNDLE);
 
     /**
      * Tests that a {@link Job} can be instantiated from a {@link JsonObject} and serialized back to one.
@@ -109,7 +117,11 @@ public class JobTest {
                 .put(Job.LAST_SUCCESSFUL_RUN, aLastSuccessfulRun);
         final Exception error = assertThrows(InvalidJobJsonException.class, () -> new Job(json));
 
-        assertEquals(anErrorClass, error.getCause().getClass());
+        if (error.getCause() != null) {
+            assertEquals(anErrorClass, error.getCause().getClass());
+        }
+
+        LOGGER.debug(LOGGER.getMessage(MessageCodes.PRL_000, error));
     }
 
     /**
@@ -130,10 +142,10 @@ public class JobTest {
         final String invalidTimestamp = LocalDate.of(2020, 1, 1).toString(); // Missing time component
 
         return Stream.of( //
-                Arguments.of(null, validURL, validSets, validSchedule, validTimestamp, NullPointerException.class), //
-                Arguments.of(2, null, validSets, validSchedule, validTimestamp, NullPointerException.class), //
+                Arguments.of(null, validURL, validSets, validSchedule, validTimestamp, null), //
+                Arguments.of(2, null, validSets, validSchedule, validTimestamp, null), //
                 Arguments.of(3, invalidURL, validSets, validSchedule, validTimestamp, MalformedURLException.class), //
-                Arguments.of(4, validURL, validSets, null, validTimestamp, NullPointerException.class), //
+                Arguments.of(4, validURL, validSets, null, validTimestamp, null), //
                 Arguments.of(5, validURL, validSets, invalidSchedule, validTimestamp, ParseException.class), //
                 Arguments.of(6, validURL, validSets, validSchedule, invalidTimestamp, DateTimeParseException.class));
     }

--- a/src/test/java/edu/ucla/library/prl/harvester/JobTest.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/JobTest.java
@@ -76,11 +76,11 @@ public class JobTest {
         final ZonedDateTime exampleTimestamp = ZonedDateTime.parse("2000-01-01T00:00Z");
 
         return Stream.of( //
-                Arguments.of(0, exampleUrl, null, exampleSchedule, null), //
-                Arguments.of(1, exampleUrl, null, exampleSchedule, exampleTimestamp), //
-                Arguments.of(2, exampleUrl, List.of(), exampleSchedule, exampleTimestamp), //
-                Arguments.of(3, exampleUrl, exampleSets, exampleSchedule, null), //
-                Arguments.of(4, exampleUrl, exampleSets, exampleSchedule, exampleTimestamp));
+                Arguments.of(1, exampleUrl, null, exampleSchedule, null), //
+                Arguments.of(2, exampleUrl, null, exampleSchedule, exampleTimestamp), //
+                Arguments.of(3, exampleUrl, List.of(), exampleSchedule, exampleTimestamp), //
+                Arguments.of(4, exampleUrl, exampleSets, exampleSchedule, null), //
+                Arguments.of(5, exampleUrl, exampleSets, exampleSchedule, exampleTimestamp));
     }
 
     /**
@@ -128,11 +128,11 @@ public class JobTest {
 
         return Stream.of( //
                 Arguments.of(null, validUrl, validSets, validSchedule, validTimestamp, NullPointerException.class), //
-                Arguments.of(0, null, validSets, validSchedule, validTimestamp, NullPointerException.class), //
-                Arguments.of(1, invalidUrl, validSets, validSchedule, validTimestamp, MalformedURLException.class), //
-                Arguments.of(2, validUrl, validSets, null, validTimestamp, NullPointerException.class), //
-                Arguments.of(3, validUrl, validSets, invalidSchedule, validTimestamp, ParseException.class), //
-                Arguments.of(4, validUrl, validSets, validSchedule, invalidTimestamp, DateTimeParseException.class));
+                Arguments.of(2, null, validSets, validSchedule, validTimestamp, NullPointerException.class), //
+                Arguments.of(3, invalidUrl, validSets, validSchedule, validTimestamp, MalformedURLException.class), //
+                Arguments.of(4, validUrl, validSets, null, validTimestamp, NullPointerException.class), //
+                Arguments.of(5, validUrl, validSets, invalidSchedule, validTimestamp, ParseException.class), //
+                Arguments.of(6, validUrl, validSets, validSchedule, invalidTimestamp, DateTimeParseException.class));
     }
 
     /**
@@ -165,7 +165,7 @@ public class JobTest {
         final ZonedDateTime validTimestamp = ZonedDateTime.parse("2020-01-01T00:00Z");
 
         return Stream.of( //
-                Arguments.of(0, null, validSets, validSchedule, validTimestamp), //
-                Arguments.of(0, validUrl, validSets, null, validTimestamp));
+                Arguments.of(1, null, validSets, validSchedule, validTimestamp), //
+                Arguments.of(2, validUrl, validSets, null, validTimestamp));
     }
 }

--- a/src/test/java/edu/ucla/library/prl/harvester/JobTest.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/JobTest.java
@@ -1,0 +1,171 @@
+
+package edu.ucla.library.prl.harvester;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.text.ParseException;
+import java.time.LocalDate;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeParseException;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.quartz.CronExpression;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.junit5.VertxExtension;
+
+/**
+ * Tests {@link Job}.
+ */
+@ExtendWith(VertxExtension.class)
+public class JobTest {
+
+    /**
+     * Tests that a {@link Job} can be instantiated from a {@link JsonObject} and serialized back to one.
+     *
+     * @param anInstitutionId The identifier of the institution that this job should be associated with
+     * @param aRepositoryBaseUrl The base URL of the OAI-PMH repository
+     * @param aSets The list of sets to harvest; if empty, assume all sets should be harvested
+     * @param aScheduleCronExpression The schedule on which this job should be run
+     * @param aLastSuccessfulRun The timestamp of the last successful run of this job; will be null at first
+     */
+    @ParameterizedTest
+    @MethodSource
+    void testJobSerDe(final int anInstitutionId, final URL aRepositoryBaseUrl, final List<String> aSets,
+            final CronExpression aScheduleCronExpression, final ZonedDateTime aLastSuccessfulRun) {
+        final Job job =
+                new Job(anInstitutionId, aRepositoryBaseUrl, aSets, aScheduleCronExpression, aLastSuccessfulRun);
+        final JsonObject json = new JsonObject() //
+                .put(Job.INSTITUTION_ID, anInstitutionId) //
+                .put(Job.REPOSITORY_BASE_URL, aRepositoryBaseUrl.toString()) //
+                .put(Job.SETS, Optional.ofNullable(aSets).orElse(null)) //
+                .put(Job.SCHEDULE_CRON_EXPRESSION, aScheduleCronExpression.getCronExpression()) //
+                .put(Job.LAST_SUCCESSFUL_RUN,
+                        Optional.ofNullable(aLastSuccessfulRun).map(ZonedDateTime::toString).orElse(null));
+        final Job jobFromJson = new Job(json);
+
+        assertEquals(json.copy().put(Job.METADATA_PREFIX, Constants.OAI_DC), job.toJson());
+        assertEquals(job.toJson(), jobFromJson.toJson());
+
+        assertEquals(job.getInstitutionId(), jobFromJson.getInstitutionId());
+        assertEquals(job.getRepositoryBaseUrl(), jobFromJson.getRepositoryBaseUrl());
+        assertEquals(job.getSets(), jobFromJson.getSets());
+        assertEquals(job.getMetadataPrefix(), jobFromJson.getMetadataPrefix());
+        assertEquals(job.getScheduleCronExpression().toString(), jobFromJson.getScheduleCronExpression().toString());
+        assertEquals(job.getLastSuccessfulRun(), jobFromJson.getLastSuccessfulRun());
+    }
+
+    /**
+     * @return The arguments for the corresponding {@link ParameterizedTest}
+     * @throws MalformedURLException
+     * @throws ParseException
+     */
+    static Stream<Arguments> testJobSerDe() throws MalformedURLException, ParseException {
+        final URL exampleUrl = new URL("http://example.com/1/oai");
+        final List<String> exampleSets = List.of("set1:subset1", "set1:subset2");
+        final CronExpression exampleSchedule = new CronExpression("0 0 3 1 * ?");
+        final ZonedDateTime exampleTimestamp = ZonedDateTime.parse("2000-01-01T00:00Z");
+
+        return Stream.of( //
+                Arguments.of(0, exampleUrl, null, exampleSchedule, null), //
+                Arguments.of(1, exampleUrl, null, exampleSchedule, exampleTimestamp), //
+                Arguments.of(2, exampleUrl, List.of(), exampleSchedule, exampleTimestamp), //
+                Arguments.of(3, exampleUrl, exampleSets, exampleSchedule, null), //
+                Arguments.of(4, exampleUrl, exampleSets, exampleSchedule, exampleTimestamp));
+    }
+
+    /**
+     * Tests that a {@link Job} cannot be instantiated from an invalid JSON representation.
+     *
+     * @param anInstitutionId The identifier of the institution that this job should be associated with
+     * @param aRepositoryBaseUrl The base URL of the OAI-PMH repository
+     * @param aSets The list of sets to harvest; if empty, assume all sets should be harvested
+     * @param aScheduleCronExpression The schedule on which this job should be run
+     * @param aLastSuccessfulRun The timestamp of the last successful run of this job; will be null at first
+     * @param anErrorClass The class of error that we expect instantiation with the above arguments to throw
+     */
+    @ParameterizedTest
+    @MethodSource
+    void testJobInvalidJsonRepresentation(final Integer anInstitutionId, final String aRepositoryBaseUrl,
+            final List<String> aSets, final String aScheduleCronExpression, final String aLastSuccessfulRun,
+            final Class<Exception> anErrorClass) {
+        final JsonObject json = new JsonObject() //
+                .put(Job.INSTITUTION_ID, anInstitutionId) //
+                .put(Job.REPOSITORY_BASE_URL, aRepositoryBaseUrl) //
+                .put(Job.SETS, aSets) //
+                .put(Job.SCHEDULE_CRON_EXPRESSION, aScheduleCronExpression) //
+                .put(Job.LAST_SUCCESSFUL_RUN, aLastSuccessfulRun);
+        final Exception error = assertThrows(IllegalArgumentException.class, () -> new Job(json));
+
+        assertEquals(anErrorClass, error.getCause().getClass());
+    }
+
+    /**
+     * @return The arguments for the corresponding {@link ParameterizedTest}
+     * @throws MalformedURLException
+     * @throws ParseException
+     */
+    static Stream<Arguments> testJobInvalidJsonRepresentation() throws MalformedURLException, ParseException {
+        final String validUrl = new URL("http://example.com/2/oai").toString();
+        final String invalidUrl = "example.com/oai"; // Missing protocol
+
+        final List<String> validSets = List.of();
+
+        final String validSchedule = new CronExpression("* * * * * ?").toString();
+        final String invalidSchedule = "* * * * *"; // Minimum of six elements is required
+
+        final String validTimestamp = ZonedDateTime.parse("2010-01-01T00:00Z").toString();
+        final String invalidTimestamp = LocalDate.of(2020, 1, 1).toString(); // Missing time component
+
+        return Stream.of( //
+                Arguments.of(null, validUrl, validSets, validSchedule, validTimestamp, NullPointerException.class), //
+                Arguments.of(0, null, validSets, validSchedule, validTimestamp, NullPointerException.class), //
+                Arguments.of(1, invalidUrl, validSets, validSchedule, validTimestamp, MalformedURLException.class), //
+                Arguments.of(2, validUrl, validSets, null, validTimestamp, NullPointerException.class), //
+                Arguments.of(3, validUrl, validSets, invalidSchedule, validTimestamp, ParseException.class), //
+                Arguments.of(4, validUrl, validSets, validSchedule, invalidTimestamp, DateTimeParseException.class));
+    }
+
+    /**
+     * Tests that the more strongly-typed constructor can't be called with certain combinations of null arguments.
+     *
+     * @param anInstitutionId The identifier of the institution that this job should be associated with
+     * @param aRepositoryBaseUrl The base URL of the OAI-PMH repository
+     * @param aSets The list of sets to harvest; if empty, assume all sets should be harvested
+     * @param aScheduleCronExpression The schedule on which this job should be run
+     * @param aLastSuccessfulRun The timestamp of the last successful run of this job; will be null at first
+     */
+    @ParameterizedTest
+    @MethodSource
+    void testJobNullArguments(final int anInstitutionId, final URL aRepositoryBaseUrl, final List<String> aSets,
+            final CronExpression aScheduleCronExpression, final ZonedDateTime aLastSuccessfulRun) {
+        assertThrows(NullPointerException.class, () -> {
+            new Job(anInstitutionId, aRepositoryBaseUrl, aSets, aScheduleCronExpression, aLastSuccessfulRun);
+        });
+    }
+
+    /**
+     * @return The arguments for the corresponding {@link ParameterizedTest}
+     * @throws MalformedURLException
+     * @throws ParseException
+     */
+    static Stream<Arguments> testJobNullArguments() throws MalformedURLException, ParseException {
+        final URL validUrl = new URL("http://example.com/3/oai");
+        final List<String> validSets = List.of();
+        final CronExpression validSchedule = new CronExpression("0 0 * * * ?");
+        final ZonedDateTime validTimestamp = ZonedDateTime.parse("2020-01-01T00:00Z");
+
+        return Stream.of( //
+                Arguments.of(0, null, validSets, validSchedule, validTimestamp), //
+                Arguments.of(0, validUrl, validSets, null, validTimestamp));
+    }
+}

--- a/src/test/java/edu/ucla/library/prl/harvester/JobTest.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/JobTest.java
@@ -54,9 +54,11 @@ public class JobTest {
                         Optional.ofNullable(aLastSuccessfulRun).map(ZonedDateTime::toString).orElse(null));
         final Job jobFromJson = new Job(json);
 
+        // If the JSON representations are equal, then serialization works
         assertEquals(json.copy().put(Job.METADATA_PREFIX, Constants.OAI_DC), job.toJson());
         assertEquals(job.toJson(), jobFromJson.toJson());
 
+        // If the objects are equal, then deserialization works
         assertEquals(job.getInstitutionID(), jobFromJson.getInstitutionID());
         assertEquals(job.getRepositoryBaseURL(), jobFromJson.getRepositoryBaseURL());
         assertEquals(job.getSets(), jobFromJson.getSets());

--- a/src/test/java/edu/ucla/library/prl/harvester/JobTest.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/JobTest.java
@@ -139,7 +139,7 @@ public class JobTest {
     }
 
     /**
-     * Tests that the more strongly-typed constructor can't be called with certain combinations of null arguments.
+     * Tests that the more strongly-typed constructor can't be called with certain arguments as null.
      *
      * @param anInstitutionID The identifier of the institution that this job should be associated with
      * @param aRepositoryBaseURL The base URL of the OAI-PMH repository

--- a/src/test/java/edu/ucla/library/prl/harvester/JobTest.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/JobTest.java
@@ -15,7 +15,6 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -25,12 +24,10 @@ import info.freelibrary.util.Logger;
 import info.freelibrary.util.LoggerFactory;
 
 import io.vertx.core.json.JsonObject;
-import io.vertx.junit5.VertxExtension;
 
 /**
  * Tests {@link Job}.
  */
-@ExtendWith(VertxExtension.class)
 public class JobTest {
 
     /**


### PR DESCRIPTION
These immutable types should be nearly* impossible to instantiate with invalid arguments, and can be used with service proxies (i.e., sent over the event bus) since they are annotated with `@DataObject`.

Justification for the various PMD suppressions:
- `PMD.AvoidThrowingNullPointerException`: I think it's fine for the `Institution` constructor to throw a NPE if it receives `null` for email, phone, _and_ web contact; that would be a "programmer error" (at least one must be supplied per the Javadoc);
- `PMD.AvoidCatchingGenericException`: the constructors that accept a `JsonObject` [are required](https://github.com/eclipse-vertx/vertx-codegen#dataobject-annotated-types) for `@DataObject` classes, since they are called by generated service proxy code. These classes don't compile if their constructors throw checked exceptions, hence the catch-all that wraps those in an `IllegalArgumentException`;
- `PMD.AvoidCatchingNPE`: I suppose that instead of using `Objects#requireNonNull` in these constructors, one could explicitly check for equality with `null` and then throw `IllegalArgumentException`, but I think it's nice that all errors end up in the catch-all;
- `PMD.DataClass`: it's intended that these classes are "data classes".

---

\* One exception is that email addresses such as `me@localhost` will not trigger an error; however, we aren't _verifying_ email addresses anyway, so there's nothing preventing an institution from e.g. accidentally providing an email address that they don't own. I think the validation that the `javax.mail` classes do is enough for our use case.