### PR TITLE
[SERV-600] Enforce camelCase in Database JSON View

### DIFF
--- a/src/main/java/edu/ucla/library/prl/harvester/Job.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/Job.java
@@ -26,17 +26,17 @@ public final class Job {
     /**
      * The JSON key for the institution ID.
      */
-    static final String INSTITUTION_ID = "institutionid";
+    static final String INSTITUTION_ID = "institutionId";
 
     /**
      * The JSON key for the repository base URL.
      */
-    static final String REPOSITORY_BASE_URL = "repositorybaseurl";
+    static final String REPOSITORY_BASE_URL = "repositoryBaseUrl";
 
     /**
      * JSON key for the metadata prefix.
      */
-    static final String METADATA_PREFIX = "metadataprefix";
+    static final String METADATA_PREFIX = "metadataPrefix";
 
     /**
      * JSON key for the list of sets.
@@ -46,12 +46,12 @@ public final class Job {
     /**
      * JSON key for the schedule.
      */
-    static final String SCHEDULE_CRON_EXPRESSION = "schedulecronexpression";
+    static final String SCHEDULE_CRON_EXPRESSION = "scheduleCronExpression";
 
     /**
      * JSON key for the last successful run.
      */
-    static final String LAST_SUCCESSFUL_RUN = "lastsuccessfulrun";
+    static final String LAST_SUCCESSFUL_RUN = "lastSuccessfulRun";
 
     /**
      * The identifier of the institution that this job should be associated with.

--- a/src/main/java/edu/ucla/library/prl/harvester/Job.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/Job.java
@@ -26,12 +26,12 @@ public final class Job {
     /**
      * The JSON key for the institution ID.
      */
-    static final String INSTITUTION_ID = "institutionId";
+    static final String INSTITUTION_ID = "institutionID";
 
     /**
      * The JSON key for the repository base URL.
      */
-    static final String REPOSITORY_BASE_URL = "repositoryBaseUrl";
+    static final String REPOSITORY_BASE_URL = "repositoryBaseURL";
 
     /**
      * JSON key for the metadata prefix.

--- a/src/main/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreServiceImpl.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreServiceImpl.java
@@ -111,7 +111,7 @@ public class HarvestScheduleStoreServiceImpl implements HarvestScheduleStoreServ
     private static final String LIST_JOBS = """
         SELECT institutionId AS "institutionID", repositoryBaseUrl AS "repositoryBaseURL",
                metadataPrefix AS "metadataPrefix", sets, lastSuccessfulRun AS "lastSuccessfulRun",
-               scheduleCronExpression AS "scheduleCronExpression" FROM public.harvestjobs ORDER BY "institutionId"
+               scheduleCronExpression AS "scheduleCronExpression" FROM public.harvestjobs ORDER BY "institutionID"
                """;
 
     /**

--- a/src/main/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreServiceImpl.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreServiceImpl.java
@@ -106,7 +106,7 @@ public class HarvestScheduleStoreServiceImpl implements HarvestScheduleStoreServ
         """;
 
     /**
-     * The select query for all jobs. N.b. awkward format to satisfy checkstyle rules
+     * The select query for all jobs.
      */
     private static final String LIST_JOBS = """
         SELECT institutionId AS "institutionID", repositoryBaseUrl AS "repositoryBaseURL",

--- a/src/main/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreServiceImpl.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreServiceImpl.java
@@ -92,7 +92,7 @@ public class HarvestScheduleStoreServiceImpl implements HarvestScheduleStoreServ
      * The select-one query for jobs.
      */
     private static final String GET_JOB = """
-        SELECT institutionId AS "institutionId", repositoryBaseUrl AS "repositoryBaseUrl",
+        SELECT institutionId AS "institutionID", repositoryBaseUrl AS "repositoryBaseURL",
         metadataPrefix AS "metadataPrefix", sets, lastSuccessfulRun AS "lastSuccessfulRun",
         scheduleCronExpression AS "scheduleCronExpression" FROM public.harvestjobs WHERE id = $1
         """;
@@ -109,7 +109,7 @@ public class HarvestScheduleStoreServiceImpl implements HarvestScheduleStoreServ
      * The select query for all jobs. N.b. awkward format to satisfy checkstyle rules
      */
     private static final String LIST_JOBS = """
-        SELECT institutionId AS "institutionId", repositoryBaseUrl AS "repositoryBaseUrl",
+        SELECT institutionId AS "institutionID", repositoryBaseUrl AS "repositoryBaseURL",
                metadataPrefix AS "metadataPrefix", sets, lastSuccessfulRun AS "lastSuccessfulRun",
                scheduleCronExpression AS "scheduleCronExpression" FROM public.harvestjobs ORDER BY "institutionId"
                """;
@@ -123,8 +123,8 @@ public class HarvestScheduleStoreServiceImpl implements HarvestScheduleStoreServ
      * The update query for a job.
      */
     private static final String UPDATE_JOB = """
-        UPDATE public.harvestjobs SET repositoryBaseUrl=$1, sets=$2, lastSuccessfulRun=$3,
-        scheduleCronExpression=$4 WHERE id = $5 AND institutionId = $6
+        UPDATE public.harvestjobs SET repositoryBaseURL=$1, sets=$2, lastSuccessfulRun=$3,
+        scheduleCronExpression=$4 WHERE id = $5 AND institutionID = $6
         """;
 
     /**

--- a/src/main/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreServiceImpl.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreServiceImpl.java
@@ -57,63 +57,64 @@ public class HarvestScheduleStoreServiceImpl implements HarvestScheduleStoreServ
      * The select-one query for institutions.
      */
     private static final String GET_INST = "SELECT \"name\", \"description\", \"location\", \"email\"," +
-            " \"phone\", \"webContact\", \"website\" FROM public.institutions WHERE id = $1";
+            " \"phone\", \"webContact\", \"website\" FROM public.\"institutions\" WHERE \"id\" = $1";
 
     /**
      * The insert query for institutions.
      */
     private static final String ADD_INST =
-            "INSERT INTO public.institutions(\"name\", \"description\", \"location\", \"email\"," +
-                    " \"phone\", \"webContact\", \"website\") VALUES($1, $2, $3, $4, $5, $6, $7) RETURNING id";
+            "INSERT INTO public.\"institutions\"(\"name\", \"description\", \"location\", \"email\"," +
+                    " \"phone\", \"webContact\", \"website\") VALUES($1, $2, $3, $4, $5, $6, $7) RETURNING \"id\"";
 
     /**
      * The select query for all institutions.
      */
     private static final String LIST_INSTS = "SELECT \"name\", \"description\", \"location\", \"email\"," +
-            " \"phone\", \"webContact\", \"website\" FROM public.institutions ORDER BY name";
+            " \"phone\", \"webContact\", \"website\" FROM public.\"institutions\" ORDER BY \"name\"";
 
     /**
      * The delete query for an institution.
      */
-    private static final String DEL_INST = "DELETE FROM public.institutions WHERE id = $1";
+    private static final String DEL_INST = "DELETE FROM public.\"institutions\" WHERE \"id\" = $1";
 
     /**
      * The update query for an institution.
      */
-    private static final String UPDATE_INST = "UPDATE public.institutions SET \"name\"=$1, \"description\"=$2," +
-            " \"location\"=$3, \"email\"=$4, \"phone\"=$5, \"webContact\"=$6, \"website\"=$7 WHERE id = $8";
+    private static final String UPDATE_INST = "UPDATE public.\"institutions\" SET \"name\"=$1, \"description\"=$2," +
+            " \"location\"=$3, \"email\"=$4, \"phone\"=$5, \"webContact\"=$6, \"website\"=$7 WHERE \"id\" = $8";
 
     /**
      * The select-one query for jobs.
      */
-    private static final String GET_JOB = "SELECT \"institutionId\", \"repositoryBaseUrl\", \"metadataPrefix\", sets," +
-            " \"lastSuccessfulRun\", \"scheduleCronExpression\" FROM public.harvestjobs WHERE id = $1";
+    private static final String GET_JOB =
+            "SELECT \"institutionId\", \"repositoryBaseUrl\", \"metadataPrefix\", \"sets\"," +
+                    " \"lastSuccessfulRun\", \"scheduleCronExpression\" FROM public.\"harvestjobs\" WHERE \"id\" = $1";
 
     /**
      * The insert query for jobs.
      */
     private static final String ADD_JOB =
-            "INSERT INTO public.harvestjobs(\"institutionId\", \"repositoryBaseUrl\", \"metadataPrefix\", sets," +
-                    " \"lastSuccessfulRun\", \"scheduleCronExpression\") VALUES($1, $2, $3, $4, $5, $6) RETURNING id";
+            "INSERT INTO public.\"harvestjobs\"(\"institutionId\", \"repositoryBaseUrl\", \"metadataPrefix\", \"sets\"," +
+                    " \"lastSuccessfulRun\", \"scheduleCronExpression\") VALUES($1, $2, $3, $4, $5, $6) RETURNING \"id\"";
 
     /**
      * The select query for all jobs.
      */
     private static final String LIST_JOBS =
-            "SELECT \"institutionId\", \"repositoryBaseUrl\", \"metadataPrefix\", sets," +
-                    " \"lastSuccessfulRun\", \"scheduleCronExpression\" FROM public.harvestjobs ORDER BY institutionID";
+            "SELECT \"institutionId\", \"repositoryBaseUrl\", \"metadataPrefix\", \"sets\"," +
+                    " \"lastSuccessfulRun\", \"scheduleCronExpression\" FROM public.\"harvestjobs\" ORDER BY \"institutionID\"";
 
     /**
      * The delete query for a job.
      */
-    private static final String DEL_JOB = "DELETE FROM public.harvestjobs WHERE id = $1";
+    private static final String DEL_JOB = "DELETE FROM public.\"harvestjobs\" WHERE \"id\" = $1";
 
     /**
      * The update query for a job.
      */
     private static final String UPDATE_JOB =
-            "UPDATE public.harvestjobs SET \"repositoryBaseUrl\"=$1, sets=$2, \"lastSuccessfulRun\"=$3," +
-                    " \"scheduleCronExpression\"=$4 WHERE id = $5 AND \"institutionId\" = $6";
+            "UPDATE public.harvestjobs SET \"repositoryBaseUrl\"=$1, \"set\"s=$2, \"lastSuccessfulRun\"=$3," +
+                    " \"scheduleCronExpression\"=$4 WHERE \"id\" = $5 AND \"institutionId\" = $6";
 
     /**
      * The postgres database (and default user) name.

--- a/src/main/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreServiceImpl.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreServiceImpl.java
@@ -56,20 +56,21 @@ public class HarvestScheduleStoreServiceImpl implements HarvestScheduleStoreServ
     /**
      * The select-one query for institutions.
      */
-    private static final String GET_INST = "SELECT name, description, location, email," +
-            " phone, \"webContact\", website FROM public.institutions WHERE id = $1";
+    private static final String GET_INST = "SELECT \"name\", \"description\", \"location\", \"email\"," +
+            " \"phone\", \"webContact\", \"website\" FROM public.institutions WHERE id = $1";
 
     /**
      * The insert query for institutions.
      */
-    private static final String ADD_INST = "INSERT INTO public.institutions(name, description, location, email," +
-            " phone, \"webContact\", website) VALUES($1, $2, $3, $4, $5, $6, $7) RETURNING id";
+    private static final String ADD_INST =
+            "INSERT INTO public.institutions(\"name\", \"description\", \"location\", \"email\"," +
+                    " \"phone\", \"webContact\", \"website\") VALUES($1, $2, $3, $4, $5, $6, $7) RETURNING id";
 
     /**
      * The select query for all institutions.
      */
-    private static final String LIST_INSTS = "SELECT name, description, location, email," +
-            " phone, \"webContact\", website FROM public.institutions ORDER BY name";
+    private static final String LIST_INSTS = "SELECT \"name\", \"description\", \"location\", \"email\"," +
+            " \"phone\", \"webContact\", \"website\" FROM public.institutions ORDER BY name";
 
     /**
      * The delete query for an institution.
@@ -79,8 +80,8 @@ public class HarvestScheduleStoreServiceImpl implements HarvestScheduleStoreServ
     /**
      * The update query for an institution.
      */
-    private static final String UPDATE_INST = "UPDATE public.institutions SET name=$1, description=$2," +
-            " location=$3, email=$4, phone=$5, \"webContact\"=$6, website=$7 WHERE id = $8";
+    private static final String UPDATE_INST = "UPDATE public.institutions SET \"name\"=$1, \"description\"=$2," +
+            " \"location\"=$3, \"email\"=$4, \"phone\"=$5, \"webContact\"=$6, \"website\"=$7 WHERE id = $8";
 
     /**
      * The select-one query for jobs.

--- a/src/main/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreServiceImpl.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreServiceImpl.java
@@ -56,65 +56,67 @@ public class HarvestScheduleStoreServiceImpl implements HarvestScheduleStoreServ
     /**
      * The select-one query for institutions.
      */
-    private static final String GET_INST = "SELECT \"name\", \"description\", \"location\", \"email\"," +
-            " \"phone\", \"webContact\", \"website\" FROM public.\"institutions\" WHERE \"id\" = $1";
+    private static final String GET_INST = "SELECT name, description, location, email," +
+            " phone, webContact AS \"webContact\", website FROM public.institutions WHERE id = $1";
 
     /**
      * The insert query for institutions.
      */
-    private static final String ADD_INST =
-            "INSERT INTO public.\"institutions\"(\"name\", \"description\", \"location\", \"email\"," +
-                    " \"phone\", \"webContact\", \"website\") VALUES($1, $2, $3, $4, $5, $6, $7) RETURNING \"id\"";
+    private static final String ADD_INST = "INSERT INTO public.institutions(name, description, location, email," +
+            " phone, webContact, website) VALUES($1, $2, $3, $4, $5, $6, $7) RETURNING id";
 
     /**
      * The select query for all institutions.
      */
-    private static final String LIST_INSTS = "SELECT \"name\", \"description\", \"location\", \"email\"," +
-            " \"phone\", \"webContact\", \"website\" FROM public.\"institutions\" ORDER BY \"name\"";
+    private static final String LIST_INSTS = "SELECT name, description, location, email, phone, " +
+            "webContact AS \"webContact\", website FROM public.institutions ORDER BY name";
 
     /**
      * The delete query for an institution.
      */
-    private static final String DEL_INST = "DELETE FROM public.\"institutions\" WHERE \"id\" = $1";
+    private static final String DEL_INST = "DELETE FROM public.institutions WHERE id = $1";
 
     /**
      * The update query for an institution.
      */
-    private static final String UPDATE_INST = "UPDATE public.\"institutions\" SET \"name\"=$1, \"description\"=$2," +
-            " \"location\"=$3, \"email\"=$4, \"phone\"=$5, \"webContact\"=$6, \"website\"=$7 WHERE \"id\" = $8";
+    private static final String UPDATE_INST = "UPDATE public.institutions SET name=$1, description=$2," +
+            " location=$3, email=$4, phone=$5, webContact=$6, website=$7 WHERE id = $8";
 
     /**
      * The select-one query for jobs.
      */
     private static final String GET_JOB =
-            "SELECT \"institutionId\", \"repositoryBaseUrl\", \"metadataPrefix\", \"sets\"," +
-                    " \"lastSuccessfulRun\", \"scheduleCronExpression\" FROM public.\"harvestjobs\" WHERE \"id\" = $1";
+            "SELECT institutionId AS \"institutionId\", repositoryBaseUrl AS \"repositoryBaseUrl\", " +
+            "metadataPrefix AS \"metadataPrefix\", sets, lastSuccessfulRun AS \"lastSuccessfulRun\", " +
+            "scheduleCronExpression AS \"scheduleCronExpression\" FROM public.harvestjobs WHERE id = $1";
 
     /**
      * The insert query for jobs.
      */
     private static final String ADD_JOB =
-            "INSERT INTO public.\"harvestjobs\"(\"institutionId\", \"repositoryBaseUrl\", \"metadataPrefix\", \"sets\"," +
-                    " \"lastSuccessfulRun\", \"scheduleCronExpression\") VALUES($1, $2, $3, $4, $5, $6) RETURNING \"id\"";
+            "INSERT INTO public.harvestjobs(institutionId, repositoryBaseUrl, metadataPrefix, sets," +
+                    " lastSuccessfulRun, scheduleCronExpression) VALUES($1, $2, $3, $4, $5, $6) RETURNING id";
 
     /**
-     * The select query for all jobs.
+     * The select query for all jobs. N.b. awkward format to satisfy checkstyle rules
      */
     private static final String LIST_JOBS =
-            "SELECT \"institutionId\", \"repositoryBaseUrl\", \"metadataPrefix\", \"sets\"," +
-                    " \"lastSuccessfulRun\", \"scheduleCronExpression\" FROM public.\"harvestjobs\" ORDER BY \"institutionID\"";
+            "SELECT institutionId AS \"institutionId\", repositoryBaseUrl AS " +
+            "\"repositoryBaseUrl\", metadataPrefix AS \"metadataPrefix\", sets, lastSuccessfulRun AS " +
+            "\"lastSuccessfulRun\", scheduleCronExpression AS \"scheduleCronExpression\" " +
+            "FROM public.harvestjobs ORDER BY \"institutionId\"";
 
     /**
      * The delete query for a job.
      */
-    private static final String DEL_JOB = "DELETE FROM public.\"harvestjobs\" WHERE \"id\" = $1";
+    private static final String DEL_JOB = "DELETE FROM public.harvestjobs WHERE id = $1";
 
     /**
      * The update query for a job.
      */
     private static final String UPDATE_JOB =
-            "UPDATE public.harvestjobs SET \"repositoryBaseUrl\"=$1, \"set\"s=$2, \"lastSuccessfulRun\"=$3," +
-                    " \"scheduleCronExpression\"=$4 WHERE \"id\" = $5 AND \"institutionId\" = $6";
+            "UPDATE public.harvestjobs SET repositoryBaseUrl=$1, sets=$2, lastSuccessfulRun=$3," +
+                    " scheduleCronExpression=$4 WHERE id = $5 AND institutionId = $6";
 
     /**
      * The postgres database (and default user) name.

--- a/src/main/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreServiceImpl.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreServiceImpl.java
@@ -55,25 +55,25 @@ public class HarvestScheduleStoreServiceImpl implements HarvestScheduleStoreServ
      * The select-one query for institutions.
      */
     private static final String GET_INST = """
-	    SELECT name, description, location, email, phone, webContact AS "webContact", 
-            website FROM public.institutions WHERE id = $1
-            """;            
+        SELECT name, description, location, email, phone, webContact AS "webContact",
+               website FROM public.institutions WHERE id = $1
+               """;
 
     /**
      * The insert query for institutions.
      */
     private static final String ADD_INST = """
-            INSERT INTO public.institutions(name, description, location, email,
-            phone, webContact, website) VALUES($1, $2, $3, $4, $5, $6, $7) RETURNING id
-	    """;
+               INSERT INTO public.institutions(name, description, location, email,
+               phone, webContact, website) VALUES($1, $2, $3, $4, $5, $6, $7) RETURNING id
+        """;
 
     /**
      * The select query for all institutions.
      */
     private static final String LIST_INSTS = """
-	    SELECT name, description, location, email, phone, 
-            webContact AS "webContact", website FROM public.institutions ORDER BY name
-            """;
+        SELECT name, description, location, email, phone,
+               webContact AS "webContact", website FROM public.institutions ORDER BY name
+               """;
 
     /**
      * The delete query for an institution.
@@ -84,35 +84,35 @@ public class HarvestScheduleStoreServiceImpl implements HarvestScheduleStoreServ
      * The update query for an institution.
      */
     private static final String UPDATE_INST = """
-            UPDATE public.institutions SET name=$1, description=$2, location=$3, 
-            email=$4, phone=$5, webContact=$6, website=$7 WHERE id = $8
-            """;
+        UPDATE public.institutions SET name=$1, description=$2, location=$3,
+        email=$4, phone=$5, webContact=$6, website=$7 WHERE id = $8
+        """;
 
     /**
      * The select-one query for jobs.
      */
     private static final String GET_JOB = """
-            SELECT institutionId AS "institutionId", repositoryBaseUrl AS "repositoryBaseUrl", 
-            metadataPrefix AS "metadataPrefix", sets, lastSuccessfulRun AS "lastSuccessfulRun", 
-            scheduleCronExpression AS "scheduleCronExpression" FROM public.harvestjobs WHERE id = $1
-            """;
+        SELECT institutionId AS "institutionId", repositoryBaseUrl AS "repositoryBaseUrl",
+        metadataPrefix AS "metadataPrefix", sets, lastSuccessfulRun AS "lastSuccessfulRun",
+        scheduleCronExpression AS "scheduleCronExpression" FROM public.harvestjobs WHERE id = $1
+        """;
 
     /**
      * The insert query for jobs.
      */
     private static final String ADD_JOB = """
-            INSERT INTO public.harvestjobs(institutionId, repositoryBaseUrl, metadataPrefix, sets, 
-            lastSuccessfulRun, scheduleCronExpression) VALUES($1, $2, $3, $4, $5, $6) RETURNING id
-            """;
+        INSERT INTO public.harvestjobs(institutionId, repositoryBaseUrl, metadataPrefix, sets,
+        lastSuccessfulRun, scheduleCronExpression) VALUES($1, $2, $3, $4, $5, $6) RETURNING id
+        """;
 
     /**
      * The select query for all jobs. N.b. awkward format to satisfy checkstyle rules
      */
     private static final String LIST_JOBS = """
-	    SELECT institutionId AS "institutionId", repositoryBaseUrl AS "repositoryBaseUrl", 
-            metadataPrefix AS "metadataPrefix", sets, lastSuccessfulRun AS "lastSuccessfulRun",
-            scheduleCronExpression AS "scheduleCronExpression" FROM public.harvestjobs ORDER BY "institutionId"
-            """;
+        SELECT institutionId AS "institutionId", repositoryBaseUrl AS "repositoryBaseUrl",
+               metadataPrefix AS "metadataPrefix", sets, lastSuccessfulRun AS "lastSuccessfulRun",
+               scheduleCronExpression AS "scheduleCronExpression" FROM public.harvestjobs ORDER BY "institutionId"
+               """;
 
     /**
      * The delete query for a job.
@@ -123,9 +123,9 @@ public class HarvestScheduleStoreServiceImpl implements HarvestScheduleStoreServ
      * The update query for a job.
      */
     private static final String UPDATE_JOB = """
-            UPDATE public.harvestjobs SET repositoryBaseUrl=$1, sets=$2, lastSuccessfulRun=$3,
-            scheduleCronExpression=$4 WHERE id = $5 AND institutionId = $6
-            """;
+        UPDATE public.harvestjobs SET repositoryBaseUrl=$1, sets=$2, lastSuccessfulRun=$3,
+        scheduleCronExpression=$4 WHERE id = $5 AND institutionId = $6
+        """;
 
     /**
      * The postgres database (and default user) name.

--- a/src/main/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreServiceImpl.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreServiceImpl.java
@@ -87,8 +87,8 @@ public class HarvestScheduleStoreServiceImpl implements HarvestScheduleStoreServ
      */
     private static final String GET_JOB =
             "SELECT institutionId AS \"institutionId\", repositoryBaseUrl AS \"repositoryBaseUrl\", " +
-            "metadataPrefix AS \"metadataPrefix\", sets, lastSuccessfulRun AS \"lastSuccessfulRun\", " +
-            "scheduleCronExpression AS \"scheduleCronExpression\" FROM public.harvestjobs WHERE id = $1";
+                    "metadataPrefix AS \"metadataPrefix\", sets, lastSuccessfulRun AS \"lastSuccessfulRun\", " +
+                    "scheduleCronExpression AS \"scheduleCronExpression\" FROM public.harvestjobs WHERE id = $1";
 
     /**
      * The insert query for jobs.
@@ -100,8 +100,7 @@ public class HarvestScheduleStoreServiceImpl implements HarvestScheduleStoreServ
     /**
      * The select query for all jobs. N.b. awkward format to satisfy checkstyle rules
      */
-    private static final String LIST_JOBS =
-            "SELECT institutionId AS \"institutionId\", repositoryBaseUrl AS " +
+    private static final String LIST_JOBS = "SELECT institutionId AS \"institutionId\", repositoryBaseUrl AS " +
             "\"repositoryBaseUrl\", metadataPrefix AS \"metadataPrefix\", sets, lastSuccessfulRun AS " +
             "\"lastSuccessfulRun\", scheduleCronExpression AS \"scheduleCronExpression\" " +
             "FROM public.harvestjobs ORDER BY \"institutionId\"";

--- a/src/main/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreServiceImpl.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreServiceImpl.java
@@ -54,20 +54,26 @@ public class HarvestScheduleStoreServiceImpl implements HarvestScheduleStoreServ
     /**
      * The select-one query for institutions.
      */
-    private static final String GET_INST = "SELECT name, description, location, email," +
-            " phone, webContact AS \"webContact\", website FROM public.institutions WHERE id = $1";
+    private static final String GET_INST = """
+	    SELECT name, description, location, email, phone, webContact AS "webContact", 
+            website FROM public.institutions WHERE id = $1
+            """;            
 
     /**
      * The insert query for institutions.
      */
-    private static final String ADD_INST = "INSERT INTO public.institutions(name, description, location, email," +
-            " phone, webContact, website) VALUES($1, $2, $3, $4, $5, $6, $7) RETURNING id";
+    private static final String ADD_INST = """
+            INSERT INTO public.institutions(name, description, location, email,
+            phone, webContact, website) VALUES($1, $2, $3, $4, $5, $6, $7) RETURNING id
+	    """;
 
     /**
      * The select query for all institutions.
      */
-    private static final String LIST_INSTS = "SELECT name, description, location, email, phone, " +
-            "webContact AS \"webContact\", website FROM public.institutions ORDER BY name";
+    private static final String LIST_INSTS = """
+	    SELECT name, description, location, email, phone, 
+            webContact AS "webContact", website FROM public.institutions ORDER BY name
+            """;
 
     /**
      * The delete query for an institution.
@@ -77,31 +83,36 @@ public class HarvestScheduleStoreServiceImpl implements HarvestScheduleStoreServ
     /**
      * The update query for an institution.
      */
-    private static final String UPDATE_INST = "UPDATE public.institutions SET name=$1, description=$2," +
-            " location=$3, email=$4, phone=$5, webContact=$6, website=$7 WHERE id = $8";
+    private static final String UPDATE_INST = """
+            UPDATE public.institutions SET name=$1, description=$2, location=$3, 
+            email=$4, phone=$5, webContact=$6, website=$7 WHERE id = $8
+            """;
 
     /**
      * The select-one query for jobs.
      */
-    private static final String GET_JOB =
-            "SELECT institutionId AS \"institutionId\", repositoryBaseUrl AS \"repositoryBaseUrl\", " +
-                    "metadataPrefix AS \"metadataPrefix\", sets, lastSuccessfulRun AS \"lastSuccessfulRun\", " +
-                    "scheduleCronExpression AS \"scheduleCronExpression\" FROM public.harvestjobs WHERE id = $1";
+    private static final String GET_JOB = """
+            SELECT institutionId AS "institutionId", repositoryBaseUrl AS "repositoryBaseUrl", 
+            metadataPrefix AS "metadataPrefix", sets, lastSuccessfulRun AS "lastSuccessfulRun", 
+            scheduleCronExpression AS "scheduleCronExpression" FROM public.harvestjobs WHERE id = $1
+            """;
 
     /**
      * The insert query for jobs.
      */
-    private static final String ADD_JOB =
-            "INSERT INTO public.harvestjobs(institutionId, repositoryBaseUrl, metadataPrefix, sets," +
-                    " lastSuccessfulRun, scheduleCronExpression) VALUES($1, $2, $3, $4, $5, $6) RETURNING id";
+    private static final String ADD_JOB = """
+            INSERT INTO public.harvestjobs(institutionId, repositoryBaseUrl, metadataPrefix, sets, 
+            lastSuccessfulRun, scheduleCronExpression) VALUES($1, $2, $3, $4, $5, $6) RETURNING id
+            """;
 
     /**
      * The select query for all jobs. N.b. awkward format to satisfy checkstyle rules
      */
-    private static final String LIST_JOBS = "SELECT institutionId AS \"institutionId\", repositoryBaseUrl AS " +
-            "\"repositoryBaseUrl\", metadataPrefix AS \"metadataPrefix\", sets, lastSuccessfulRun AS " +
-            "\"lastSuccessfulRun\", scheduleCronExpression AS \"scheduleCronExpression\" " +
-            "FROM public.harvestjobs ORDER BY \"institutionId\"";
+    private static final String LIST_JOBS = """
+	    SELECT institutionId AS "institutionId", repositoryBaseUrl AS "repositoryBaseUrl", 
+            metadataPrefix AS "metadataPrefix", sets, lastSuccessfulRun AS "lastSuccessfulRun",
+            scheduleCronExpression AS "scheduleCronExpression" FROM public.harvestjobs ORDER BY "institutionId"
+            """;
 
     /**
      * The delete query for a job.
@@ -111,9 +122,10 @@ public class HarvestScheduleStoreServiceImpl implements HarvestScheduleStoreServ
     /**
      * The update query for a job.
      */
-    private static final String UPDATE_JOB =
-            "UPDATE public.harvestjobs SET repositoryBaseUrl=$1, sets=$2, lastSuccessfulRun=$3," +
-                    " scheduleCronExpression=$4 WHERE id = $5 AND institutionId = $6";
+    private static final String UPDATE_JOB = """
+            UPDATE public.harvestjobs SET repositoryBaseUrl=$1, sets=$2, lastSuccessfulRun=$3,
+            scheduleCronExpression=$4 WHERE id = $5 AND institutionId = $6
+            """;
 
     /**
      * The postgres database (and default user) name.

--- a/src/main/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreServiceImpl.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreServiceImpl.java
@@ -56,18 +56,20 @@ public class HarvestScheduleStoreServiceImpl implements HarvestScheduleStoreServ
     /**
      * The select-one query for institutions.
      */
-    private static final String GET_INST = "SELECT * FROM public.institutions WHERE id = $1";
+    private static final String GET_INST = "SELECT name, description, location, email," +
+            " phone, \"webContact\", website FROM public.institutions WHERE id = $1";
 
     /**
      * The insert query for institutions.
      */
     private static final String ADD_INST = "INSERT INTO public.institutions(name, description, location, email," +
-            " phone, webContact, website) VALUES($1, $2, $3, $4, $5, $6, $7) RETURNING id";
+            " phone, \"webContact\", website) VALUES($1, $2, $3, $4, $5, $6, $7) RETURNING id";
 
     /**
      * The select query for all institutions.
      */
-    private static final String LIST_INSTS = "SELECT * FROM public.institutions ORDER BY name";
+    private static final String LIST_INSTS = "SELECT name, description, location, email," +
+            " phone, \"webContact\", website FROM public.institutions ORDER BY name";
 
     /**
      * The delete query for an institution.
@@ -78,24 +80,27 @@ public class HarvestScheduleStoreServiceImpl implements HarvestScheduleStoreServ
      * The update query for an institution.
      */
     private static final String UPDATE_INST = "UPDATE public.institutions SET name=$1, description=$2," +
-            " location=$3, email=$4, phone=$5, webContact=$6, website=$7 WHERE id = $8";
+            " location=$3, email=$4, phone=$5, \"webContact\"=$6, website=$7 WHERE id = $8";
 
     /**
      * The select-one query for jobs.
      */
-    private static final String GET_JOB = "SELECT * FROM public.harvestjobs WHERE id = $1";
+    private static final String GET_JOB = "SELECT \"institutionId\", \"repositoryBaseUrl\", \"metadataPrefix\", sets," +
+            " \"lastSuccessfulRun\", \"scheduleCronExpression\" FROM public.harvestjobs WHERE id = $1";
 
     /**
      * The insert query for jobs.
      */
     private static final String ADD_JOB =
-            "INSERT INTO public.harvestjobs(institutionID, repositoryBaseURL, metadataPrefix, sets," +
-                    " lastSuccessfulRun, scheduleCronExpression) VALUES($1, $2, $3, $4, $5, $6) RETURNING id";
+            "INSERT INTO public.harvestjobs(\"institutionId\", \"repositoryBaseUrl\", \"metadataPrefix\", sets," +
+                    " \"lastSuccessfulRun\", \"scheduleCronExpression\") VALUES($1, $2, $3, $4, $5, $6) RETURNING id";
 
     /**
      * The select query for all jobs.
      */
-    private static final String LIST_JOBS = "SELECT * FROM public.harvestjobs ORDER BY institutionID";
+    private static final String LIST_JOBS =
+            "SELECT \"institutionId\", \"repositoryBaseUrl\", \"metadataPrefix\", sets," +
+                    " \"lastSuccessfulRun\", \"scheduleCronExpression\" FROM public.harvestjobs ORDER BY institutionID";
 
     /**
      * The delete query for a job.
@@ -106,8 +111,8 @@ public class HarvestScheduleStoreServiceImpl implements HarvestScheduleStoreServ
      * The update query for a job.
      */
     private static final String UPDATE_JOB =
-            "UPDATE public.harvestjobs SET repositoryBaseURL=$1, sets=$2, lastSuccessfulRun=$3," +
-                    " scheduleCronExpression=$4 WHERE id = $5 AND institutionID = $6";
+            "UPDATE public.harvestjobs SET \"repositoryBaseUrl\"=$1, sets=$2, \"lastSuccessfulRun\"=$3," +
+                    " \"scheduleCronExpression\"=$4 WHERE id = $5 AND \"institutionId\" = $6";
 
     /**
      * The postgres database (and default user) name.

--- a/src/test/resources/db/prldb.sql
+++ b/src/test/resources/db/prldb.sql
@@ -114,16 +114,16 @@ COMMENT ON COLUMN public.institutions.website IS 'The website for an institution
 COMMENT ON COLUMN public.harvestjobs.id IS 'The unique identifier for a harvest job';
 
 --
--- Name: COLUMN harvestjobs.institutionID; Type: COMMENT; Schema: public; Owner: postgres
+-- Name: COLUMN harvestjobs.institutionId; Type: COMMENT; Schema: public; Owner: postgres
 --
 
-COMMENT ON COLUMN public.harvestjobs.institutionID IS 'The unique identifier for a related institution';
+COMMENT ON COLUMN public.harvestjobs.institutionId IS 'The unique identifier for a related institution';
 
 --
--- Name: COLUMN harvestjobs.repositoryBaseURL; Type: COMMENT; Schema: public; Owner: postgres
+-- Name: COLUMN harvestjobs.repositoryBaseUrl; Type: COMMENT; Schema: public; Owner: postgres
 --
 
-COMMENT ON COLUMN public.harvestjobs.repositoryBaseURL IS 'The base URL for a harvested repository';
+COMMENT ON COLUMN public.harvestjobs.repositoryBaseUrl IS 'The base URL for a harvested repository';
 
 --
 -- Name: COLUMN harvestjobs.metadataPrefix; Type: COMMENT; Schema: public; Owner: postgres
@@ -160,7 +160,7 @@ COPY public.institutions (id, name, description, location, email, phone, webCont
 -- Name: origins; Type: TABLE DATA; Schema: public; Owner: postgres
 --
 
-COPY public.harvestjobs (id, institutionID, repositoryBaseURL, metadataPrefix, sets, lastSuccessfulRun,
+COPY public.harvestjobs (id, institutionId, repositoryBaseUrl, metadataPrefix, sets, lastSuccessfulRun,
   scheduleCronExpression) FROM stdin;
 \.
 
@@ -197,8 +197,8 @@ INSERT INTO public.institutions(name, description, location, email, phone, webCo
 INSERT INTO public.institutions(name, description, location, email, phone, webContact, website) VALUES('Sample 3', 'A third sample', 'Everywhere', 'no@where.com', '+1 888 567 8901', 'http://acme.edu/1/contact', 'http://acme.edu/1');
 
 
-INSERT INTO public.harvestjobs(institutionID, repositoryBaseURL, metadataPrefix, sets, lastSuccessfulRun, scheduleCronExpression) VALUES(1, 'http://acme.edu/', 'oai_dc', '{this, that, the_other}', '2020-01-08 04:05:06 -8:00', '0 0/30 8-9 5,20 * ?');
-INSERT INTO public.harvestjobs(institutionID, repositoryBaseURL, metadataPrefix, sets, lastSuccessfulRun, scheduleCronExpression) VALUES(2, 'http://acme.edu/', 'oai_dc', '{this, that, the_other}', '2020-01-08 04:05:06 -8:00', '0 0/30 8-9 5,20 * ?');
-INSERT INTO public.harvestjobs(institutionID, repositoryBaseURL, metadataPrefix, sets, lastSuccessfulRun, scheduleCronExpression) VALUES(3, 'http://acme.edu/', 'oai_dc', '{this, that, the_other}', '2020-01-08 04:05:06 -8:00', '0 0/30 8-9 5,20 * ?');
+INSERT INTO public.harvestjobs(institutionId, repositoryBaseUrl, metadataPrefix, sets, lastSuccessfulRun, scheduleCronExpression) VALUES(1, 'http://acme.edu/', 'oai_dc', '{this, that, the_other}', '2020-01-08 04:05:06 -8:00', '0 0/30 8-9 5,20 * ?');
+INSERT INTO public.harvestjobs(institutionId, repositoryBaseUrl, metadataPrefix, sets, lastSuccessfulRun, scheduleCronExpression) VALUES(2, 'http://acme.edu/', 'oai_dc', '{this, that, the_other}', '2020-01-08 04:05:06 -8:00', '0 0/30 8-9 5,20 * ?');
+INSERT INTO public.harvestjobs(institutionId, repositoryBaseUrl, metadataPrefix, sets, lastSuccessfulRun, scheduleCronExpression) VALUES(3, 'http://acme.edu/', 'oai_dc', '{this, that, the_other}', '2020-01-08 04:05:06 -8:00', '0 0/30 8-9 5,20 * ?');
 
 

--- a/src/test/resources/db/prldb.sql
+++ b/src/test/resources/db/prldb.sql
@@ -34,30 +34,30 @@ SET default_table_access_method = heap;
 -- Name: items; Type: TABLE; Schema: public; Owner: postgres
 --
 
-CREATE TABLE public.institutions (
-    id SERIAL PRIMARY KEY,
-    name text NOT NULL,
-    description text NOT NULL,
-    location text NOT NULL,
-    email text,
-    phone text,
+CREATE TABLE public."institutions" (
+    "id" SERIAL PRIMARY KEY,
+    "name" text NOT NULL,
+    "description" text NOT NULL,
+    "location" text NOT NULL,
+    "email" text,
+    "phone" text,
     "webContact" text,
-    website text NOT NULL
+    "website" text NOT NULL
 );
 
-CREATE TABLE public.harvestjobs (
-    id SERIAL PRIMARY KEY,
+CREATE TABLE public."harvestjobs" (
+    "id" SERIAL PRIMARY KEY,
     "institutionId" INT,
     "repositoryBaseUrl" TEXT NOT NULL,
     "metadataPrefix" TEXT NOT NULL,
-    sets TEXT [],
+    "sets" TEXT [],
     "lastSuccessfulRun" TIMESTAMPTZ,
     "scheduleCronExpression" TEXT NOT NULL
 );
 
-ALTER TABLE public.institutions OWNER TO postgres;
+ALTER TABLE public."institutions" OWNER TO postgres;
 
-ALTER TABLE public.harvestjobs OWNER TO postgres;
+ALTER TABLE public."harvestjobs" OWNER TO postgres;
 
 --
 -- Name: COLUMN institutions.id; Type: COMMENT; Schema: public; Owner: postgres
@@ -191,9 +191,9 @@ GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO prl;
 -- sample entires for unit/integration test
 --
 
-INSERT INTO public.institutions(name, description, location, email, phone, webContact, website) VALUES('Sample 1', 'A sample institution', 'Here', 'this@that.com', '+1 888 123 4567', 'http://acme.edu/1/contact', 'http://acme.edu/1');
-INSERT INTO public.institutions(name, description, location, email, phone, webContact, website) VALUES('Sample 2', 'Another sample', 'There', 'that@theother.com', '+1 888 890 1234', 'http://acme.edu/1/contact', 'http://acme.edu/1');
-INSERT INTO public.institutions(name, description, location, email, phone, webContact, website) VALUES('Sample 3', 'A third sample', 'Everywhere', 'no@where.com', '+1 888 567 8901', 'http://acme.edu/1/contact', 'http://acme.edu/1');
+INSERT INTO public."institutions"(name, description, location, email, phone, webContact, website) VALUES('Sample 1', 'A sample institution', 'Here', 'this@that.com', '+1 888 123 4567', 'http://acme.edu/1/contact', 'http://acme.edu/1');
+INSERT INTO public."institutions"(name, description, location, email, phone, webContact, website) VALUES('Sample 2', 'Another sample', 'There', 'that@theother.com', '+1 888 890 1234', 'http://acme.edu/1/contact', 'http://acme.edu/1');
+INSERT INTO public."institutions"(name, description, location, email, phone, webContact, website) VALUES('Sample 3', 'A third sample', 'Everywhere', 'no@where.com', '+1 888 567 8901', 'http://acme.edu/1/contact', 'http://acme.edu/1');
 
 
 INSERT INTO public.harvestjobs(institutionID, repositoryBaseURL, metadataPrefix, sets, lastSuccessfulRun, scheduleCronExpression) VALUES(1, 'http://acme.edu/', 'oai_dc', '{"this", "that", "the_other"}', '2020-01-08 04:05:06 -8:00', '0 0/30 8-9 5,20 * ?');

--- a/src/test/resources/db/prldb.sql
+++ b/src/test/resources/db/prldb.sql
@@ -34,155 +34,155 @@ SET default_table_access_method = heap;
 -- Name: items; Type: TABLE; Schema: public; Owner: postgres
 --
 
-CREATE TABLE public."institutions" (
-    "id" SERIAL PRIMARY KEY,
-    "name" text NOT NULL,
-    "description" text NOT NULL,
-    "location" text NOT NULL,
-    "email" text,
-    "phone" text,
-    "webContact" text,
-    "website" text NOT NULL
+CREATE TABLE public.institutions (
+    id SERIAL PRIMARY KEY,
+    name text NOT NULL,
+    description text NOT NULL,
+    location text NOT NULL,
+    email text,
+    phone text,
+    webContact text,
+    website text NOT NULL
 );
 
-CREATE TABLE public."harvestjobs" (
-    "id" SERIAL PRIMARY KEY,
-    "institutionId" INT,
-    "repositoryBaseUrl" TEXT NOT NULL,
-    "metadataPrefix" TEXT NOT NULL,
-    "sets" TEXT [],
-    "lastSuccessfulRun" TIMESTAMPTZ,
-    "scheduleCronExpression" TEXT NOT NULL
+CREATE TABLE public.harvestjobs (
+    id SERIAL PRIMARY KEY,
+    institutionId INT,
+    repositoryBaseUrl TEXT NOT NULL,
+    metadataPrefix TEXT NOT NULL,
+    sets TEXT [],
+    lastSuccessfulRun TIMESTAMPTZ,
+    scheduleCronExpression TEXT NOT NULL
 );
 
-ALTER TABLE public."institutions" OWNER TO postgres;
+ALTER TABLE public.institutions OWNER TO postgres;
 
-ALTER TABLE public."harvestjobs" OWNER TO postgres;
-
---
--- Name: COLUMN "institutions"."id"; Type: COMMENT; Schema: public; Owner: postgres
---
-
-COMMENT ON COLUMN public."institutions"."id" IS 'The unique identifier of an institution';
+ALTER TABLE public.harvestjobs OWNER TO postgres;
 
 --
--- Name: COLUMN "institutions"."name"; Type: COMMENT; Schema: public; Owner: postgres
+-- Name: COLUMN institutions.id; Type: COMMENT; Schema: public; Owner: postgres
 --
 
-COMMENT ON COLUMN public."institutions"."name" IS 'The "name" of an institution';
+COMMENT ON COLUMN public.institutions.id IS 'The unique identifier of an institution';
 
 --
--- Name: COLUMN "institutions"."description"; Type: COMMENT; Schema: public; Owner: postgres
+-- Name: COLUMN institutions.name; Type: COMMENT; Schema: public; Owner: postgres
 --
 
-COMMENT ON COLUMN public."institutions"."description" IS 'The "description" of an institution';
+COMMENT ON COLUMN public.institutions.name IS 'The name of an institution';
 
 --
--- Name: COLUMN "institutions"."location"; Type: COMMENT; Schema: public; Owner: postgres
+-- Name: COLUMN institutions.description; Type: COMMENT; Schema: public; Owner: postgres
 --
 
-COMMENT ON COLUMN public."institutions"."location" IS 'The "location" of an institution';
+COMMENT ON COLUMN public.institutions.description IS 'The description of an institution';
 
 --
--- Name: COLUMN "institutions"."email"; Type: COMMENT; Schema: public; Owner: postgres
+-- Name: COLUMN institutions.location; Type: COMMENT; Schema: public; Owner: postgres
 --
 
-COMMENT ON COLUMN public."institutions"."email" IS 'The "email" contact for an institution';
+COMMENT ON COLUMN public.institutions.location IS 'The location of an institution';
 
 --
--- Name: COLUMN "institutions"."phone"; Type: COMMENT; Schema: public; Owner: postgres
+-- Name: COLUMN institutions.email; Type: COMMENT; Schema: public; Owner: postgres
 --
 
-COMMENT ON COLUMN public."institutions"."phone" IS 'The "phone" contact for an institution';
+COMMENT ON COLUMN public.institutions.email IS 'The email contact for an institution';
 
 --
--- Name: COLUMN "institutions"."webContact"; Type: COMMENT; Schema: public; Owner: postgres
+-- Name: COLUMN institutions.phone; Type: COMMENT; Schema: public; Owner: postgres
 --
 
-COMMENT ON COLUMN public."institutions"."webContact" IS 'The Web contact for an institution';
+COMMENT ON COLUMN public.institutions.phone IS 'The phone contact for an institution';
 
 --
--- Name: COLUMN "institutions"."website"; Type: COMMENT; Schema: public; Owner: postgres
+-- Name: COLUMN institutions.webContact; Type: COMMENT; Schema: public; Owner: postgres
 --
 
-COMMENT ON COLUMN public."institutions"."website" IS 'The "website" for an institution';
+COMMENT ON COLUMN public.institutions.webContact IS 'The Web contact for an institution';
 
 --
--- Name: COLUMN "harvestjobs"."id"; Type: COMMENT; Schema: public; Owner: postgres
+-- Name: COLUMN institutions.website; Type: COMMENT; Schema: public; Owner: postgres
 --
 
-COMMENT ON COLUMN public."harvestjobs"."id" IS 'The unique identifier for a harvest job';
+COMMENT ON COLUMN public.institutions.website IS 'The website for an institution';
 
 --
--- Name: COLUMN "harvestjobs".institutionID; Type: COMMENT; Schema: public; Owner: postgres
+-- Name: COLUMN harvestjobs.id; Type: COMMENT; Schema: public; Owner: postgres
 --
 
-COMMENT ON COLUMN public."harvestjobs".institutionID IS 'The unique identifier for a related institution';
+COMMENT ON COLUMN public.harvestjobs.id IS 'The unique identifier for a harvest job';
 
 --
--- Name: COLUMN "harvestjobs".repositoryBaseURL; Type: COMMENT; Schema: public; Owner: postgres
+-- Name: COLUMN harvestjobs.institutionID; Type: COMMENT; Schema: public; Owner: postgres
 --
 
-COMMENT ON COLUMN public."harvestjobs".repositoryBaseURL IS 'The base URL for a harvested repository';
+COMMENT ON COLUMN public.harvestjobs.institutionID IS 'The unique identifier for a related institution';
 
 --
--- Name: COLUMN "harvestjobs"."metadataPrefix"; Type: COMMENT; Schema: public; Owner: postgres
+-- Name: COLUMN harvestjobs.repositoryBaseURL; Type: COMMENT; Schema: public; Owner: postgres
 --
 
-COMMENT ON COLUMN public."harvestjobs"."metadataPrefix" IS 'The metadata prefix for a harvest job';
+COMMENT ON COLUMN public.harvestjobs.repositoryBaseURL IS 'The base URL for a harvested repository';
 
 --
--- Name: COLUMN "harvestjobs"."sets"; Type: COMMENT; Schema: public; Owner: postgres
+-- Name: COLUMN harvestjobs.metadataPrefix; Type: COMMENT; Schema: public; Owner: postgres
 --
 
-COMMENT ON COLUMN public."harvestjobs"."sets" IS 'The array of harvest "sets"';
+COMMENT ON COLUMN public.harvestjobs.metadataPrefix IS 'The metadata prefix for a harvest job';
 
 --
--- Name: COLUMN "harvestjobs"."lastSuccessfulRun"; Type: COMMENT; Schema: public; Owner: postgres
+-- Name: COLUMN harvestjobs.sets; Type: COMMENT; Schema: public; Owner: postgres
 --
 
-COMMENT ON COLUMN public."harvestjobs"."lastSuccessfulRun" IS 'The timestamp for the last successful harvest';
+COMMENT ON COLUMN public.harvestjobs.sets IS 'The array of harvest sets';
 
 --
--- Name: COLUMN "harvestjobs"."scheduleCronExpression"; Type: COMMENT; Schema: public; Owner: postgres
+-- Name: COLUMN harvestjobs.lastSuccessfulRun; Type: COMMENT; Schema: public; Owner: postgres
 --
 
-COMMENT ON COLUMN public."harvestjobs"."scheduleCronExpression" IS 'The cron expression for a harvest job';
+COMMENT ON COLUMN public.harvestjobs.lastSuccessfulRun IS 'The timestamp for the last successful harvest';
+
+--
+-- Name: COLUMN harvestjobs.scheduleCronExpression; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN public.harvestjobs.scheduleCronExpression IS 'The cron expression for a harvest job';
 
 --
 -- Name: items; Type: TABLE DATA; Schema: public; Owner: postgres
 --
 
-COPY public."institutions" ("id", "name", "description", "location", "email", "phone", "webContact", "website") FROM stdin;
+COPY public.institutions (id, name, description, location, email, phone, webContact, website) FROM stdin;
 \.
 
 --
 -- Name: origins; Type: TABLE DATA; Schema: public; Owner: postgres
 --
 
-COPY public."harvestjobs" ("id", institutionID, repositoryBaseURL, "metadataPrefix", "sets", "lastSuccessfulRun",
-  "scheduleCronExpression") FROM stdin;
+COPY public.harvestjobs (id, institutionID, repositoryBaseURL, metadataPrefix, sets, lastSuccessfulRun,
+  scheduleCronExpression) FROM stdin;
 \.
 
 --
 -- Name: harvestjobs_fkey; Type: CONSTRAINT; Schema: public; Owner: postgres
 --
 
-ALTER TABLE ONLY public."harvestjobs"
-    ADD CONSTRAINT harvestjobs_fkey FOREIGN KEY("institutionId") REFERENCES public."institutions"("id")
+ALTER TABLE ONLY public.harvestjobs
+    ADD CONSTRAINT harvestjobs_fkey FOREIGN KEY(institutionId) REFERENCES public.institutions(id)
     ON DELETE CASCADE;;
 
 --
--- Name: TABLE "institutions"; Type: ACL; Schema: public; Owner: postgres
+-- Name: TABLE institutions; Type: ACL; Schema: public; Owner: postgres
 --
 
-GRANT ALL ON TABLE public."institutions" TO prl;
+GRANT ALL ON TABLE public.institutions TO prl;
 
 --
--- Name: TABLE "harvestjobs"; Type: ACL; Schema: public; Owner: postgres
+-- Name: TABLE harvestjobs; Type: ACL; Schema: public; Owner: postgres
 --
 
-GRANT ALL ON TABLE public."harvestjobs" TO prl;
+GRANT ALL ON TABLE public.harvestjobs TO prl;
 
 --
 
@@ -192,12 +192,13 @@ GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO prl;
 -- sample entires for unit/integration test
 --
 
-INSERT INTO public."institutions"("name", "description", "location", "email", "phone", "webContact", "website") VALUES('Sample 1', 'A sample institution', 'Here', 'this@that.com', '+1 888 123 4567', 'http://acme.edu/1/contact', 'http://acme.edu/1');
-INSERT INTO public."institutions"("name", "description", "location", "email", "phone", "webContact", "website") VALUES('Sample 2', 'Another sample', 'There', 'that@theother.com', '+1 888 890 1234', 'http://acme.edu/1/contact', 'http://acme.edu/1');
-INSERT INTO public."institutions"("name", "description", "location", "email", "phone", "webContact", "website") VALUES('Sample 3', 'A third sample', 'Everywhere', 'no@where.com', '+1 888 567 8901', 'http://acme.edu/1/contact', 'http://acme.edu/1');
+INSERT INTO public.institutions(name, description, location, email, phone, webContact, website) VALUES('Sample 1', 'A sample institution', 'Here', 'this@that.com', '+1 888 123 4567', 'http://acme.edu/1/contact', 'http://acme.edu/1');
+INSERT INTO public.institutions(name, description, location, email, phone, webContact, website) VALUES('Sample 2', 'Another sample', 'There', 'that@theother.com', '+1 888 890 1234', 'http://acme.edu/1/contact', 'http://acme.edu/1');
+INSERT INTO public.institutions(name, description, location, email, phone, webContact, website) VALUES('Sample 3', 'A third sample', 'Everywhere', 'no@where.com', '+1 888 567 8901', 'http://acme.edu/1/contact', 'http://acme.edu/1');
 
 
-INSERT INTO public."harvestjobs"(institutionID, repositoryBaseURL, "metadataPrefix", "sets", "lastSuccessfulRun", "scheduleCronExpression") VALUES(1, 'http://acme.edu/', 'oai_dc', '{"this", "that", "the_other"}', '2020-01-08 04:05:06 -8:00', '0 0/30 8-9 5,20 * ?');
-INSERT INTO public."harvestjobs"(institutionID, repositoryBaseURL, "metadataPrefix", "sets", "lastSuccessfulRun", "scheduleCronExpression") VALUES(2, 'http://acme.edu/', 'oai_dc', '{"this", "that", "the_other"}', '2020-01-08 04:05:06 -8:00', '0 0/30 8-9 5,20 * ?');
-INSERT INTO public."harvestjobs"(institutionID, repositoryBaseURL, "metadataPrefix", "sets", "lastSuccessfulRun", "scheduleCronExpression") VALUES(3, 'http://acme.edu/', 'oai_dc', '{"this", "that", "the_other"}', '2020-01-08 04:05:06 -8:00', '0 0/30 8-9 5,20 * ?');
+INSERT INTO public.harvestjobs(institutionID, repositoryBaseURL, metadataPrefix, sets, lastSuccessfulRun, scheduleCronExpression) VALUES(1, 'http://acme.edu/', 'oai_dc', '{this, that, the_other}', '2020-01-08 04:05:06 -8:00', '0 0/30 8-9 5,20 * ?');
+INSERT INTO public.harvestjobs(institutionID, repositoryBaseURL, metadataPrefix, sets, lastSuccessfulRun, scheduleCronExpression) VALUES(2, 'http://acme.edu/', 'oai_dc', '{this, that, the_other}', '2020-01-08 04:05:06 -8:00', '0 0/30 8-9 5,20 * ?');
+INSERT INTO public.harvestjobs(institutionID, repositoryBaseURL, metadataPrefix, sets, lastSuccessfulRun, scheduleCronExpression) VALUES(3, 'http://acme.edu/', 'oai_dc', '{this, that, the_other}', '2020-01-08 04:05:06 -8:00', '0 0/30 8-9 5,20 * ?');
+
 

--- a/src/test/resources/db/prldb.sql
+++ b/src/test/resources/db/prldb.sql
@@ -41,18 +41,18 @@ CREATE TABLE public.institutions (
     location text NOT NULL,
     email text,
     phone text,
-    webContact text,
+    "webContact" text,
     website text NOT NULL
 );
 
 CREATE TABLE public.harvestjobs (
     id SERIAL PRIMARY KEY,
-    institutionID INT,
-    repositoryBaseURL TEXT NOT NULL,
-    metadataPrefix TEXT NOT NULL,
+    "institutionId" INT,
+    "repositoryBaseUrl" TEXT NOT NULL,
+    "metadataPrefix" TEXT NOT NULL,
     sets TEXT [],
-    lastSuccessfulRun TIMESTAMPTZ,
-    scheduleCronExpression TEXT NOT NULL
+    "lastSuccessfulRun" TIMESTAMPTZ,
+    "scheduleCronExpression" TEXT NOT NULL
 );
 
 ALTER TABLE public.institutions OWNER TO postgres;

--- a/src/test/resources/db/prldb.sql
+++ b/src/test/resources/db/prldb.sql
@@ -47,8 +47,8 @@ CREATE TABLE public.institutions (
 
 CREATE TABLE public.harvestjobs (
     id SERIAL PRIMARY KEY,
-    institutionId INT,
-    repositoryBaseUrl TEXT NOT NULL,
+    institutionID INT,
+    repositoryBaseURL TEXT NOT NULL,
     metadataPrefix TEXT NOT NULL,
     sets TEXT [],
     lastSuccessfulRun TIMESTAMPTZ,
@@ -114,16 +114,16 @@ COMMENT ON COLUMN public.institutions.website IS 'The website for an institution
 COMMENT ON COLUMN public.harvestjobs.id IS 'The unique identifier for a harvest job';
 
 --
--- Name: COLUMN harvestjobs.institutionId; Type: COMMENT; Schema: public; Owner: postgres
+-- Name: COLUMN harvestjobs.institutionID; Type: COMMENT; Schema: public; Owner: postgres
 --
 
-COMMENT ON COLUMN public.harvestjobs.institutionId IS 'The unique identifier for a related institution';
+COMMENT ON COLUMN public.harvestjobs.institutionID IS 'The unique identifier for a related institution';
 
 --
--- Name: COLUMN harvestjobs.repositoryBaseUrl; Type: COMMENT; Schema: public; Owner: postgres
+-- Name: COLUMN harvestjobs.repositoryBaseURL; Type: COMMENT; Schema: public; Owner: postgres
 --
 
-COMMENT ON COLUMN public.harvestjobs.repositoryBaseUrl IS 'The base URL for a harvested repository';
+COMMENT ON COLUMN public.harvestjobs.repositoryBaseURL IS 'The base URL for a harvested repository';
 
 --
 -- Name: COLUMN harvestjobs.metadataPrefix; Type: COMMENT; Schema: public; Owner: postgres
@@ -160,7 +160,7 @@ COPY public.institutions (id, name, description, location, email, phone, webCont
 -- Name: origins; Type: TABLE DATA; Schema: public; Owner: postgres
 --
 
-COPY public.harvestjobs (id, institutionId, repositoryBaseUrl, metadataPrefix, sets, lastSuccessfulRun,
+COPY public.harvestjobs (id, institutionID, repositoryBaseURL, metadataPrefix, sets, lastSuccessfulRun,
   scheduleCronExpression) FROM stdin;
 \.
 
@@ -169,7 +169,7 @@ COPY public.harvestjobs (id, institutionId, repositoryBaseUrl, metadataPrefix, s
 --
 
 ALTER TABLE ONLY public.harvestjobs
-    ADD CONSTRAINT harvestjobs_fkey FOREIGN KEY(institutionId) REFERENCES public.institutions(id)
+    ADD CONSTRAINT harvestjobs_fkey FOREIGN KEY(institutionID) REFERENCES public.institutions(id)
     ON DELETE CASCADE;;
 
 --
@@ -197,8 +197,8 @@ INSERT INTO public.institutions(name, description, location, email, phone, webCo
 INSERT INTO public.institutions(name, description, location, email, phone, webContact, website) VALUES('Sample 3', 'A third sample', 'Everywhere', 'no@where.com', '+1 888 567 8901', 'http://acme.edu/1/contact', 'http://acme.edu/1');
 
 
-INSERT INTO public.harvestjobs(institutionId, repositoryBaseUrl, metadataPrefix, sets, lastSuccessfulRun, scheduleCronExpression) VALUES(1, 'http://acme.edu/', 'oai_dc', '{this, that, the_other}', '2020-01-08 04:05:06 -8:00', '0 0/30 8-9 5,20 * ?');
-INSERT INTO public.harvestjobs(institutionId, repositoryBaseUrl, metadataPrefix, sets, lastSuccessfulRun, scheduleCronExpression) VALUES(2, 'http://acme.edu/', 'oai_dc', '{this, that, the_other}', '2020-01-08 04:05:06 -8:00', '0 0/30 8-9 5,20 * ?');
-INSERT INTO public.harvestjobs(institutionId, repositoryBaseUrl, metadataPrefix, sets, lastSuccessfulRun, scheduleCronExpression) VALUES(3, 'http://acme.edu/', 'oai_dc', '{this, that, the_other}', '2020-01-08 04:05:06 -8:00', '0 0/30 8-9 5,20 * ?');
+INSERT INTO public.harvestjobs(institutionID, repositoryBaseURL, metadataPrefix, sets, lastSuccessfulRun, scheduleCronExpression) VALUES(1, 'http://acme.edu/', 'oai_dc', '{this, that, the_other}', '2020-01-08 04:05:06 -8:00', '0 0/30 8-9 5,20 * ?');
+INSERT INTO public.harvestjobs(institutionID, repositoryBaseURL, metadataPrefix, sets, lastSuccessfulRun, scheduleCronExpression) VALUES(2, 'http://acme.edu/', 'oai_dc', '{this, that, the_other}', '2020-01-08 04:05:06 -8:00', '0 0/30 8-9 5,20 * ?');
+INSERT INTO public.harvestjobs(institutionID, repositoryBaseURL, metadataPrefix, sets, lastSuccessfulRun, scheduleCronExpression) VALUES(3, 'http://acme.edu/', 'oai_dc', '{this, that, the_other}', '2020-01-08 04:05:06 -8:00', '0 0/30 8-9 5,20 * ?');
 
 

--- a/src/test/resources/db/prldb.sql
+++ b/src/test/resources/db/prldb.sql
@@ -169,8 +169,7 @@ COPY public.harvestjobs (id, institutionID, repositoryBaseURL, metadataPrefix, s
 --
 
 ALTER TABLE ONLY public.harvestjobs
-    ADD CONSTRAINT harvestjobs_fkey FOREIGN KEY(institutionID) REFERENCES public.institutions(id)
-    ON DELETE CASCADE;;
+    ADD CONSTRAINT harvestjobs_fkey FOREIGN KEY(institutionID) REFERENCES public.institutions(id);
 
 --
 -- Name: TABLE institutions; Type: ACL; Schema: public; Owner: postgres

--- a/src/test/resources/db/prldb.sql
+++ b/src/test/resources/db/prldb.sql
@@ -60,128 +60,129 @@ ALTER TABLE public."institutions" OWNER TO postgres;
 ALTER TABLE public."harvestjobs" OWNER TO postgres;
 
 --
--- Name: COLUMN institutions.id; Type: COMMENT; Schema: public; Owner: postgres
+-- Name: COLUMN "institutions"."id"; Type: COMMENT; Schema: public; Owner: postgres
 --
 
-COMMENT ON COLUMN public.institutions.id IS 'The unique identifier of an institution';
+COMMENT ON COLUMN public."institutions"."id" IS 'The unique identifier of an institution';
 
 --
--- Name: COLUMN institutions.name; Type: COMMENT; Schema: public; Owner: postgres
+-- Name: COLUMN "institutions"."name"; Type: COMMENT; Schema: public; Owner: postgres
 --
 
-COMMENT ON COLUMN public.institutions.name IS 'The name of an institution';
+COMMENT ON COLUMN public."institutions"."name" IS 'The "name" of an institution';
 
 --
--- Name: COLUMN institutions.description; Type: COMMENT; Schema: public; Owner: postgres
+-- Name: COLUMN "institutions"."description"; Type: COMMENT; Schema: public; Owner: postgres
 --
 
-COMMENT ON COLUMN public.institutions.description IS 'The description of an institution';
+COMMENT ON COLUMN public."institutions"."description" IS 'The "description" of an institution';
 
 --
--- Name: COLUMN institutions.location; Type: COMMENT; Schema: public; Owner: postgres
+-- Name: COLUMN "institutions"."location"; Type: COMMENT; Schema: public; Owner: postgres
 --
 
-COMMENT ON COLUMN public.institutions.location IS 'The location of an institution';
+COMMENT ON COLUMN public."institutions"."location" IS 'The "location" of an institution';
 
 --
--- Name: COLUMN institutions.email; Type: COMMENT; Schema: public; Owner: postgres
+-- Name: COLUMN "institutions"."email"; Type: COMMENT; Schema: public; Owner: postgres
 --
 
-COMMENT ON COLUMN public.institutions.email IS 'The email contact for an institution';
+COMMENT ON COLUMN public."institutions"."email" IS 'The "email" contact for an institution';
 
 --
--- Name: COLUMN institutions.phone; Type: COMMENT; Schema: public; Owner: postgres
+-- Name: COLUMN "institutions"."phone"; Type: COMMENT; Schema: public; Owner: postgres
 --
 
-COMMENT ON COLUMN public.institutions.phone IS 'The phone contact for an institution';
+COMMENT ON COLUMN public."institutions"."phone" IS 'The "phone" contact for an institution';
 
 --
--- Name: COLUMN institutions.webContact; Type: COMMENT; Schema: public; Owner: postgres
+-- Name: COLUMN "institutions"."webContact"; Type: COMMENT; Schema: public; Owner: postgres
 --
 
-COMMENT ON COLUMN public.institutions.webContact IS 'The Web contact for an institution';
+COMMENT ON COLUMN public."institutions"."webContact" IS 'The Web contact for an institution';
 
 --
--- Name: COLUMN institutions.website; Type: COMMENT; Schema: public; Owner: postgres
+-- Name: COLUMN "institutions"."website"; Type: COMMENT; Schema: public; Owner: postgres
 --
 
-COMMENT ON COLUMN public.institutions.website IS 'The website for an institution';
+COMMENT ON COLUMN public."institutions"."website" IS 'The "website" for an institution';
 
 --
--- Name: COLUMN harvestjobs.id; Type: COMMENT; Schema: public; Owner: postgres
+-- Name: COLUMN "harvestjobs"."id"; Type: COMMENT; Schema: public; Owner: postgres
 --
 
-COMMENT ON COLUMN public.harvestjobs.id IS 'The unique identifier for a harvest job';
+COMMENT ON COLUMN public."harvestjobs"."id" IS 'The unique identifier for a harvest job';
 
 --
--- Name: COLUMN harvestjobs.institutionID; Type: COMMENT; Schema: public; Owner: postgres
+-- Name: COLUMN "harvestjobs".institutionID; Type: COMMENT; Schema: public; Owner: postgres
 --
 
-COMMENT ON COLUMN public.harvestjobs.institutionID IS 'The unique identifier for a related institution';
+COMMENT ON COLUMN public."harvestjobs".institutionID IS 'The unique identifier for a related institution';
 
 --
--- Name: COLUMN harvestjobs.repositoryBaseURL; Type: COMMENT; Schema: public; Owner: postgres
+-- Name: COLUMN "harvestjobs".repositoryBaseURL; Type: COMMENT; Schema: public; Owner: postgres
 --
 
-COMMENT ON COLUMN public.harvestjobs.repositoryBaseURL IS 'The base URL for a harvested repository';
+COMMENT ON COLUMN public."harvestjobs".repositoryBaseURL IS 'The base URL for a harvested repository';
 
 --
--- Name: COLUMN harvestjobs.metadataPrefix; Type: COMMENT; Schema: public; Owner: postgres
+-- Name: COLUMN "harvestjobs"."metadataPrefix"; Type: COMMENT; Schema: public; Owner: postgres
 --
 
-COMMENT ON COLUMN public.harvestjobs.metadataPrefix IS 'The metadata prefix for a harvest job';
+COMMENT ON COLUMN public."harvestjobs"."metadataPrefix" IS 'The metadata prefix for a harvest job';
 
 --
--- Name: COLUMN harvestjobs.sets; Type: COMMENT; Schema: public; Owner: postgres
+-- Name: COLUMN "harvestjobs"."sets"; Type: COMMENT; Schema: public; Owner: postgres
 --
 
-COMMENT ON COLUMN public.harvestjobs.sets IS 'The array of harvest sets';
+COMMENT ON COLUMN public."harvestjobs"."sets" IS 'The array of harvest "sets"';
 
 --
--- Name: COLUMN harvestjobs.lastSuccessfulRun; Type: COMMENT; Schema: public; Owner: postgres
+-- Name: COLUMN "harvestjobs"."lastSuccessfulRun"; Type: COMMENT; Schema: public; Owner: postgres
 --
 
-COMMENT ON COLUMN public.harvestjobs.lastSuccessfulRun IS 'The timestamp for the last successful harvest';
+COMMENT ON COLUMN public."harvestjobs"."lastSuccessfulRun" IS 'The timestamp for the last successful harvest';
 
 --
--- Name: COLUMN harvestjobs.scheduleCronExpression; Type: COMMENT; Schema: public; Owner: postgres
+-- Name: COLUMN "harvestjobs"."scheduleCronExpression"; Type: COMMENT; Schema: public; Owner: postgres
 --
 
-COMMENT ON COLUMN public.harvestjobs.scheduleCronExpression IS 'The cron expression for a harvest job';
+COMMENT ON COLUMN public."harvestjobs"."scheduleCronExpression" IS 'The cron expression for a harvest job';
 
 --
 -- Name: items; Type: TABLE DATA; Schema: public; Owner: postgres
 --
 
-COPY public.institutions (id, name, description, location, email, phone, webContact, website) FROM stdin;
+COPY public."institutions" ("id", "name", "description", "location", "email", "phone", "webContact", "website") FROM stdin;
 \.
 
 --
 -- Name: origins; Type: TABLE DATA; Schema: public; Owner: postgres
 --
 
-COPY public.harvestjobs (id, institutionID, repositoryBaseURL, metadataPrefix, sets, lastSuccessfulRun,
-  scheduleCronExpression) FROM stdin;
+COPY public."harvestjobs" ("id", institutionID, repositoryBaseURL, "metadataPrefix", "sets", "lastSuccessfulRun",
+  "scheduleCronExpression") FROM stdin;
 \.
 
 --
 -- Name: harvestjobs_fkey; Type: CONSTRAINT; Schema: public; Owner: postgres
 --
 
-ALTER TABLE ONLY public.harvestjobs
-    ADD CONSTRAINT harvestjobs_fkey FOREIGN KEY(institutionID) REFERENCES public.institutions(id);
+ALTER TABLE ONLY public."harvestjobs"
+    ADD CONSTRAINT harvestjobs_fkey FOREIGN KEY("institutionId") REFERENCES public."institutions"("id")
+    ON DELETE CASCADE;;
 
 --
--- Name: TABLE institutions; Type: ACL; Schema: public; Owner: postgres
+-- Name: TABLE "institutions"; Type: ACL; Schema: public; Owner: postgres
 --
 
-GRANT ALL ON TABLE public.institutions TO prl;
+GRANT ALL ON TABLE public."institutions" TO prl;
 
 --
--- Name: TABLE harvestjobs; Type: ACL; Schema: public; Owner: postgres
+-- Name: TABLE "harvestjobs"; Type: ACL; Schema: public; Owner: postgres
 --
 
-GRANT ALL ON TABLE public.harvestjobs TO prl;
+GRANT ALL ON TABLE public."harvestjobs" TO prl;
 
 --
 
@@ -191,12 +192,12 @@ GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO prl;
 -- sample entires for unit/integration test
 --
 
-INSERT INTO public."institutions"(name, description, location, email, phone, webContact, website) VALUES('Sample 1', 'A sample institution', 'Here', 'this@that.com', '+1 888 123 4567', 'http://acme.edu/1/contact', 'http://acme.edu/1');
-INSERT INTO public."institutions"(name, description, location, email, phone, webContact, website) VALUES('Sample 2', 'Another sample', 'There', 'that@theother.com', '+1 888 890 1234', 'http://acme.edu/1/contact', 'http://acme.edu/1');
-INSERT INTO public."institutions"(name, description, location, email, phone, webContact, website) VALUES('Sample 3', 'A third sample', 'Everywhere', 'no@where.com', '+1 888 567 8901', 'http://acme.edu/1/contact', 'http://acme.edu/1');
+INSERT INTO public."institutions"("name", "description", "location", "email", "phone", "webContact", "website") VALUES('Sample 1', 'A sample institution', 'Here', 'this@that.com', '+1 888 123 4567', 'http://acme.edu/1/contact', 'http://acme.edu/1');
+INSERT INTO public."institutions"("name", "description", "location", "email", "phone", "webContact", "website") VALUES('Sample 2', 'Another sample', 'There', 'that@theother.com', '+1 888 890 1234', 'http://acme.edu/1/contact', 'http://acme.edu/1');
+INSERT INTO public."institutions"("name", "description", "location", "email", "phone", "webContact", "website") VALUES('Sample 3', 'A third sample', 'Everywhere', 'no@where.com', '+1 888 567 8901', 'http://acme.edu/1/contact', 'http://acme.edu/1');
 
 
-INSERT INTO public.harvestjobs(institutionID, repositoryBaseURL, metadataPrefix, sets, lastSuccessfulRun, scheduleCronExpression) VALUES(1, 'http://acme.edu/', 'oai_dc', '{"this", "that", "the_other"}', '2020-01-08 04:05:06 -8:00', '0 0/30 8-9 5,20 * ?');
-INSERT INTO public.harvestjobs(institutionID, repositoryBaseURL, metadataPrefix, sets, lastSuccessfulRun, scheduleCronExpression) VALUES(2, 'http://acme.edu/', 'oai_dc', '{"this", "that", "the_other"}', '2020-01-08 04:05:06 -8:00', '0 0/30 8-9 5,20 * ?');
-INSERT INTO public.harvestjobs(institutionID, repositoryBaseURL, metadataPrefix, sets, lastSuccessfulRun, scheduleCronExpression) VALUES(3, 'http://acme.edu/', 'oai_dc', '{"this", "that", "the_other"}', '2020-01-08 04:05:06 -8:00', '0 0/30 8-9 5,20 * ?');
+INSERT INTO public."harvestjobs"(institutionID, repositoryBaseURL, "metadataPrefix", "sets", "lastSuccessfulRun", "scheduleCronExpression") VALUES(1, 'http://acme.edu/', 'oai_dc', '{"this", "that", "the_other"}', '2020-01-08 04:05:06 -8:00', '0 0/30 8-9 5,20 * ?');
+INSERT INTO public."harvestjobs"(institutionID, repositoryBaseURL, "metadataPrefix", "sets", "lastSuccessfulRun", "scheduleCronExpression") VALUES(2, 'http://acme.edu/', 'oai_dc', '{"this", "that", "the_other"}', '2020-01-08 04:05:06 -8:00', '0 0/30 8-9 5,20 * ?');
+INSERT INTO public."harvestjobs"(institutionID, repositoryBaseURL, "metadataPrefix", "sets", "lastSuccessfulRun", "scheduleCronExpression") VALUES(3, 'http://acme.edu/', 'oai_dc', '{"this", "that", "the_other"}', '2020-01-08 04:05:06 -8:00', '0 0/30 8-9 5,20 * ?');
 


### PR DESCRIPTION
* Updated SELECT queries to alias column names (where necessary) to impose camelCase on JSON field names
* Tweaked Institution and Job field-name constants to match values in OpenAPI spec
* Tweaks to db script to synchronize field names (that PostgreSQL actually ignores)