### PR TITLE
[SERV-516, SERV-517, SERV-519] Define interfaces for event bus services

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,10 @@
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
+      <artifactId>vertx-service-proxy</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
       <artifactId>vertx-codegen</artifactId>
       <classifier>processor</classifier>
     </dependency>

--- a/src/main/java/edu/ucla/library/prl/harvester/services/HarvestJobSchedulerService.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/services/HarvestJobSchedulerService.java
@@ -52,7 +52,7 @@ public interface HarvestJobSchedulerService {
      * @param aJob The harvest job to add
      * @return A Future that succeeds, with a unique local ID for the harvest job, if it was added
      */
-    Future<Integer> addHarvestJob(Job aJob);
+    Future<Integer> addJob(Job aJob);
 
     /**
      * Updates a harvest job.
@@ -61,7 +61,7 @@ public interface HarvestJobSchedulerService {
      * @param aJob The harvest job to replace the existing one with
      * @return A Future that succeeds if the harvest job was updated
      */
-    Future<Void> updateHarvestJob(int aJobId, Job aJob);
+    Future<Void> updateJob(int aJobId, Job aJob);
 
     /**
      * Removes a harvest job.
@@ -69,7 +69,7 @@ public interface HarvestJobSchedulerService {
      * @param aJobId The unique local ID for the harvest job
      * @return A Future that succeeds if the harvest job was removed
      */
-    Future<Void> removeHarvestJob(int aJobId);
+    Future<Void> removeJob(int aJobId);
 
     /**
      * Closes the underlying resources used by this service.

--- a/src/main/java/edu/ucla/library/prl/harvester/services/HarvestJobSchedulerService.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/services/HarvestJobSchedulerService.java
@@ -1,0 +1,81 @@
+
+package edu.ucla.library.prl.harvester.services;
+
+import edu.ucla.library.prl.harvester.Job;
+
+import io.vertx.codegen.annotations.ProxyClose;
+import io.vertx.codegen.annotations.ProxyGen;
+import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.serviceproxy.ServiceProxyBuilder;
+
+/**
+ * The interface of the event bus service that schedules harvest jobs.
+ */
+@ProxyGen
+@VertxGen
+public interface HarvestJobSchedulerService {
+
+    /**
+     * The event bus address that the service will be registered on, for access via service proxies.
+     */
+    String ADDRESS = HarvestJobSchedulerService.class.getName();
+
+    /**
+     * Creates an instance of the service.
+     *
+     * @param aVertx A Vert.x instance
+     * @param aConfig A configuration
+     * @return The service instance
+     */
+    static HarvestJobSchedulerService create(final Vertx aVertx, final JsonObject aConfig) {
+        // FIXME: this is incorrect, instantiate an implementing class instead
+        // TODO: depending on implementation, consider returning Future<HarvestJobSchedulerService> instead
+        return createProxy(aVertx);
+    }
+
+    /**
+     * Creates an instance of the service proxy.
+     *
+     * @param aVertx A Vert.x instance
+     * @return A service proxy instance
+     */
+    static HarvestJobSchedulerService createProxy(final Vertx aVertx) {
+        return new ServiceProxyBuilder(aVertx).setAddress(ADDRESS).build(HarvestJobSchedulerService.class);
+    }
+
+    /**
+     * Adds a harvest job.
+     *
+     * @param aJob The harvest job to add
+     * @return A Future that succeeds, with a unique local ID for the harvest job, if it was added
+     */
+    Future<Integer> addHarvestJob(Job aJob);
+
+    /**
+     * Updates a harvest job.
+     *
+     * @param aJobId The unique local ID for the harvest job
+     * @param aJob The harvest job to replace the existing one with
+     * @return A Future that succeeds if the harvest job was updated
+     */
+    Future<Void> updateHarvestJob(int aJobId, Job aJob);
+
+    /**
+     * Removes a harvest job.
+     *
+     * @param aJobId The unique local ID for the harvest job
+     * @return A Future that succeeds if the harvest job was removed
+     */
+    Future<Void> removeHarvestJob(int aJobId);
+
+    /**
+     * Closes the underlying resources used by this service.
+     *
+     * @return A Future that succeeds once the resources have been closed
+     */
+    @ProxyClose
+    Future<Void> close();
+}

--- a/src/main/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreService.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreService.java
@@ -1,0 +1,139 @@
+
+package edu.ucla.library.prl.harvester.services;
+
+import java.util.Collection;
+
+import edu.ucla.library.prl.harvester.Institution;
+import edu.ucla.library.prl.harvester.Job;
+
+import io.vertx.codegen.annotations.ProxyClose;
+import io.vertx.codegen.annotations.ProxyGen;
+import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.serviceproxy.ServiceProxyBuilder;
+
+/**
+ * The interface of the event bus service that stores the information needed to schedule harvest jobs.
+ */
+@ProxyGen
+@VertxGen
+public interface HarvestScheduleStoreService {
+
+    /**
+     * The event bus address that the service will be registered on, for access via service proxies.
+     */
+    String ADDRESS = HarvestScheduleStoreService.class.getName();
+
+    /**
+     * Creates an instance of the service.
+     *
+     * @param aVertx A Vert.x instance
+     * @param aConfig A configuration
+     * @return The service instance
+     */
+    static HarvestScheduleStoreService create(final Vertx aVertx, final JsonObject aConfig) {
+        // FIXME: this is incorrect, instantiate an implementing class instead
+        // TODO: depending on implementation, consider returning Future<HarvestScheduleStoreService> instead
+        return createProxy(aVertx);
+    }
+
+    /**
+     * Creates an instance of the service proxy.
+     *
+     * @param aVertx A Vert.x instance
+     * @return A service proxy instance
+     */
+    static HarvestScheduleStoreService createProxy(final Vertx aVertx) {
+        return new ServiceProxyBuilder(aVertx).setAddress(ADDRESS).build(HarvestScheduleStoreService.class);
+    }
+
+    /**
+     * Gets an institution.
+     *
+     * @param anInstitutionId The unique local ID for the institution
+     * @return A Future that succeeds if the institution exists
+     */
+    Future<Institution> getInstitution(int anInstitutionId);
+
+    /**
+     * Gets the list of all institutions.
+     *
+     * @return A Future that succeeds with a list of all institutions (if any)
+     */
+    Future<Collection<Institution>> listInstitutions();
+
+    /**
+     * Adds an institution.
+     *
+     * @param anInstitution The institution to add
+     * @return A Future that succeeds, with a unique local ID for the institution, if it was added
+     */
+    Future<Integer> addInstitution(Institution anInstitution);
+
+    /**
+     * Updates an institution.
+     *
+     * @param anInstitutionId The unique local ID for the institution
+     * @param anInstitution The institution to replace the existing one with
+     * @return A Future that succeeds if the institution was updated
+     */
+    Future<Void> updateInstitution(int anInstitutionId, Institution anInstitution);
+
+    /**
+     * Removes an institution and all associated jobs.
+     *
+     * @param anInstitutionId The unique local ID for the institution
+     * @return A Future that succeeds if the institution was removed
+     */
+    Future<Void> removeInstitution(int anInstitutionId);
+
+    /**
+     * Gets a harvest job.
+     *
+     * @param aJobId The unique local ID for the harvest job
+     * @return A Future that succeeds if the harvest job exists
+     */
+    Future<Job> getHarvestJob(int aJobId);
+
+    /**
+     * Gets the list of all harvest jobs.
+     *
+     * @return A Future that succeeds with a list of all harvest jobs (if any)
+     */
+    Future<Collection<Job>> listHarvestJobs();
+
+    /**
+     * Adds a harvest job.
+     *
+     * @param aJob The harvest job to add
+     * @return A Future that succeeds, with a unique local ID for the harvest job, if it was added
+     */
+    Future<Integer> addHarvestJob(Job aJob);
+
+    /**
+     * Updates a harvest job.
+     *
+     * @param aJobId The unique local ID for the harvest job
+     * @param aJob The harvest job to replace the existing one with
+     * @return A Future that succeeds if the harvest job was updated
+     */
+    Future<Void> updateHarvestJob(int aJobId, Job aJob);
+
+    /**
+     * Removes a harvest job.
+     *
+     * @param aJobId The unique local ID for the harvest job
+     * @return A Future that succeeds if the harvest job was removed
+     */
+    Future<Void> removeHarvestJob(int aJobId);
+
+    /**
+     * Closes the underlying resources used by this service.
+     *
+     * @return A Future that succeeds once the resources have been closed
+     */
+    @ProxyClose
+    Future<Void> close();
+}

--- a/src/main/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreService.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreService.java
@@ -1,7 +1,7 @@
 
 package edu.ucla.library.prl.harvester.services;
 
-import java.util.Collection;
+import java.util.List;
 
 import edu.ucla.library.prl.harvester.Institution;
 import edu.ucla.library.prl.harvester.Job;
@@ -62,7 +62,7 @@ public interface HarvestScheduleStoreService {
      *
      * @return A Future that succeeds with a list of all institutions (if any)
      */
-    Future<Collection<Institution>> listInstitutions();
+    Future<List<Institution>> listInstitutions();
 
     /**
      * Adds an institution.
@@ -102,7 +102,7 @@ public interface HarvestScheduleStoreService {
      *
      * @return A Future that succeeds with a list of all harvest jobs (if any)
      */
-    Future<Collection<Job>> listHarvestJobs();
+    Future<List<Job>> listHarvestJobs();
 
     /**
      * Adds a harvest job.

--- a/src/main/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreService.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreService.java
@@ -95,14 +95,14 @@ public interface HarvestScheduleStoreService {
      * @param aJobId The unique local ID for the harvest job
      * @return A Future that succeeds if the harvest job exists
      */
-    Future<Job> getHarvestJob(int aJobId);
+    Future<Job> getJob(int aJobId);
 
     /**
      * Gets the list of all harvest jobs.
      *
      * @return A Future that succeeds with a list of all harvest jobs (if any)
      */
-    Future<List<Job>> listHarvestJobs();
+    Future<List<Job>> listJobs();
 
     /**
      * Adds a harvest job.
@@ -110,7 +110,7 @@ public interface HarvestScheduleStoreService {
      * @param aJob The harvest job to add
      * @return A Future that succeeds, with a unique local ID for the harvest job, if it was added
      */
-    Future<Integer> addHarvestJob(Job aJob);
+    Future<Integer> addJob(Job aJob);
 
     /**
      * Updates a harvest job.
@@ -119,7 +119,7 @@ public interface HarvestScheduleStoreService {
      * @param aJob The harvest job to replace the existing one with
      * @return A Future that succeeds if the harvest job was updated
      */
-    Future<Void> updateHarvestJob(int aJobId, Job aJob);
+    Future<Void> updateJob(int aJobId, Job aJob);
 
     /**
      * Removes a harvest job.
@@ -127,7 +127,7 @@ public interface HarvestScheduleStoreService {
      * @param aJobId The unique local ID for the harvest job
      * @return A Future that succeeds if the harvest job was removed
      */
-    Future<Void> removeHarvestJob(int aJobId);
+    Future<Void> removeJob(int aJobId);
 
     /**
      * Closes the underlying resources used by this service.

--- a/src/main/java/edu/ucla/library/prl/harvester/services/HarvestService.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/services/HarvestService.java
@@ -1,0 +1,64 @@
+
+package edu.ucla.library.prl.harvester.services;
+
+import edu.ucla.library.prl.harvester.Job;
+
+import io.vertx.codegen.annotations.ProxyClose;
+import io.vertx.codegen.annotations.ProxyGen;
+import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.serviceproxy.ServiceProxyBuilder;
+
+/**
+ * The interface of the event bus service that runs harvest jobs.
+ */
+@ProxyGen
+@VertxGen
+public interface HarvestService {
+
+    /**
+     * The event bus address that the service will be registered on, for access via service proxies.
+     */
+    String ADDRESS = HarvestService.class.getName();
+
+    /**
+     * Creates an instance of the service.
+     *
+     * @param aVertx A Vert.x instance
+     * @param aConfig A configuration
+     * @return The service instance
+     */
+    static HarvestService create(final Vertx aVertx, final JsonObject aConfig) {
+        // FIXME: this is incorrect, instantiate an implementing class instead
+        // TODO: depending on implementation, consider returning Future<HarvestService> instead
+        return createProxy(aVertx);
+    }
+
+    /**
+     * Creates an instance of the service proxy.
+     *
+     * @param aVertx A Vert.x instance
+     * @return A service proxy instance
+     */
+    static HarvestService createProxy(final Vertx aVertx) {
+        return new ServiceProxyBuilder(aVertx).setAddress(ADDRESS).build(HarvestService.class);
+    }
+
+    /**
+     * Runs a harvest job.
+     *
+     * @param aJob The harvest job to run
+     * @return A Future that succeeds if the harvest job succeeded
+     */
+    Future<Object> run(Job aJob); // FIXME: use more appropriate return type
+
+    /**
+     * Closes the underlying resources used by this service.
+     *
+     * @return A Future that succeeds once the resources have been closed
+     */
+    @ProxyClose
+    Future<Void> close();
+}

--- a/src/main/java/edu/ucla/library/prl/harvester/services/package-info.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/services/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Package info required for handling generated sources.
+ */
+
+@ModuleGen(groupPackage = "edu.ucla.library.prl.harvester.services", name = "services", useFutures = true)
+package edu.ucla.library.prl.harvester.services;
+
+import io.vertx.codegen.annotations.ModuleGen;


### PR DESCRIPTION
Intended usage:

- **HarvestScheduleStoreService** (the "database service") called by HTTP request handlers for these operations:
  - `listInstitutions`, `getInstitution`, `addInstitution`, `updateInstitution`, `removeInstitution`
  - `listJobs`, `getJob`
- **HarvestScheduleStoreService** also called by HarvestJobSchedulerService on invocation of the latter's `addJob`, `updateJob`, and `deleteJob` methods (see next bullet)
- **HarvestJobSchedulerService** (the thing that holds cron timers for each job) called by HTTP request handlers for these operations:
  - `addJob`, `updateJob`, `deleteJob`
- **HarvestService** (the thing that sends OAI-PMH requests, etc.) called by HarvestJobSchedulerService via cron timers

~Wasn't entirely sure about naming choices; for example, OpenAPI operations for jobs are currently like `getJob`, while method names are like `getHarvestJob` -- which is better / should they match?~ Edit: matched