### PR TITLE
[SERV-526] Configure project for debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,18 @@ OAI-PMH harvester for the Pacific Rim Library.
 ## Running in Development
 
     mvn vertx:initialize vertx:run
+
+## The `debug` Maven Profile
+
+The POM includes a `debug` profile for making it easier to debug test classes annotated with `@ExtendWith(VertxExtension.class)`.
+
+To use:
+
+1. Run something like this:
+
+    ```bash
+    mvn verify -Pdebug -Dmaven.failsafe.debug
+    ```
+
+2. Attach a debugger via JDWP to the ports specified in the Maven process output
+3. Set breakpoints and enjoy

--- a/pom.xml
+++ b/pom.xml
@@ -294,7 +294,9 @@
         <artifactId>maven-failsafe-plugin</artifactId>
         <configuration>
           <argLine>${jacoco.agent.arg}</argLine>
-          <environmentVariables></environmentVariables>
+          <environmentVariables>
+            <HTTP_PORT>${http.test.port}</HTTP_PORT>
+          </environmentVariables>
           <systemPropertyVariables>
             <vertx.logger-delegate-factory-class-name>io.vertx.core.logging.SLF4JLogDelegateFactory</vertx.logger-delegate-factory-class-name>
           </systemPropertyVariables>
@@ -599,6 +601,74 @@
                     <arg>--org=${env.UCLALIBRARY_SNYK_ORG}</arg>
                     <arg>--fail-on=all</arg>
                   </args> 
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>debug</id>
+      <properties>
+        <maven.compiler.debug>true</maven.compiler.debug>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <properties>
+                <configurationParameters>
+                  junit.jupiter.execution.timeout.mode = disabled_on_debug
+                </configurationParameters>
+              </properties>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration>
+              <properties>
+                <configurationParameters>
+                  junit.jupiter.execution.timeout.mode = disabled_on_debug
+                </configurationParameters>
+              </properties>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>io.fabric8</groupId>
+            <artifactId>docker-maven-plugin</artifactId>
+            <configuration>
+              <imagesMap>
+                <image>
+                  <name>${docker.registry.account}${project.artifactId}:%l</name>
+                  <run>
+                    <ports>
+                      <port>${http.test.port}:${http.test.port}</port>
+                      <port>5555:5555</port>
+                    </ports>
+                    <env>
+                      <JAVA_OPTS>-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5555</JAVA_OPTS>
+                    </env>
+                    <wait>
+                      <time>60000</time>
+                    </wait>
+                  </run>
+                </image>
+              </imagesMap>
+            </configuration>
+            <executions>
+              <execution>
+                <id>docker-start</id>
+                <phase>pre-integration-test</phase>
+                <goals>
+                  <goal>start</goal>
+                </goals>
+                <configuration>
+                  <showLogs>true</showLogs>
                 </configuration>
               </execution>
             </executions>

--- a/src/test/java/edu/ucla/library/prl/harvester/handlers/StatusHandlerIT.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/handlers/StatusHandlerIT.java
@@ -1,0 +1,84 @@
+
+package edu.ucla.library.prl.harvester.handlers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import static info.freelibrary.util.Constants.INADDR_ANY;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import info.freelibrary.util.HTTP;
+
+import edu.ucla.library.prl.harvester.Config;
+import edu.ucla.library.prl.harvester.MediaType;
+
+import io.vertx.config.ConfigRetriever;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.client.HttpRequest;
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+
+/**
+ * Tests {@link StatusHandler#handle}.
+ */
+@ExtendWith(VertxExtension.class)
+@TestInstance(Lifecycle.PER_CLASS)
+public class StatusHandlerIT {
+
+    /**
+     * The application configuration.
+     */
+    private JsonObject myConfig;
+
+    /**
+     * A WebClient for calling the HTTP API.
+     */
+    private WebClient myWebClient;
+
+    /**
+     * The port on which the application is listening.
+     */
+    private int myPort;
+
+    /**
+     * Sets up the test.
+     *
+     * @param aVertx A Vert.x instance
+     * @param aContext A test context
+     */
+    @BeforeAll
+    public void setUp(final Vertx aVertx, final VertxTestContext aContext) {
+        ConfigRetriever.create(aVertx).getConfig().onSuccess(config -> {
+            myConfig = config;
+            myWebClient = WebClient.create(aVertx);
+            myPort = config.getInteger(Config.HTTP_PORT, 8888);
+
+            aContext.completeNow();
+        }).onFailure(aContext::failNow);
+    }
+
+    /**
+     * Tests the status handler.
+     *
+     * @param aVertx A Vert.x instance
+     * @param aContext A test context
+     */
+    @Test
+    public void testGetStatus(final Vertx aVertx, final VertxTestContext aContext) {
+        final HttpRequest<?> getStatus = myWebClient.get(myPort, INADDR_ANY, "/status");
+
+        getStatus.send().onSuccess(response -> {
+            aContext.verify(() -> {
+                assertEquals(HTTP.OK, response.statusCode());
+                assertEquals(MediaType.APPLICATION_JSON.toString(), response.headers().get(HttpHeaders.CONTENT_TYPE));
+            }).completeNow();
+        }).onFailure(aContext::failNow);
+    }
+}


### PR DESCRIPTION
You can now more easily use your favorite JDWP client to debug pretty much everything in this app. Eclipse's works well:
1. From the top-level menu, go to _Run_ > _Debug Configurations..._ and create a "Socket Attach" config for localhost:5005, and another for localhost:5555
2. Set a breakpoint inside StatusHandlerIT#testGetStatus
3. Run a command like the one in the README and connect each debug client when prompted by the Maven process output