### PR TITLE
[SERV-514] Implement Harvest Service

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,9 @@
     <quartz.version>2.3.2</quartz.version>
     <javax.mail.version>1.6.2</javax.mail.version>
     <libphonenumber.version>8.12.54</libphonenumber.version>
+    <solrs.version>2.6.0</solrs.version>
+    <xoai.version>4.2.0</xoai.version>
+    <guava.version>31.1-jre</guava.version>
 
     <!-- Security update overrides -->
     <snakeyaml.version>1.32</snakeyaml.version>
@@ -183,6 +186,40 @@
       <groupId>com.googlecode.libphonenumber</groupId>
       <artifactId>libphonenumber</artifactId>
       <version>${libphonenumber.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.ino</groupId>
+      <artifactId>solrs_2.12</artifactId>
+      <version>${solrs.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.dspace</groupId>
+      <artifactId>xoai-common</artifactId>
+      <version>${xoai.version}</version>
+      <exclusions>
+        <!-- Conflicts with solrs -->
+        <exclusion>
+          <groupId>org.codehaus.woodstox</groupId>
+          <artifactId>stax2-api</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.dspace</groupId>
+      <artifactId>xoai-service-provider</artifactId>
+      <version>${xoai.version}</version>
+      <exclusions>
+        <!-- Conflicts with solrs -->
+        <exclusion>
+          <groupId>org.codehaus.woodstox</groupId>
+          <artifactId>stax2-api</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
     </dependency>
 
     <!-- Security update overrides -->
@@ -343,22 +380,17 @@
         <configuration>
           <argLine>${jacoco.agent.arg}</argLine>
           <environmentVariables>
-            <AWS_ACCESS_KEY_ID>test</AWS_ACCESS_KEY_ID> <!-- access key and secret key must be set (to anything) -->
-            <AWS_DEFAULT_REGION>us-east-1</AWS_DEFAULT_REGION>
-            <AWS_ENDPOINT_URL>http://localhost:${test.s3.port}</AWS_ENDPOINT_URL>
-            <AWS_SECRET_ACCESS_KEY>test</AWS_SECRET_ACCESS_KEY>
             <HTTP_PORT>${test.harvester.port}</HTTP_PORT>
-          </environmentVariables>
-          <systemPropertyVariables>
-            <vertx.logger-delegate-factory-class-name>io.vertx.core.logging.SLF4JLogDelegateFactory</vertx.logger-delegate-factory-class-name>
-          </systemPropertyVariables>
-          <environmentVariables>
             <PGDATABASE>postgres</PGDATABASE>
             <PGUSER>${test.db.user}</PGUSER>
             <PGPASSWORD>${test.db.password}</PGPASSWORD>
             <PGPORT>${test.db.port}</PGPORT>
-            <HTTP_PORT>${test.harvester.port}</HTTP_PORT>
+            <SOLR_CORE_URL>http://172.17.0.1:${test.solr.port}/solr/prl</SOLR_CORE_URL>
+            <TEST_PROVIDER_BASE_URL>http://localhost:${test.provider.port}/provider</TEST_PROVIDER_BASE_URL>
           </environmentVariables>
+          <systemPropertyVariables>
+            <vertx.logger-delegate-factory-class-name>io.vertx.core.logging.SLF4JLogDelegateFactory</vertx.logger-delegate-factory-class-name>
+          </systemPropertyVariables>
         </configuration>
       </plugin>
 
@@ -454,10 +486,6 @@
                   <port>${test.harvester.port}:${test.harvester.port}</port>
                 </ports>
                 <env>
-                  <AWS_ACCESS_KEY_ID>test</AWS_ACCESS_KEY_ID> <!-- access key and secret key must be set (to anything) -->
-                  <AWS_DEFAULT_REGION>us-east-1</AWS_DEFAULT_REGION>
-                  <AWS_ENDPOINT_URL>http://localhost:${test.s3.port}</AWS_ENDPOINT_URL>
-                  <AWS_SECRET_ACCESS_KEY>test</AWS_SECRET_ACCESS_KEY>
                   <HTTP_PORT>${test.harvester.port}</HTTP_PORT>
                 </env>
                 <dependsOn>
@@ -534,7 +562,7 @@
                 </links>
                 <wait>
                   <exit>0</exit>
-                  <time>15000</time>
+                  <time>30000</time>
                 </wait>
               </run>
             </s3-initializer>
@@ -559,7 +587,7 @@
                     <method>GET</method>
                     <status>200</status>
                   </http>
-                  <time>15000</time>
+                  <time>30000</time>
                 </wait>
               </run>
             </provider>
@@ -583,7 +611,7 @@
                 </links>
                 <wait>
                   <exit>0</exit>
-                  <time>15000</time>
+                  <time>30000</time>
                 </wait>
               </run>
             </provider-initializer>

--- a/pom.xml
+++ b/pom.xml
@@ -214,7 +214,7 @@
           <include>logback-test.xml</include>
           <include>db/prldb.sql</include>
           <include>images/</include>
-          <include>provider/</include>
+          <include>provider/**</include>
         </includes>
       </testResource>
     </testResources>

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
     <deploy.plugin.version>2.8.2</deploy.plugin.version>
     <jar.plugin.version>3.2.2</jar.plugin.version>
     <scm.plugin.version>1.13.0</scm.plugin.version>
+    <patch.plugin.version>1.2</patch.plugin.version>
 
     <!-- Test dependency versions -->
     <junit.version>5.9.0</junit.version>
@@ -423,6 +424,29 @@
               <scmVersionType>tag</scmVersionType>
               <skipCheckoutIfExists>true</skipCheckoutIfExists>
             </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <!-- The jOAI container is missing a required dependency on some machines -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-patch-plugin</artifactId>
+        <version>${patch.plugin.version}</version>
+        <configuration>
+          <patchDirectory>src/test/resources/</patchDirectory>
+          <patches>
+            <patch>joai-Dockerfile.patch</patch>
+          </patches>
+          <originalFile>${project.build.directory}/checkout/joai/Dockerfile</originalFile>
+        </configuration>
+        <executions>
+          <execution>
+            <id>patch-joai-Dockerfile</id>
+            <phase>generate-test-resources</phase>
+            <goals>
+              <goal>apply</goal>
+            </goals>
           </execution>
         </executions>
       </plugin>

--- a/src/main/java/edu/ucla/library/prl/harvester/Config.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/Config.java
@@ -57,6 +57,18 @@ public final class Config {
     public static final String DB_RECONNECT_INTERVAL = "DB_RECONNECT_INTERVAL";
 
     /**
+     * The ENV property for the Solr core URL.
+     */
+    public static final String SOLR_CORE_URL = "SOLR_CORE_URL";
+
+    // Below are additional configuration options required by test classes (i.e., not the application).
+
+    /**
+     * The test configuration property for the data provider's base URL.
+     */
+    public static final String TEST_PROVIDER_BASE_URL = "TEST_PROVIDER_BASE_URL";
+
+    /**
      * Constant classes should have private constructors.
      */
     private Config() {

--- a/src/main/java/edu/ucla/library/prl/harvester/Constants.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/Constants.java
@@ -9,7 +9,7 @@ public final class Constants {
     /**
      * The metadata prefix for OAI-PMH harvesting (currently we only support Dublin Core).
      */
-    static final String OAI_DC = "oai_dc";
+    public static final String OAI_DC = "oai_dc";
 
     /**
      * Constant classes should have private constructors.

--- a/src/main/java/edu/ucla/library/prl/harvester/InvalidJobResultJsonException.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/InvalidJobResultJsonException.java
@@ -1,0 +1,45 @@
+
+package edu.ucla.library.prl.harvester;
+
+import info.freelibrary.util.I18nRuntimeException;
+
+/**
+ * Represents an error in the JSON representation of a {@link JobResult}.
+ */
+public class InvalidJobResultJsonException extends I18nRuntimeException {
+
+    /**
+     * The <code>serialVersionUID</code> for this class.
+     */
+    private static final long serialVersionUID = 2121139592421503754L;
+
+    /**
+     * Instantiates an exception.
+     *
+     * @param aMessageKey The message key
+     */
+    public InvalidJobResultJsonException(final String aMessageKey) {
+        super(MessageCodes.BUNDLE, aMessageKey);
+    }
+
+    /**
+     * Instantiates an exception.
+     *
+     * @param aMessageKey The message key
+     * @param aVarArgs The message details
+     */
+    public InvalidJobResultJsonException(final String aMessageKey, final Object... aVarArgs) {
+        super(MessageCodes.BUNDLE, aMessageKey, aVarArgs);
+    }
+
+    /**
+     * Instantiates an exception.
+     *
+     * @param aCause The cause
+     * @param aMessageKey The message key
+     * @param aVarArgs The message details
+     */
+    public InvalidJobResultJsonException(final Throwable aCause, final String aMessageKey, final Object... aVarArgs) {
+        super(aCause, MessageCodes.BUNDLE, aMessageKey, aVarArgs);
+    }
+}

--- a/src/main/java/edu/ucla/library/prl/harvester/JobResult.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/JobResult.java
@@ -1,0 +1,105 @@
+
+package edu.ucla.library.prl.harvester;
+
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeParseException;
+import java.util.Objects;
+
+import io.vertx.codegen.annotations.DataObject;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Represents the result of an OAI-PMH harvest job.
+ */
+@DataObject
+public class JobResult {
+
+    /**
+     * The JSON key for the start time.
+     */
+    static final String START_TIME = "startTime";
+
+    /**
+     * The JSON key for the record count.
+     */
+    static final String RECORD_COUNT = "recordCount";
+
+    /**
+     * The time when the job was started.
+     */
+    private final ZonedDateTime myStartTime;
+
+    /**
+     * The number of records harvested.
+     */
+    private final int myRecordCount;
+
+    /**
+     * Instantiates a job result.
+     *
+     * @param aStartTime The time when the job was started
+     * @param aRecordCount The number of records harvested
+     */
+    public JobResult(final ZonedDateTime aStartTime, final int aRecordCount) {
+        myStartTime = Objects.requireNonNull(aStartTime);
+        myRecordCount = aRecordCount;
+    }
+
+    /**
+     * Instantiates a job result from its JSON representation.
+     * <p>
+     * <b>This constructor is meant to be used only by generated service proxy code!</b>
+     * {@link #JobResult(ZonedDateTime, int)} should be used everywhere else.
+     *
+     * @param aJsonObject A job result represented as JSON
+     * @throws InvalidJobResultJsonException If the JSON representation is invalid
+     */
+    public JobResult(final JsonObject aJsonObject) {
+        Objects.requireNonNull(aJsonObject);
+
+        final String startTime = aJsonObject.getString(START_TIME);
+        final Integer recordCount = aJsonObject.getInteger(RECORD_COUNT);
+
+        if (startTime != null) {
+            try {
+                myStartTime = ZonedDateTime.parse(startTime);
+            } catch (final DateTimeParseException details) {
+                throw new InvalidJobResultJsonException(details, MessageCodes.PRL_004, START_TIME,
+                        details.getMessage());
+            }
+        } else {
+            throw new InvalidJobResultJsonException(MessageCodes.PRL_002, START_TIME);
+        }
+
+        if (recordCount != null) {
+            if (recordCount >= 0) {
+                myRecordCount = recordCount.intValue();
+            } else {
+                throw new InvalidJobResultJsonException(MessageCodes.PRL_004, RECORD_COUNT, recordCount);
+            }
+        } else {
+            throw new InvalidJobResultJsonException(MessageCodes.PRL_002, RECORD_COUNT);
+        }
+    }
+
+    /**
+     * @return The JSON representation of the job result
+     */
+    public JsonObject toJson() {
+        return new JsonObject().put(START_TIME, getStartTime().toString()).put(RECORD_COUNT, getRecordCount());
+    }
+
+    /**
+     * @return The start time
+     */
+    public ZonedDateTime getStartTime() {
+        return myStartTime;
+    }
+
+    /**
+     * @return The record count
+     */
+    public int getRecordCount() {
+        return myRecordCount;
+    }
+}

--- a/src/main/java/edu/ucla/library/prl/harvester/services/HarvestService.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/services/HarvestService.java
@@ -2,6 +2,7 @@
 package edu.ucla.library.prl.harvester.services;
 
 import edu.ucla.library.prl.harvester.Job;
+import edu.ucla.library.prl.harvester.JobResult;
 
 import io.vertx.codegen.annotations.ProxyClose;
 import io.vertx.codegen.annotations.ProxyGen;
@@ -31,9 +32,7 @@ public interface HarvestService {
      * @return The service instance
      */
     static HarvestService create(final Vertx aVertx, final JsonObject aConfig) {
-        // FIXME: this is incorrect, instantiate an implementing class instead
-        // TODO: depending on implementation, consider returning Future<HarvestService> instead
-        return createProxy(aVertx);
+        return new HarvestServiceImpl(aVertx, aConfig);
     }
 
     /**
@@ -52,7 +51,7 @@ public interface HarvestService {
      * @param aJob The harvest job to run
      * @return A Future that succeeds if the harvest job succeeded
      */
-    Future<Object> run(Job aJob); // FIXME: use more appropriate return type
+    Future<JobResult> run(Job aJob);
 
     /**
      * Closes the underlying resources used by this service.

--- a/src/main/java/edu/ucla/library/prl/harvester/services/HarvestServiceImpl.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/services/HarvestServiceImpl.java
@@ -1,31 +1,286 @@
 
 package edu.ucla.library.prl.harvester.services;
 
-import edu.ucla.library.prl.harvester.Job;
+import java.net.URL;
+import java.time.ZonedDateTime;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletionStage;
+import java.util.stream.Collectors;
 
+import org.apache.solr.client.solrj.response.UpdateResponse;
+import org.apache.solr.common.SolrInputDocument;
+
+import org.dspace.xoai.model.oaipmh.Record;
+import org.dspace.xoai.model.oaipmh.Set;
+import org.dspace.xoai.serviceprovider.ServiceProvider;
+import org.dspace.xoai.serviceprovider.client.HttpOAIClient;
+import org.dspace.xoai.serviceprovider.exceptions.BadArgumentException;
+import org.dspace.xoai.serviceprovider.exceptions.NoSetHierarchyException;
+import org.dspace.xoai.serviceprovider.model.Context;
+import org.dspace.xoai.serviceprovider.model.Context.KnownTransformer;
+import org.dspace.xoai.serviceprovider.parameters.ListRecordsParameters;
+
+import com.google.common.collect.ImmutableList;
+
+import edu.ucla.library.prl.harvester.Config;
+import edu.ucla.library.prl.harvester.Constants;
+import edu.ucla.library.prl.harvester.Job;
+import edu.ucla.library.prl.harvester.JobResult;
+import edu.ucla.library.prl.harvester.MessageCodes;
+
+import info.freelibrary.util.Logger;
+import info.freelibrary.util.LoggerFactory;
+
+import io.ino.solrs.JavaAsyncSolrClient;
+
+import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.serviceproxy.ServiceException;
 
 /**
  * The implementation of {@link HarvestService}.
  */
+@SuppressWarnings("PMD.ExcessiveImports")
 public class HarvestServiceImpl implements HarvestService {
 
-    @SuppressWarnings("PMD.UnusedFormalParameter") // FIXME: temp until constructor defined
-    HarvestServiceImpl(final Vertx aVertx, final JsonObject aConfig) {
-        // TODO: code class constructor
+    /**
+     * A logger for the service.
+     */
+    private static final Logger LOGGER = LoggerFactory.getLogger(HarvestServiceImpl.class, MessageCodes.BUNDLE);
+
+    /**
+     * A Vert.x instance.
+     */
+    private final Vertx myVertx;
+
+    /**
+     * An HTTP client for verifying thumbnail image URLs.
+     */
+    private final WebClient myWebClient;
+
+    /**
+     * A client for sending transformed metadata records to Solr.
+     */
+    private final JavaAsyncSolrClient mySolrClient;
+
+    /**
+     * A proxy to the harvest schedule store service, for retrieving institution names.
+     */
+    private final HarvestScheduleStoreService myHarvestScheduleStoreService;
+
+    /**
+     * Creates an instance of the service.
+     *
+     * @param aVertx A Vert.x instance
+     * @param aConfig A configuration
+     */
+    protected HarvestServiceImpl(final Vertx aVertx, final JsonObject aConfig) {
+        myVertx = aVertx;
+        myWebClient = WebClient.create(aVertx);
+        mySolrClient = JavaAsyncSolrClient.create(aConfig.getString(Config.SOLR_CORE_URL));
+        myHarvestScheduleStoreService = HarvestScheduleStoreService.createProxy(aVertx);
     }
 
     @Override
-    public Future<Object> run(final Job aJob) {
-        // TODO implement method
-        return Future.succeededFuture(null);
+    public Future<JobResult> run(final Job aJob) {
+        final URL baseURL = aJob.getRepositoryBaseURL();
+
+        return listSetsAsync(baseURL).compose(sets -> {
+            final Map<String, String> setNameLookup =
+                    sets.stream().collect(Collectors.toMap(Set::getSpec, Set::getName));
+            final int institutionID = aJob.getInstitutionID();
+
+            return myHarvestScheduleStoreService.getInstitution(institutionID).compose(institution -> {
+                final String institutionName = institution.getName();
+
+                final List<String> targetSets;
+                final ZonedDateTime startTime;
+                final Future<List<Record>> harvest;
+
+                if (aJob.getSets().isPresent() && !aJob.getSets().get().isEmpty()) {
+                    // Harvest only the specified sets
+                    targetSets = aJob.getSets().get();
+                } else {
+                    // Harvest all sets in the repository
+                    targetSets = new LinkedList<>(setNameLookup.keySet());
+                }
+
+                startTime = ZonedDateTime.now();
+
+                LOGGER.debug(MessageCodes.PRL_008, aJob.toJson(), startTime);
+
+                // TODO: de-duplicate list of records (based on identifier; some sets may contain the same record)
+                harvest = listRecords(baseURL, targetSets, aJob.getMetadataPrefix(), aJob.getLastSuccessfulRun());
+
+                return harvest.compose(records -> {
+                    final Future<Void> solrResult;
+
+                    if (!records.isEmpty()) {
+                        solrResult = updateSolr(records, institutionName, baseURL, setNameLookup).mapEmpty();
+                    } else {
+                        solrResult = Future.succeededFuture();
+                    }
+
+                    return solrResult.map(unused -> new JobResult(startTime, records.size()));
+                });
+            });
+        }).recover(details -> {
+            // TODO: consider retrying on failure
+            return Future.failedFuture(new ServiceException(hashCode(), details.toString()));
+        });
+    }
+
+    /**
+     * Performs a listRecords operation.
+     *
+     * @param aBaseURL The OAI-PMH base URL
+     * @param aSets The non-empty list of sets to harvest
+     * @param aMetadataPrefix The OAI-PMH metadata prefix
+     * @param aFrom The optional timestamp of the last successful run
+     * @return The list of OAI-PMH records
+     */
+    private Future<List<Record>> listRecords(final URL aBaseURL, final List<String> aSets, final String aMetadataPrefix,
+            final Optional<ZonedDateTime> aFrom) {
+        @SuppressWarnings("rawtypes")
+        final List<Future> selectiveHarvests = new LinkedList<>();
+
+        for (final String setSpec : aSets) {
+            final ListRecordsParameters params =
+                    ListRecordsParameters.request().withMetadataPrefix(aMetadataPrefix).withSetSpec(setSpec);
+
+            aFrom.ifPresent(from -> params.withFrom(Date.from(from.toInstant())));
+
+            selectiveHarvests.add(listRecordsAsync(aBaseURL, params));
+        }
+
+        return CompositeFuture.all(selectiveHarvests).map(result -> {
+            final List<ImmutableList<Record>> results = result.<ImmutableList<Record>>list();
+
+            // Flatten the list of lists
+            return results.parallelStream().flatMap(List::parallelStream).collect(Collectors.toUnmodifiableList());
+        });
+    }
+
+    /**
+     * Performs a Solr update.
+     *
+     * @param aRecords A list of OAI-PMH records
+     * @param anInstitutionName The name of the institution
+     * @param aBaseURL The OAI-PMH base URL
+     * @param aSetNameLookup A lookup table that maps setSpec to setName
+     * @return The result of performing the Solr update
+     */
+    private Future<UpdateResponse> updateSolr(final List<Record> aRecords, final String anInstitutionName,
+            final URL aBaseURL, final Map<String, String> aSetNameLookup) {
+        @SuppressWarnings("rawtypes")
+        final List<Future> docResults = new LinkedList<>();
+
+        // Transform each OAI-PMH XML record into a Solr document
+        for (final Record record : aRecords) {
+            final Future<SolrInputDocument> docResult = HarvestServiceUtils.getSolrDocument(record, anInstitutionName,
+                    aBaseURL, aSetNameLookup, myWebClient);
+
+            docResults.add(docResult);
+        }
+
+        return CompositeFuture.all(docResults).compose(result -> {
+            final CompletionStage<UpdateResponse> updateResponse = mySolrClient //
+                    .addDocs(result.<SolrInputDocument>list()) //
+                    .thenCompose(res -> mySolrClient.commit());
+
+            return Future.fromCompletionStage(updateResponse);
+        });
+    }
+
+    /**
+     * Provides an asynchronous API for the synchronous XOAI listSets API.
+     *
+     * @param aBaseURL An OAI-PMH base URL
+     * @return A Future that resolves to a list of OAI-PMH sets
+     */
+    private Future<ImmutableList<Set>> listSetsAsync(final URL aBaseURL) {
+        final Promise<ImmutableList<Set>> promise = Promise.promise();
+
+        myVertx.<ImmutableList<Set>>executeBlocking(execution -> {
+            try {
+                final Iterator<Set> synchronousResult = getNewOaipmhClient(aBaseURL).listSets();
+
+                execution.complete(ImmutableList.copyOf(synchronousResult));
+            } catch (final NoSetHierarchyException details) {
+                execution.fail(details.getCause());
+            }
+        }, false, execution -> {
+            if (execution.succeeded()) {
+                promise.complete(execution.result());
+            } else {
+                promise.fail(execution.cause());
+            }
+        });
+
+        return promise.future();
+    }
+
+    /**
+     * Provides an asynchronous API for the synchronous XOAI listRecords API.
+     *
+     * @param aBaseURL An OAI-PMH base URL
+     * @param aParams The OAI-PMH request parameters
+     * @return A Future that resolves to a list of OAI-PMH records
+     */
+    private Future<ImmutableList<Record>> listRecordsAsync(final URL aBaseURL, final ListRecordsParameters aParams) {
+        final Promise<ImmutableList<Record>> promise = Promise.promise();
+
+        myVertx.<ImmutableList<Record>>executeBlocking(execution -> {
+            try {
+                final Iterator<Record> synchronousResult = getNewOaipmhClient(aBaseURL).listRecords(aParams);
+
+                execution.complete(ImmutableList.copyOf(synchronousResult));
+            } catch (final BadArgumentException details) {
+                execution.fail(details.getCause());
+            }
+        }, false, execution -> {
+            if (execution.succeeded()) {
+                promise.complete(execution.result());
+            } else {
+                promise.fail(execution.cause());
+            }
+        });
+
+        return promise.future();
+    }
+
+    /**
+     * Gets a new OAI-PMH client.
+     * <p>
+     * Reusing a {@link ServiceProvider} instance causes IllegalStateException due to mishandling of the underlying
+     * input stream, so we must instantiate a new one for every OAI-PMH request.
+     * <p>
+     * Related: <a href="https://github.com/DSpace/xoai/issues/55">DSpace/xoai/issues/55</a>
+     *
+     * @param aBaseURL An OAI-PMH base URL
+     * @return A new OAI-PMH client instance
+     */
+    private static ServiceProvider getNewOaipmhClient(final URL aBaseURL) {
+        final Context context = new Context().withOAIClient(new HttpOAIClient(aBaseURL.toString()))
+                .withMetadataTransformer(Constants.OAI_DC, KnownTransformer.OAI_DC);
+
+        return new ServiceProvider(context);
     }
 
     @Override
     public Future<Void> close() {
-        // TODO implement method
-        return Future.succeededFuture(null);
+        myWebClient.close();
+        mySolrClient.shutdown();
+
+        return myHarvestScheduleStoreService.close();
     }
 }

--- a/src/main/java/edu/ucla/library/prl/harvester/services/HarvestServiceUtils.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/services/HarvestServiceUtils.java
@@ -1,0 +1,322 @@
+
+package edu.ucla.library.prl.harvester.services;
+
+import static info.freelibrary.util.Constants.COLON;
+import static info.freelibrary.util.Constants.EMPTY;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.Map.Entry;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.apache.solr.common.SolrInputDocument;
+
+import org.dspace.xoai.model.oaipmh.Record;
+import org.dspace.xoai.model.xoai.Element;
+
+import io.vertx.core.CompositeFuture;
+import io.vertx.core.Future;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.ext.web.client.HttpRequest;
+import io.vertx.ext.web.client.WebClient;
+
+/**
+ * A collection of utility methods for processing OAI-PMH records.
+ */
+final class HarvestServiceUtils {
+
+    /**
+     * dc:date
+     */
+    private static final String DC_DATE = "date";
+
+    /**
+     * dc:description
+     */
+    private static final String DC_DESCRIPTION = "description";
+
+    /**
+     * dc:identifier
+     */
+    private static final String DC_IDENTIFIER = "identifier";
+
+    /**
+     * dc:title
+     */
+    private static final String DC_TITLE = "title";
+
+    /**
+     * The list of Dublin Core elements.
+     */
+    private static final Set<String> DC_ELEMENTS =
+            Set.of(DC_TITLE, "creator", "subject", DC_DESCRIPTION, "publisher", "contributor", DC_DATE, "type",
+                    "format", DC_IDENTIFIER, "source", "language", "relation", "coverage", "rights");
+
+    /**
+     * The list of Dublin Core elements that we expect may contain a thumbnail URL.
+     */
+    private static final Set<String> THUMBNAIL_URL_FIELDS =
+            Set.of(DC_DESCRIPTION, DC_IDENTIFIER, "identifier.thumbnail");
+
+    /**
+     * The pattern for Dublin Core elements that we expect may contain an item URL.
+     */
+    private static final Pattern ITEM_URL_FIELD_PATTERN = Pattern.compile("identifier(?:\\..+)?");
+
+    /**
+     * Private constructor for utility class to prohibit instantiation.
+     */
+    private HarvestServiceUtils() {
+    }
+
+    /**
+     * Transforms an OAI-PMH record into a PRL Solr document.
+     *
+     * @param aRecord A Dublin Core record
+     * @param anInstitutionName The name of the associated institution
+     * @param aBaseURL An OAI-PMH repository base URL
+     * @param aSetNameLookup A lookup table that maps setSpec to setName
+     * @param aWebClient An HTTP client for checking thumbnail URLs
+     * @return The record transformed to a Solr document
+     */
+    @SuppressWarnings({ "PMD.AvoidLiteralsInIfCondition", "PMD.CognitiveComplexity", "PMD.EmptyCatchBlock",
+        "PMD.ExcessiveMethodLength", "PMD.NPathComplexity" })
+    static Future<SolrInputDocument> getSolrDocument(final Record aRecord, final String anInstitutionName,
+            final URL aBaseURL, final Map<String, String> aSetNameLookup, final WebClient aWebClient) {
+        final SolrInputDocument doc = new SolrInputDocument();
+        final Map<String, List<String>> dcElementsMap = new HashMap<>();
+        final List<URL> possibleThumbnailUrls = new LinkedList<>();
+        final List<String> setNames = new LinkedList<>();
+
+        final String recordIdentifier = aRecord.getHeader().getIdentifier();
+        final List<String> setSpecs = aRecord.getHeader().getSetSpecs();
+
+        // Get an iterator over the elements inside the top-level "dc" element
+        final List<Element> allElements = aRecord.getMetadata().getValue().getElements().get(0).getElements();
+
+        doc.addField("id", recordIdentifier);
+        doc.addField("institutionName", anInstitutionName);
+
+        for (final String setSpec : setSpecs) {
+            setNames.add(aSetNameLookup.get(setSpec));
+        }
+
+        doc.addField("collectionName", setNames);
+
+        for (final Element element : allElements) {
+            final String name = element.getName();
+            // Each element contains just a text node
+            final String value = element.getFields().get(0).getValue();
+
+            if (THUMBNAIL_URL_FIELDS.contains(name)) {
+                try {
+                    possibleThumbnailUrls.add(new URL(value));
+                } catch (final MalformedURLException details) {
+                    // No worries, it's just not a URL
+                }
+            }
+        }
+
+        return findImageURL(possibleThumbnailUrls, aWebClient).map(thumbnailURL -> {
+            final List<URL> possibleItemUrls = new LinkedList<>();
+            final List<String> stringifiedItemUrls;
+
+            if (thumbnailURL.isPresent()) {
+                doc.addField("thumbnail_url", thumbnailURL.get().toString());
+            }
+
+            for (final Element element : allElements) {
+                final String name = element.getName();
+                final String value = element.getFields().get(0).getValue();
+
+                // Skip over the thumbnail URL
+                if (ITEM_URL_FIELD_PATTERN.matcher(name).matches() && !value.equals(thumbnailURL.get().toString())) {
+                    try {
+                        possibleItemUrls.add(new URL(value));
+                    } catch (final MalformedURLException details) {
+                        // No worries, it's just not a URL
+                    }
+                }
+            }
+
+            possibleItemUrls.sort((url1, url2) -> {
+                // The higher-scoring URL should be placed first
+                // If url1 scores higher than url2, put url1 first (negative return value); otherwise, url2 first
+                // (positive)
+                return scoreURL(url2, recordIdentifier, aBaseURL) - scoreURL(url1, recordIdentifier, aBaseURL);
+            });
+
+            // SolrInputDocument wants strings
+            stringifiedItemUrls = unwrapUrls(possibleItemUrls);
+
+            if (!stringifiedItemUrls.isEmpty()) {
+                // The URL with the highest score is probably the canonical item URL
+                doc.addField("external_link", stringifiedItemUrls.get(0).toString());
+            }
+            if (stringifiedItemUrls.size() > 1) {
+                // All other URLs go in this field
+                doc.addField("alternate_external_link", stringifiedItemUrls.subList(1, stringifiedItemUrls.size()));
+            }
+
+            for (final Element element : allElements) {
+                final String name = element.getName();
+                // Each element contains just a text node
+                final String value = element.getFields().get(0).getValue();
+
+                // Skip over the item URLs and thumbnail URL
+                if (DC_ELEMENTS.contains(name) && !value.equals(thumbnailURL.get().toString()) &&
+                        !stringifiedItemUrls.contains(value)) {
+                    if (dcElementsMap.containsKey(name)) {
+                        dcElementsMap.get(name).add(value);
+                    } else {
+                        // First instance of element
+                        final List<String> elements = new LinkedList<>();
+
+                        elements.add(value);
+                        dcElementsMap.put(name, elements);
+                    }
+                }
+            }
+
+            // Now that we know which values are item URLs and thumbnail URLs, we can avoid them
+            for (final Entry<String, List<String>> entry : dcElementsMap.entrySet()) {
+                doc.addField(entry.getKey() + "_keyword", entry.getValue());
+
+                switch (entry.getKey()) {
+                    case DC_DATE:
+                        final List<Integer> decades = getDecadesAscending(entry.getValue());
+
+                        if (!decades.isEmpty()) {
+                            doc.addField("decade", decades);
+                            doc.addField("sort_decade", decades.get(0));
+                        }
+                        break;
+                    case DC_TITLE:
+                        doc.addField("first_title", entry.getValue().get(0));
+                        break;
+                    default:
+                        break;
+                }
+            }
+
+            return doc;
+        });
+    }
+
+    /**
+     * @param aUrlList A list of URLs
+     * @return A list of the URLs in string form
+     */
+    private static List<String> unwrapUrls(final List<URL> aUrlList) {
+        final List<String> strings = new LinkedList<>();
+
+        for (final URL url : aUrlList) {
+            strings.add(url.toString());
+        }
+
+        return strings;
+    }
+
+    /**
+     * @param aDates A list of strings contained in a record's dc:date fields
+     * @return The list of decades to which all the dates in the record belong, sorted in ascending order
+     */
+    static List<Integer> getDecadesAscending(final List<String> aDates) {
+        // FIXME: this implementation is incorrect
+        return List.of(2000 + "FIXME".length());
+    }
+
+    /**
+     * Assigns a score to a URL based on how likely it is to be a record's canonical item URL, according to a simple
+     * heuristic.
+     * <p>
+     * A URL is considered more likely to be the canonical item URL if:
+     * <ul>
+     * <li>it contains the record identifier in its path part</li>
+     * <li>it has the same domain part as the OAI-PMH base URL</li>
+     * </ul>
+     *
+     * @param aURL The URL to score
+     * @param aRecordIdentifier The identifier of the record in which the URL was found
+     * @param aRepositoryURL The base URL from which the record was harvested
+     * @return The score
+     */
+    static int scoreURL(final URL aURL, final String aRecordIdentifier, final URL aRepositoryURL) {
+        int score = 0;
+        final String importantIdentifierPart;
+
+        if (isOaiIdentifier(aRecordIdentifier)) {
+            importantIdentifierPart = aRecordIdentifier.split(COLON, 3)[2];
+        } else {
+            importantIdentifierPart = aRecordIdentifier;
+        }
+
+        if (aURL.getPath().contains(URLEncoder.encode(importantIdentifierPart, StandardCharsets.UTF_8))) {
+            score++;
+        }
+
+        if (aURL.getHost().equals(aRepositoryURL.getHost())) {
+            score++;
+        }
+
+        return score;
+    }
+
+    /**
+     * @param aRecordIdentifier A record identifier
+     * @return Whether or not the identifier follows the OAI identifier guidelines
+     * @see <a href="http://www.openarchives.org/OAI/2.0/guidelines-oai-identifier.htm">identifier guidelines</a>
+     */
+    static boolean isOaiIdentifier(final String aRecordIdentifier) {
+        final String[] components = aRecordIdentifier.split(COLON, 3);
+
+        return components.length == 3 && "oai".equals(components[0]) && !components[1].equals(EMPTY) &&
+                !components[2].equals(EMPTY);
+    }
+
+    /**
+     * Finds an image URL, if any, out of the provided list of URLs.
+     *
+     * @param aPossibleImageUrls The list of URLs to try
+     * @param aWebClient An HTTP client for checking URLs
+     * @return The optional image URL
+     */
+    static Future<Optional<URL>> findImageURL(final List<URL> aPossibleImageUrls, final WebClient aWebClient) {
+        @SuppressWarnings("rawtypes")
+        final List<Future> contentTypeChecks = aPossibleImageUrls.stream().map(url -> {
+            final HttpRequest<?> headRequest = aWebClient.headAbs(url.toString());
+
+            return headRequest.send().compose(response -> {
+                final String contentType = response.getHeader(HttpHeaders.CONTENT_TYPE.toString());
+
+                if (contentType.contains("image")) {
+                    return Future.succeededFuture(url);
+                } else {
+                    return Future.failedFuture("not an image URL");
+                }
+            }, Future::failedFuture);
+        }).collect(Collectors.toUnmodifiableList());
+
+        return CompositeFuture.any(contentTypeChecks).map(result -> {
+            // Scan the list for the first image URL
+            for (final URL url : result.<URL>list()) {
+                if (url != null) {
+                    return Optional.of(url);
+                }
+            }
+            return Optional.<URL>empty(); // By the semantics of CompositeFuture, this will never be reached
+        }).recover(details -> {
+            // It's okay if there is no thumbnail
+            return Future.succeededFuture(Optional.<URL>empty());
+        });
+    }
+}

--- a/src/main/resources/prl-harvester_messages.xml
+++ b/src/main/resources/prl-harvester_messages.xml
@@ -13,5 +13,6 @@
   <entry key="PRL_005">User '{}' connecting to test database at port '{}' with password: {}</entry>
   <entry key="PRL_006">Error during institution insert: {}</entry>
   <entry key="PRL_007">No institution found for ID: {}</entry>
+  <entry key="PRL_008">Starting job {} at {}</entry>
 
 </properties>

--- a/src/test/docker/s3-initializer/docker-entrypoint.sh
+++ b/src/test/docker/s3-initializer/docker-entrypoint.sh
@@ -16,10 +16,9 @@ then
     export AWS_ENDPOINT_URL="http://${S3_PORT_4566_TCP_ADDR}:${S3_PORT_4566_TCP_PORT}"
 fi
 
-# Create S3 buckets
+# Create S3 bucket
 
 aws s3 mb --endpoint-url ${AWS_ENDPOINT_URL} s3://thumbnails-source
-aws s3 mb --endpoint-url ${AWS_ENDPOINT_URL} s3://thumbnails-target
 
 # Uploads a file to S3
 

--- a/src/test/java/edu/ucla/library/prl/harvester/JobResultTest.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/JobResultTest.java
@@ -1,0 +1,111 @@
+
+package edu.ucla.library.prl.harvester;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.time.LocalDate;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeParseException;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import info.freelibrary.util.Logger;
+import info.freelibrary.util.LoggerFactory;
+
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Tests {@link JobResult}.
+ */
+@Execution(ExecutionMode.CONCURRENT)
+public class JobResultTest {
+
+    /**
+     * The logger.
+     */
+    private static final Logger LOGGER = LoggerFactory.getLogger(JobResultTest.class, MessageCodes.BUNDLE);
+
+    /**
+     * Tests that a {@link JobResultTest} can be instantiated from a {@link JsonObject} and serialized back to one.
+     */
+    @Test
+    void testJobResultSerDe() {
+        final ZonedDateTime exampleStartTime = ZonedDateTime.parse("2000-01-01T00:00Z");
+        final int exampleRecordCount = 10;
+
+        final JobResult jobResult = new JobResult(exampleStartTime, exampleRecordCount);
+        final JsonObject json = new JsonObject() //
+                .put(JobResult.START_TIME, exampleStartTime.toString()) //
+                .put(JobResult.RECORD_COUNT, exampleRecordCount);
+        final JobResult jobResultFromJson = new JobResult(json);
+
+        // If the JSON representations are equal, then serialization works
+        assertEquals(json, jobResult.toJson());
+        assertEquals(jobResult.toJson(), jobResultFromJson.toJson());
+
+        // If the objects are equal, then deserialization works
+        assertEquals(jobResult.getStartTime(), jobResultFromJson.getStartTime());
+        assertEquals(jobResult.getRecordCount(), jobResultFromJson.getRecordCount());
+    }
+
+    /**
+     * Tests that a {@link JobResult} cannot be instantiated from an invalid JSON representation.
+     *
+     * @param aStartTime The time when the job was started
+     * @param aRecordCount The number of records harvested for the job
+     * @param anErrorClass The class of error that we expect instantiation with the above arguments to throw
+     */
+    @ParameterizedTest
+    @MethodSource
+    void testJobResultInvalidJsonRepresentation(final String aStartTime, final Integer aRecordCount,
+            final Class<Exception> anErrorClass) {
+        final JsonObject json = new JsonObject() //
+                .put(JobResult.START_TIME, aStartTime) //
+                .put(JobResult.RECORD_COUNT, aRecordCount);
+        final Exception error = assertThrows(InvalidJobResultJsonException.class, () -> new JobResult(json));
+
+        if (error.getCause() != null) {
+            assertEquals(anErrorClass, error.getCause().getClass());
+        }
+
+        LOGGER.debug(LOGGER.getMessage(MessageCodes.PRL_000, error));
+    }
+
+    /**
+     * @return The arguments for the corresponding {@link ParameterizedTest}
+     * @throws DateTimeParseException
+     */
+    static Stream<Arguments> testJobResultInvalidJsonRepresentation() throws DateTimeParseException {
+        final String validTimestamp = ZonedDateTime.parse("2010-01-01T00:00Z").toString();
+        final String invalidTimestamp = LocalDate.of(2020, 1, 1).toString(); // Missing time component
+
+        return Stream.of( //
+                Arguments.of(null, 10, null), //
+                Arguments.of(invalidTimestamp, 50, DateTimeParseException.class), //
+                Arguments.of(validTimestamp, null, null), //
+                Arguments.of(validTimestamp, -1, null));
+    }
+
+    /**
+     * Tests that the more strongly-typed constructor can't be called with certain arguments as null.
+     */
+    @Test
+    void testJobResultNullArguments() {
+        assertThrows(NullPointerException.class, () -> new JobResult(null, 10));
+    }
+
+    /**
+     * Tests that passing a null {@link JsonObject} throws a {@link NullPointerException}.
+     */
+    @Test
+    void testJobResultNullJsonObject() {
+        assertThrows(NullPointerException.class, () -> new JobResult(null));
+    }
+}

--- a/src/test/java/edu/ucla/library/prl/harvester/services/HarvestServiceIT.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/services/HarvestServiceIT.java
@@ -126,7 +126,6 @@ public class HarvestServiceIT {
             final CompletionStage<QueryResponse> query;
             final NamedList<String> solrParams = new NamedList<>();
 
-            // Matches all documents
             solrParams.add("q", SOLR_SELECT_ALL);
 
             query = mySolrClient.query(solrParams.toSolrParams());

--- a/src/test/java/edu/ucla/library/prl/harvester/services/HarvestServiceIT.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/services/HarvestServiceIT.java
@@ -157,13 +157,13 @@ public class HarvestServiceIT {
         // These arguments reflect the directory structure of src/test/resources/provider
         return Stream.of( //
                 Arguments.of(new Job(1, baseURL, List.of(set1), schedule, null), 1), //
-                Arguments.of(new Job(2, baseURL, List.of(set2), schedule, null), 3), //
-                Arguments.of(new Job(3, baseURL, List.of(set1, set2), schedule, null), 4), //
-                Arguments.of(new Job(4, baseURL, List.of(), schedule, null), 4), //
-                Arguments.of(new Job(5, baseURL, List.of("undefined"), schedule, null), 0), //
-                Arguments.of(new Job(6, baseURL, List.of(set1, "nil"), schedule, null), 1), //
-                Arguments.of(new Job(7, baseURL, null, schedule, ZonedDateTime.now().minusHours(1)), 4), //
-                Arguments.of(new Job(8, baseURL, null, schedule, ZonedDateTime.now().plusHours(1)), 0));
+                Arguments.of(new Job(1, baseURL, List.of(set2), schedule, null), 3), //
+                Arguments.of(new Job(1, baseURL, List.of(set1, set2), schedule, null), 4), //
+                Arguments.of(new Job(1, baseURL, List.of(), schedule, null), 4), //
+                Arguments.of(new Job(1, baseURL, List.of("undefined"), schedule, null), 0), //
+                Arguments.of(new Job(1, baseURL, List.of(set1, "nil"), schedule, null), 1), //
+                Arguments.of(new Job(1, baseURL, null, schedule, ZonedDateTime.now().minusHours(1)), 4), //
+                Arguments.of(new Job(1, baseURL, null, schedule, ZonedDateTime.now().plusHours(1)), 0));
     }
 
     /**

--- a/src/test/java/edu/ucla/library/prl/harvester/services/HarvestServiceIT.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/services/HarvestServiceIT.java
@@ -1,0 +1,209 @@
+
+package edu.ucla.library.prl.harvester.services;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.text.ParseException;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.stream.Stream;
+
+import org.apache.solr.client.solrj.response.QueryResponse;
+import org.apache.solr.client.solrj.response.UpdateResponse;
+import org.apache.solr.common.util.NamedList;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import org.quartz.CronExpression;
+
+import edu.ucla.library.prl.harvester.Config;
+import edu.ucla.library.prl.harvester.Job;
+import edu.ucla.library.prl.harvester.MessageCodes;
+
+import info.freelibrary.util.Logger;
+import info.freelibrary.util.LoggerFactory;
+
+import io.ino.solrs.JavaAsyncSolrClient;
+
+import io.vertx.config.ConfigRetriever;
+import io.vertx.core.CompositeFuture;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.eventbus.MessageConsumer;
+import io.vertx.core.json.JsonObject;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import io.vertx.serviceproxy.ServiceBinder;
+
+/**
+ * Tests {@link HarvestService}.
+ */
+@ExtendWith(VertxExtension.class)
+@TestInstance(Lifecycle.PER_CLASS)
+public class HarvestServiceIT {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(HarvestServiceIT.class, MessageCodes.BUNDLE);
+
+    private static final String SOLR_SELECT_ALL = "*:*";
+
+    private MessageConsumer<JsonObject> myHarvestService;
+
+    private HarvestService myHarvestServiceProxy;
+
+    private JavaAsyncSolrClient mySolrClient;
+
+    private MessageConsumer<JsonObject> myHarvestScheduleStoreService;
+
+    private String myTestProviderBaseURL;
+
+    /**
+     * @param aVertx A Vert.x instance
+     * @param aContext A test context
+     */
+    @BeforeAll
+    public void setUp(final Vertx aVertx, final VertxTestContext aContext) {
+        ConfigRetriever.create(aVertx).getConfig().onSuccess(config -> {
+            final ServiceBinder binder = new ServiceBinder(aVertx);
+
+            myTestProviderBaseURL = config.getString(Config.TEST_PROVIDER_BASE_URL);
+            mySolrClient = JavaAsyncSolrClient.create(config.getString(Config.SOLR_CORE_URL));
+
+            myHarvestService = binder.setAddress(HarvestService.ADDRESS).register(HarvestService.class,
+                    HarvestService.create(aVertx, config));
+            myHarvestServiceProxy = HarvestService.createProxy(aVertx);
+            myHarvestScheduleStoreService = binder.setAddress(HarvestScheduleStoreService.ADDRESS)
+                    .register(HarvestScheduleStoreService.class, HarvestScheduleStoreService.create(aVertx, config));
+
+            aContext.completeNow();
+        }).onFailure(aContext::failNow);
+    }
+
+    /**
+     * @param aVertx A Vert.x instance
+     * @param aContext A test context
+     */
+    @BeforeEach
+    public void beforeEach(final Vertx aVertx, final VertxTestContext aContext) {
+        wipeSolr().onSuccess(unused -> aContext.completeNow()).onFailure(aContext::failNow);
+    }
+
+    /**
+     * Clears out the Solr index.
+     *
+     * @return A Future that succeeds if the Solr index was wiped successfully, and fails otherwise
+     */
+    private Future<Void> wipeSolr() {
+        final CompletionStage<UpdateResponse> wipeSolr =
+                mySolrClient.deleteByQuery(SOLR_SELECT_ALL).thenCompose(unused -> mySolrClient.commit());
+
+        return Future.fromCompletionStage(wipeSolr).mapEmpty();
+    }
+
+    /**
+     * Tests the harvesting of various jobs that should succeed.
+     *
+     * @param aJob A harvest job
+     * @param anExpectedRecordCount The expected number of records that would be harvested by the job
+     * @param aVertx A Vert.x instance
+     * @param aContext A test context
+     */
+    @ParameterizedTest
+    @MethodSource
+    public void testRun(final Job aJob, final int anExpectedRecordCount, final Vertx aVertx,
+            final VertxTestContext aContext) {
+        myHarvestServiceProxy.run(aJob).onSuccess(jobResult -> {
+            final CompletionStage<QueryResponse> query;
+            final NamedList<String> solrParams = new NamedList<>();
+
+            // Matches all documents
+            solrParams.add("q", SOLR_SELECT_ALL);
+
+            query = mySolrClient.query(solrParams.toSolrParams());
+
+            Future.fromCompletionStage(query).onSuccess(queryResponse -> {
+                LOGGER.debug(queryResponse.toString());
+
+                aContext.verify(() -> {
+                    // Check that the two counts agree
+                    assertEquals(anExpectedRecordCount, jobResult.getRecordCount());
+                    assertEquals(anExpectedRecordCount, queryResponse.getResults().size());
+                }).completeNow();
+            }).onFailure(aContext::failNow);
+        }).onFailure(aContext::failNow);
+    }
+
+    /**
+     * @return The arguments for the corresponding {@link ParameterizedTest}
+     * @throws MalformedURLException
+     * @throws ParseException
+     */
+    Stream<Arguments> testRun() throws MalformedURLException, ParseException {
+        // The schedule is irrelevant here, but we need something to instantiate Jobs with
+        final URL baseURL = new URL(myTestProviderBaseURL);
+        final String set1 = "set1";
+        final String set2 = "set2";
+        final CronExpression schedule = new CronExpression("* * * * * ?");
+
+        // These arguments reflect the directory structure of src/test/resources/provider
+        return Stream.of( //
+                Arguments.of(new Job(1, baseURL, List.of(set1), schedule, null), 1), //
+                Arguments.of(new Job(2, baseURL, List.of(set2), schedule, null), 3), //
+                Arguments.of(new Job(3, baseURL, List.of(set1, set2), schedule, null), 4), //
+                Arguments.of(new Job(4, baseURL, List.of(), schedule, null), 4), //
+                Arguments.of(new Job(5, baseURL, List.of("undefined"), schedule, null), 0), //
+                Arguments.of(new Job(6, baseURL, List.of(set1, "nil"), schedule, null), 1), //
+                Arguments.of(new Job(7, baseURL, null, schedule, ZonedDateTime.now().minusHours(1)), 4), //
+                Arguments.of(new Job(8, baseURL, null, schedule, ZonedDateTime.now().plusHours(1)), 0));
+    }
+
+    /**
+     * Tests that a harvest job fails if the base URL is not that of an OAI-PMH data provider.
+     *
+     * @param aVertx A Vert.x instance
+     * @param aContext A test context
+     * @throws ParseException
+     * @throws MalformedURLException
+     */
+    public void testRunInvalidbaseURL(final Vertx aVertx, final VertxTestContext aContext)
+            throws MalformedURLException, ParseException {
+        final Job job = new Job(1, new URL("http://example.com"), null, new CronExpression("0 0 * * * ?"), null);
+
+        myHarvestServiceProxy.run(job).onFailure(details -> {
+            LOGGER.debug(details.toString());
+
+            aContext.completeNow();
+        }).onSuccess(result -> {
+            aContext.failNow(LOGGER.getMessage(MessageCodes.PRL_000, result.toJson()));
+        });
+    }
+
+    /**
+     * @param aVertx A Vert.x instance
+     * @param aContext A test context
+     */
+    @AfterAll
+    public void tearDown(final Vertx aVertx, final VertxTestContext aContext) {
+        final Future<Void> closeHarvestService =
+                myHarvestServiceProxy.close().compose(unused -> myHarvestService.unregister());
+        final Future<Void> closeSolr = wipeSolr().compose(unused -> {
+            mySolrClient.shutdown();
+
+            return Future.succeededFuture();
+        });
+
+        CompositeFuture
+                .all(closeHarvestService.compose(unused -> myHarvestScheduleStoreService.unregister()), closeSolr)
+                .onSuccess(unused -> aContext.completeNow()).onFailure(aContext::failNow);
+    }
+}

--- a/src/test/java/edu/ucla/library/prl/harvester/services/HarvestServiceUtilsTest.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/services/HarvestServiceUtilsTest.java
@@ -103,10 +103,14 @@ public class HarvestServiceUtilsTest {
      */
     @ParameterizedTest
     @CsvSource({ //
-        "oai:namespace-identifier:local-identifier, true", "oai:0:1, true", //
-        "test, false", "oai:namespace-identifier:, false", //
-        "oai:namespace-identifier, false", "oai:0, false", //
-        "oai::local-identifier, false", "oai::1, false" //
+        "oai:namespace-identifier:local-identifier, true", //
+        "oai:0:1, true", //
+        "test, false", //
+        "oai:namespace-identifier:, false", //
+        "oai:namespace-identifier, false", //
+        "oai:0, false", //
+        "oai::local-identifier, false", //
+        "oai::1, false" //
     })
     public void testIsOaiIdentifier(final String aRecordIdentifier, final boolean anExpectedResult, final Vertx aVertx,
             final VertxTestContext aContext) {

--- a/src/test/java/edu/ucla/library/prl/harvester/services/HarvestServiceUtilsTest.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/services/HarvestServiceUtilsTest.java
@@ -1,0 +1,158 @@
+
+package edu.ucla.library.prl.harvester.services;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import io.vertx.core.Vertx;
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+
+/**
+ * Tests {@link HarvestServiceUtils}.
+ */
+@ExtendWith(VertxExtension.class)
+@TestInstance(Lifecycle.PER_CLASS)
+public class HarvestServiceUtilsTest {
+
+    private WebClient myWebClient;
+
+    /**
+     * @param aVertx A Vert.x instance
+     * @param aContext A test context
+     */
+    @BeforeAll
+    public void setUp(final Vertx aVertx, final VertxTestContext aContext) {
+        myWebClient = WebClient.create(aVertx);
+
+        aContext.completeNow();
+    }
+
+    /**
+     * Tests {@link HarvestServiceUtils#getDecadesAscending(List)}.
+     *
+     * @param aDates A list of strings contained in a record's dc:date fields
+     * @param anExpectedResult
+     * @param aVertx A Vert.x instance
+     * @param aContext A test context
+     */
+    @ParameterizedTest
+    @MethodSource
+    public void testGetDecadesAscending(final List<String> aDates, final List<Integer> anExpectedResult,
+            final Vertx aVertx, final VertxTestContext aContext) {
+        aContext.verify(() -> {
+            assertEquals(anExpectedResult, HarvestServiceUtils.getDecadesAscending(aDates));
+        }).completeNow();
+    }
+
+    /**
+     * FIXME
+     *
+     * @return The arguments for the corresponding {@link ParameterizedTest}
+     */
+    Stream<Arguments> testGetDecadesAscending() {
+        return Stream.of(Arguments.of(List.of("FIXME"), List.of(2005)));
+    }
+
+    /**
+     * Tests {@link HarvestServiceUtils#scoreURL(URL, String, URL)}.
+     *
+     * @param aURL The URL to score
+     * @param aRecordIdentifier The identifier of the record in which the URL was found
+     * @param aRepositoryURL The base URL from which the record was harvested
+     * @param anExpectedResult
+     * @param aVertx A Vert.x instance
+     * @param aContext A test context
+     */
+    @ParameterizedTest
+    @CsvSource({ //
+        "http://example.edu/catalog/1, oai:0:1, http://example.edu/provider, 2", //
+        "http://test.example.edu/catalog/1, oai:0:1, http://example.edu/provider, 1", //
+        "http://test.example.edu/catalog/one, oai:0:1, http://example.edu/provider, 0" //
+    })
+    public void testScoreUrl(final URL aURL, final String aRecordIdentifier, final URL aRepositoryURL,
+            final int anExpectedResult, final Vertx aVertx, final VertxTestContext aContext) {
+        aContext.verify(() -> {
+            assertEquals(anExpectedResult, HarvestServiceUtils.scoreURL(aURL, aRecordIdentifier, aRepositoryURL));
+        }).completeNow();
+    }
+
+    /**
+     * Tests {@link HarvestServiceUtils#isOaiIdentifier(String)}.
+     *
+     * @param aRecordIdentifier A record identifier
+     * @param anExpectedResult
+     * @param aVertx A Vert.x instance
+     * @param aContext A test context
+     */
+    @ParameterizedTest
+    @CsvSource({ //
+        "oai:namespace-identifier:local-identifier, true", "oai:0:1, true", //
+        "test, false", "oai:namespace-identifier:, false", //
+        "oai:namespace-identifier, false", "oai:0, false", //
+        "oai::local-identifier, false", "oai::1, false" //
+    })
+    public void testIsOaiIdentifier(final String aRecordIdentifier, final boolean anExpectedResult, final Vertx aVertx,
+            final VertxTestContext aContext) {
+        aContext.verify(() -> {
+            assertEquals(anExpectedResult, HarvestServiceUtils.isOaiIdentifier(aRecordIdentifier));
+        }).completeNow();
+    }
+
+    /**
+     * Tests {@link HarvestServiceUtils#findImageURL(List, WebClient)}.
+     *
+     * @param aPossibleImageUrls The list of URLs to try
+     * @param anExpectedResult
+     * @param aVertx A Vert.x instance
+     * @param aContext A test context
+     */
+    @ParameterizedTest
+    @MethodSource
+    public void testFindImageURL(final List<URL> aPossibleImageUrls, final Optional<URL> anExpectedResult,
+            final Vertx aVertx, final VertxTestContext aContext) {
+        HarvestServiceUtils.findImageURL(aPossibleImageUrls, myWebClient).onSuccess(url -> {
+            aContext.verify(() -> {
+                assertEquals(anExpectedResult, url);
+            }).completeNow();
+        }).onFailure(aContext::failNow);
+    }
+
+    /**
+     * @return The arguments for the corresponding {@link ParameterizedTest}
+     * @throws MalformedURLException
+     */
+    Stream<Arguments> testFindImageURL() throws MalformedURLException {
+        final URL imageURL = new URL("https://http.cat/200.jpg");
+
+        return Stream.of( //
+                Arguments.of(List.of(new URL("http://example.com"), imageURL), Optional.of(imageURL)), //
+                Arguments.of(List.of(new URL("http://example.edu")), Optional.empty()));
+    }
+
+    /**
+     * @param aVertx A Vert.x instance
+     * @param aContext A test context
+     */
+    @AfterAll
+    public void tearDown(final Vertx aVertx, final VertxTestContext aContext) {
+        myWebClient.close();
+        aContext.completeNow();
+    }
+}

--- a/src/test/resources/joai-Dockerfile.patch
+++ b/src/test/resources/joai-Dockerfile.patch
@@ -1,0 +1,12 @@
+diff --git a/Dockerfile b/Dockerfile
+index f07bb5c..efc7550 100644
+--- a/Dockerfile
++++ b/Dockerfile
+@@ -21,6 +21,7 @@ COPY --from=builder /war/ ./ROOT/
+ RUN \
+   wget -O ../lib/woodstox-core-5.0.3.jar 'https://search.maven.org/remotecontent?filepath=com/fasterxml/woodstox/woodstox-core/5.0.3/woodstox-core-5.0.3.jar' && \
+   wget -O ../lib/stax2-api-4.0.0.jar 'https://search.maven.org/remotecontent?filepath=org/codehaus/woodstox/stax2-api/4.0.0/stax2-api-4.0.0.jar' && \
++  wget -O ../lib/xalan-2.7.2.jar 'https://search.maven.org/remotecontent?filepath=xalan/xalan/2.7.2/xalan-2.7.2.jar' && \
+   rm -r docs/ examples/ host-manager/ manager/ && \
+   mkdir -p /joai/config/harvester /joai/config/repository && \
+   ln -s /joai/config/harvester /usr/local/tomcat/webapps/ROOT/WEB-INF/harvester_settings_and_data && \


### PR DESCRIPTION
Summary:
- Implemented `HarvestService#run`
  - Defined `JobResult` type (and corresponding exception) to use as the return value of `HarvestService#run`
  - Added two additional private instance methods
  - Added package-visible utilities class for the service (to reduce the LOC count of `HarvestServiceImpl.java`)
    - Testing `getSolrDocument` seemed like a rather heavy lift, however the rest of the utility methods have tests; I recommend running `mvn verify -DlogLevel=DEBUG` to see the Solr docs that are created by `HarvestServiceIT`
- Removed writable S3 bucket since we decided to drop (for now, at least) the thumbnail copying requirement
- Bumped container start timeouts to 30 seconds
- Fixed maven-resource-plugin config to actually filter sample DC records

Note that `HarvestServiceUtils#getDecadesAscending` is intentionally not implemented correctly. The code in the original Python implementation is quite complex since it cleans a lot of dirty data, so I figured tackling the method in a new task would make more sense (at which time the new FIXMEs will be addressed).

Sorry for such a small number of commits for a PR this large.