### PR TITLE
[SERV-716] Fix parameter maps for INSERT and UPDATE queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,14 +5,6 @@ src/main/generated
 dependency-reduced-pom.xml
 .flattened-pom.xml
 
-# Eclipse IDE artifacts
-.settings/
-.project
-.classpath
-
-# VS Code IDE artifacts
-.vscode/
-
 # Vert.x test artifacts
 file-uploads/
 vertx-start-process.id

--- a/.gitignore
+++ b/.gitignore
@@ -5,10 +5,13 @@ src/main/generated
 dependency-reduced-pom.xml
 .flattened-pom.xml
 
-# Eclipse ID artifacts
+# Eclipse IDE artifacts
 .settings/
 .project
 .classpath
+
+# VS Code IDE artifacts
+.vscode/
 
 # Vert.x test artifacts
 file-uploads/

--- a/pom.xml
+++ b/pom.xml
@@ -397,6 +397,7 @@
           <environmentVariables>
             <HARVEST_TIMEOUT>86400000</HARVEST_TIMEOUT><!-- 1 day -->
             <HTTP_PORT>${test.harvester.port}</HTTP_PORT>
+            <PGHOSTADDR>localhost</PGHOSTADDR>
             <PGDATABASE>postgres</PGDATABASE>
             <PGUSER>${test.db.user}</PGUSER>
             <PGPASSWORD>${test.db.password}</PGPASSWORD>
@@ -934,6 +935,7 @@
                 </configurationParameters>
               </properties>
               <environmentVariables>
+                <PGHOSTADDR>localhost</PGHOSTADDR>
                 <PGDATABASE>postgres</PGDATABASE>
                 <PGUSER>${test.db.user}</PGUSER>
                 <PGPASSWORD>${test.db.password}</PGPASSWORD>

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
     <solrs.version>2.6.0</solrs.version>
     <xoai.version>4.2.0</xoai.version>
     <guava.version>31.1-jre</guava.version>
+    <jackson.version>2.14.1</jackson.version>
 
     <!-- Security update overrides -->
     <snakeyaml.version>1.32</snakeyaml.version>
@@ -163,6 +164,10 @@
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
+      <artifactId>vertx-sql-client-templates</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
       <artifactId>vertx-service-proxy</artifactId>
     </dependency>
     <dependency>
@@ -222,6 +227,16 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>${guava.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+      <version>${jackson.version}</version>
     </dependency>
 
     <!-- Security update overrides -->

--- a/src/main/java/edu/ucla/library/prl/harvester/Config.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/Config.java
@@ -34,12 +34,12 @@ public final class Config {
     /**
      * The ENV property for the database host.
      */
-    public static final String DB_HOST = "DB_HOST";
+    public static final String DB_HOST = "PGHOSTADDR";
 
     /**
      * The ENV property for the database name.
      */
-    public static final String DB_NAME = "DB_NAME";
+    public static final String DB_NAME = "PGDATABASE";
 
     /**
      * The ENV property for the max size of the database connection pool.

--- a/src/main/java/edu/ucla/library/prl/harvester/Institution.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/Institution.java
@@ -27,6 +27,11 @@ import io.vertx.core.json.JsonObject;
 public final class Institution {
 
     /**
+     * The JSON key for the ID.
+     */
+    public static final String ID = "id";
+
+    /**
      * The JSON key for the name.
      */
     static final String NAME = "name";
@@ -65,6 +70,11 @@ public final class Institution {
      * Parses and formats phone numbers.
      */
     private static final PhoneNumberUtil PHONE_NUMBER_UTIL = PhoneNumberUtil.getInstance();
+
+    /**
+     * The institution's optional identifier.
+     */
+    private final Optional<Integer> myID;
 
     /**
      * The institution's name.
@@ -116,6 +126,7 @@ public final class Institution {
     public Institution(final String aName, final String aDescription, final String aLocation,
             final Optional<InternetAddress> anEmail, final Optional<PhoneNumber> aPhone,
             final Optional<URL> aWebContact, final URL aWebsite) {
+        myID = Optional.empty();
         myName = Objects.requireNonNull(aName);
         myDescription = Objects.requireNonNull(aDescription);
         myLocation = Objects.requireNonNull(aLocation);
@@ -134,7 +145,9 @@ public final class Institution {
     /**
      * Instantiates an institution from its JSON representation.
      * <p>
-     * <b>This constructor is meant to be used only by generated service proxy code!</b>
+     * Note that the JSON representation may contain an ID, which must have been assigned by the database.
+     * <p>
+     * <b>This constructor is meant to be used only by the service code (generated or otherwise)!</b>
      * {@link #Institution(String, String, String, Optional, Optional, Optional, URL)} should be used everywhere else.
      *
      * @param aJsonObject An institution represented as JSON
@@ -151,6 +164,8 @@ public final class Institution {
         final Optional<PhoneNumber> phone;
         final Optional<URL> webContact;
         final String website = aJsonObject.getString(WEBSITE);
+
+        myID = Optional.ofNullable(aJsonObject.getInteger(ID));
 
         if (name != null) {
             myName = name;
@@ -216,7 +231,7 @@ public final class Institution {
      * @return The JSON representation of the institution
      */
     public JsonObject toJson() {
-        return new JsonObject() //
+        final JsonObject json = new JsonObject() //
                 .put(NAME, getName()) //
                 .put(DESCRIPTION, getDescription()) //
                 .put(LOCATION, getLocation()) //
@@ -226,6 +241,17 @@ public final class Institution {
                         .orElse(null)) //
                 .put(WEB_CONTACT, getWebContact().map(URL::toString).orElse(null)) //
                 .put(WEBSITE, myWebsite.toString());
+
+        myID.ifPresent(id -> json.put(ID, id));
+
+        return json;
+    }
+
+    /**
+     * @return The optional ID
+     */
+    public Optional<Integer> getID() {
+        return myID;
     }
 
     /**

--- a/src/main/java/edu/ucla/library/prl/harvester/Job.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/Job.java
@@ -24,6 +24,11 @@ import io.vertx.core.json.JsonObject;
 public final class Job {
 
     /**
+     * The JSON key for the ID.
+     */
+    public static final String ID = "id";
+
+    /**
      * The JSON key for the institution ID.
      */
     static final String INSTITUTION_ID = "institutionID";
@@ -52,6 +57,11 @@ public final class Job {
      * JSON key for the last successful run.
      */
     static final String LAST_SUCCESSFUL_RUN = "lastSuccessfulRun";
+
+    /**
+     * The identifier of the job.
+     */
+    private final Optional<Integer> myID;
 
     /**
      * The identifier of the institution that this job should be associated with.
@@ -89,6 +99,7 @@ public final class Job {
      */
     public Job(final int anInstitutionID, final URL aRepositoryBaseURL, final List<String> aSets,
             final CronExpression aScheduleCronExpression, final OffsetDateTime aLastSuccessfulRun) {
+        myID = Optional.empty();
         myInstitutionID = anInstitutionID;
         myRepositoryBaseURL = Objects.requireNonNull(aRepositoryBaseURL);
         mySets = Optional.ofNullable(aSets);
@@ -99,7 +110,9 @@ public final class Job {
     /**
      * Instantiates a job from its JSON representation.
      * <p>
-     * <b>This constructor is meant to be used only by generated service proxy code!</b>
+     * Note that the JSON representation may contain an ID, which must have been assigned by the database.
+     * <p>
+     * <b>This constructor is meant to be used only by the service code (generated or otherwise)!</b>
      * {@link #Job(int, URL, List, CronExpression, OffsetDateTime)} should be used everywhere else.
      *
      * @param aJsonObject A job represented as JSON
@@ -112,6 +125,8 @@ public final class Job {
         final Integer institutionID = aJsonObject.getInteger(INSTITUTION_ID);
         final String repositoryBaseURL = aJsonObject.getString(REPOSITORY_BASE_URL);
         final String scheduleCronExpression = aJsonObject.getString(SCHEDULE_CRON_EXPRESSION);
+
+        myID = Optional.ofNullable(aJsonObject.getInteger(ID));
 
         if (institutionID != null) {
             myInstitutionID = institutionID;
@@ -157,12 +172,23 @@ public final class Job {
      * @return The JSON representation of the job
      */
     public JsonObject toJson() {
-        return new JsonObject() //
+        final JsonObject json = new JsonObject() //
                 .put(INSTITUTION_ID, getInstitutionID()) //
                 .put(REPOSITORY_BASE_URL, getRepositoryBaseURL().toString()).put(METADATA_PREFIX, getMetadataPrefix())//
                 .put(SETS, getSets().orElse(null)) //
                 .put(SCHEDULE_CRON_EXPRESSION, getScheduleCronExpression().getCronExpression()) //
                 .put(LAST_SUCCESSFUL_RUN, getLastSuccessfulRun().map(OffsetDateTime::toString).orElse(null));
+
+        myID.ifPresent(id -> json.put(ID, id));
+
+        return json;
+    }
+
+    /**
+     * @return The optional ID
+     */
+    public Optional<Integer> getID() {
+        return myID;
     }
 
     /**

--- a/src/main/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreService.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreService.java
@@ -98,7 +98,8 @@ public interface HarvestScheduleStoreService {
     /**
      * Gets the list of all harvest jobs.
      *
-     * @return A Future that succeeds with a list of all harvest jobs (if any)
+     * @return A Future that succeeds with a list of all harvest jobs (if any); these jobs must each have an
+     *         {@link Job#ID} key
      */
     Future<List<Job>> listJobs();
 

--- a/src/main/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreService.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreService.java
@@ -58,7 +58,8 @@ public interface HarvestScheduleStoreService {
     /**
      * Gets the list of all institutions.
      *
-     * @return A Future that succeeds with a list of all institutions (if any)
+     * @return A Future that succeeds with a list of all institutions (if any); these institutions must each have an
+     *         {@link Institution#ID} key
      */
     Future<List<Institution>> listInstitutions();
 

--- a/src/main/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreServiceImpl.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreServiceImpl.java
@@ -238,7 +238,7 @@ public class HarvestScheduleStoreServiceImpl implements HarvestScheduleStoreServ
                 return Future.succeededFuture();
             }
             return Future.failedFuture(
-+                    new ServiceException(NOT_FOUND_ERROR, LOGGER.getMessage(MessageCodes.PRL_019, anInstitutionId)));
+                    new ServiceException(NOT_FOUND_ERROR, LOGGER.getMessage(MessageCodes.PRL_019, anInstitutionId)));
         });
     }
 

--- a/src/main/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreServiceImpl.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreServiceImpl.java
@@ -56,7 +56,7 @@ public class HarvestScheduleStoreServiceImpl implements HarvestScheduleStoreServ
      * The select-one query for institutions.
      */
     private static final String GET_INST = """
-        SELECT name, description, location, email, phone, webcontact AS "webContact", website
+        SELECT name, description, location, email, phone, webContact AS "webContact", website
         FROM public.institutions
         WHERE id = $1
         """;
@@ -65,7 +65,7 @@ public class HarvestScheduleStoreServiceImpl implements HarvestScheduleStoreServ
      * The insert query for institutions.
      */
     private static final String ADD_INST = """
-        INSERT INTO public.institutions (name, description, location, email, phone, webcontact, website)
+        INSERT INTO public.institutions (name, description, location, email, phone, webContact, website)
         VALUES (#{name}, #{description}, #{location}, #{email}, #{phone}, #{webContact}, #{website})
         RETURNING id
         """;
@@ -74,7 +74,7 @@ public class HarvestScheduleStoreServiceImpl implements HarvestScheduleStoreServ
      * The select query for all institutions.
      */
     private static final String LIST_INSTS = """
-        SELECT id, name, description, location, email, phone, webcontact AS "webContact", website
+        SELECT id, name, description, location, email, phone, webContact AS "webContact", website
         FROM public.institutions
         ORDER BY name
         """;
@@ -90,7 +90,7 @@ public class HarvestScheduleStoreServiceImpl implements HarvestScheduleStoreServ
     private static final String UPDATE_INST = """
         UPDATE public.institutions
         SET name = #{name}, description = #{description}, location = #{location}, email = #{email}, phone = #{phone},
-            webcontact = #{webContact}, website = #{website}
+            webContact = #{webContact}, website = #{website}
         WHERE id = #{id}
         """;
 
@@ -99,9 +99,9 @@ public class HarvestScheduleStoreServiceImpl implements HarvestScheduleStoreServ
      */
     private static final String GET_JOB = """
         SELECT
-            institutionid AS "institutionID", repositorybaseurl AS "repositoryBaseURL",
-            metadataprefix AS "metadataPrefix", sets, lastsuccessfulrun AS "lastSuccessfulRun",
-            schedulecronexpression AS "scheduleCronExpression"
+            institutionID AS "institutionID", repositoryBaseURL AS "repositoryBaseURL",
+            metadataPrefix AS "metadataPrefix", sets, lastSuccessfulRun AS "lastSuccessfulRun",
+            scheduleCronExpression AS "scheduleCronExpression"
         FROM public.harvestjobs
         WHERE id = $1
         """;
@@ -111,7 +111,7 @@ public class HarvestScheduleStoreServiceImpl implements HarvestScheduleStoreServ
      */
     private static final String ADD_JOB = """
         INSERT INTO public.harvestjobs (
-            institutionid, repositorybaseurl, metadataprefix, sets, lastsuccessfulrun, schedulecronexpression
+            institutionID, repositoryBaseURL, metadataPrefix, sets, lastSuccessfulRun, scheduleCronExpression
         )
         VALUES (
             #{institutionID}, #{repositoryBaseURL}, #{metadataPrefix}, #{sets}, #{lastSuccessfulRun},
@@ -125,9 +125,9 @@ public class HarvestScheduleStoreServiceImpl implements HarvestScheduleStoreServ
      */
     private static final String LIST_JOBS = """
         SELECT
-            id, institutionid AS "institutionID", repositorybaseurl AS "repositoryBaseURL",
-            metadataprefix AS "metadataPrefix", sets, lastsuccessfulrun AS "lastSuccessfulRun",
-            schedulecronexpression AS "scheduleCronExpression"
+            id, institutionID AS "institutionID", repositoryBaseURL AS "repositoryBaseURL",
+            metadataPrefix AS "metadataPrefix", sets, lastSuccessfulRun AS "lastSuccessfulRun",
+            scheduleCronExpression AS "scheduleCronExpression"
         FROM public.harvestjobs
         ORDER BY "institutionID"
         """;
@@ -143,9 +143,9 @@ public class HarvestScheduleStoreServiceImpl implements HarvestScheduleStoreServ
     private static final String UPDATE_JOB = """
         UPDATE public.harvestjobs
         SET
-            repositorybaseurl = #{repositoryBaseURL}, sets = #{sets}, lastsuccessfulrun = #{lastSuccessfulRun},
-            schedulecronexpression = #{scheduleCronExpression}
-        WHERE id = #{id} AND institutionid = #{institutionID}
+        repositoryBaseURL = #{repositoryBaseURL}, sets = #{sets}, lastSuccessfulRun = #{lastSuccessfulRun},
+            scheduleCronExpression = #{scheduleCronExpression}
+        WHERE id = #{id} AND institutionID = #{institutionID}
         """;
 
     /**

--- a/src/main/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreServiceImpl.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreServiceImpl.java
@@ -115,7 +115,7 @@ public class HarvestScheduleStoreServiceImpl implements HarvestScheduleStoreServ
      */
     private static final String LIST_JOBS = """
         SELECT
-            institutionid AS "institutionID", repositorybaseurl AS "repositoryBaseURL",
+            id, institutionid AS "institutionID", repositorybaseurl AS "repositoryBaseURL",
             metadataprefix AS "metadataPrefix", sets, lastsuccessfulrun AS "lastSuccessfulRun",
             schedulecronexpression AS "scheduleCronExpression"
         FROM public.harvestjobs

--- a/src/main/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreServiceImpl.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreServiceImpl.java
@@ -53,11 +53,6 @@ public class HarvestScheduleStoreServiceImpl implements HarvestScheduleStoreServ
     private static final TupleMapper<Job> JOB_MAPPER = TupleMapper.mapper(Job::toSqlTemplateParametersMap);
 
     /**
-     * Constant of ID primary key fields.
-     */
-    private static final String ID = "id";
-
-    /**
      * The select-one query for institutions.
      */
     private static final String GET_INST = """
@@ -226,7 +221,7 @@ public class HarvestScheduleStoreServiceImpl implements HarvestScheduleStoreServ
             LOGGER.error(MessageCodes.PRL_006, error.getMessage());
             return Future.failedFuture(new ServiceException(500, error.getMessage()));
         }).compose(insert -> {
-            return Future.succeededFuture(insert.iterator().next().getInteger(ID));
+            return Future.succeededFuture(insert.iterator().next().getInteger(Institution.ID));
         });
     }
 
@@ -297,7 +292,7 @@ public class HarvestScheduleStoreServiceImpl implements HarvestScheduleStoreServ
             LOGGER.error(MessageCodes.PRL_009, error.getMessage());
             return Future.failedFuture(new ServiceException(500, error.getMessage()));
         }).compose(insert -> {
-            return Future.succeededFuture(insert.iterator().next().getInteger(ID));
+            return Future.succeededFuture(insert.iterator().next().getInteger(Job.ID));
         });
     }
 

--- a/src/main/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreServiceImpl.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreServiceImpl.java
@@ -201,7 +201,7 @@ public class HarvestScheduleStoreServiceImpl implements HarvestScheduleStoreServ
             return connection.preparedQuery(ADD_INST)
                     .execute(Tuple.of(anInstitution.getName(), anInstitution.getDescription(),
                             anInstitution.getLocation(), getOptionalAsString(anInstitution.getEmail()),
-                            getOptionalPhoneAsString(anInstitution.getPhone()),
+                            anInstitution.getPhone().map(PhoneNumber::toString).orElse(null),
                             getOptionalAsString(anInstitution.getWebContact()), anInstitution.getWebsite().toString()));
         }).recover(error -> {
             LOGGER.error(MessageCodes.PRL_006, error.getMessage());
@@ -220,20 +220,6 @@ public class HarvestScheduleStoreServiceImpl implements HarvestScheduleStoreServ
     private String getOptionalAsString(final Optional aParam) {
         if (aParam.isPresent()) {
             return aParam.get().toString();
-        } else {
-            return String.valueOf("");
-        }
-    }
-
-    /**
-     * Converts Optional phone number values to String for use in prepared queries.
-     *
-     * @param aPhoneParam An Optional used as a query param
-     * @return The String representation of the Optional value, or an empty string if Optional is empty
-     */
-    private String getOptionalPhoneAsString(final Optional<PhoneNumber> aPhoneParam) {
-        if (aPhoneParam.isPresent()) {
-            return PHONE_NUMBER_UTIL.format(aPhoneParam.get(), PhoneNumberFormat.INTERNATIONAL);
         } else {
             return String.valueOf("");
         }
@@ -259,7 +245,7 @@ public class HarvestScheduleStoreServiceImpl implements HarvestScheduleStoreServ
             return connection.preparedQuery(UPDATE_INST)
                     .execute(Tuple.of(anInstitution.getName(), anInstitution.getDescription(),
                             anInstitution.getLocation(), getOptionalAsString(anInstitution.getEmail()),
-                            getOptionalPhoneAsString(anInstitution.getPhone()),
+                            anInstitution.getPhone().map(PhoneNumber::toString).orElse(null),
                             getOptionalAsString(anInstitution.getWebContact()), anInstitution.getWebsite().toString(),
                             anInstitutionId));
         }).recover(error -> {

--- a/src/main/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreServiceImpl.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreServiceImpl.java
@@ -136,16 +136,6 @@ public class HarvestScheduleStoreServiceImpl implements HarvestScheduleStoreServ
         """;
 
     /**
-     * The postgres database (and default user) name.
-     */
-    private static final String POSTGRES = "postgres";
-
-    /**
-     * The database's default hostname.
-     */
-    private static final String DEFAULT_HOSTNAME = "localhost";
-
-    /**
      * The failure code to use for a ServiceException that represents {@link Error#INTERNAL_ERROR}.
      */
     private static final int INTERNAL_ERROR = Error.INTERNAL_ERROR.ordinal();
@@ -377,16 +367,11 @@ public class HarvestScheduleStoreServiceImpl implements HarvestScheduleStoreServ
      * @return The database's connection options
      */
     private PgConnectOptions getConnectionOpts(final JsonObject aConfig) {
-        final String dbHost = aConfig.getString(Config.DB_HOST, DEFAULT_HOSTNAME);
-        final int dbPort = aConfig.getInteger(Config.DB_PORT, 5432);
-        final String dbName = aConfig.getString(Config.DB_NAME, POSTGRES);
-        final String dbUser = aConfig.getString(Config.DB_USERNAME, POSTGRES);
-        final String dbPassword = aConfig.getString(Config.DB_PASSWORD);
         final int dbReconnectAttempts = aConfig.getInteger(Config.DB_RECONNECT_ATTEMPTS, 2);
         final long dbReconnectInterval = aConfig.getInteger(Config.DB_RECONNECT_INTERVAL, 1000);
 
-        return new PgConnectOptions().setPort(dbPort).setHost(dbHost).setDatabase(dbName).setUser(dbUser)
-                .setPassword(dbPassword).setReconnectAttempts(dbReconnectAttempts)
+        return PgConnectOptions.fromEnv() //
+                .setReconnectAttempts(dbReconnectAttempts) //
                 .setReconnectInterval(dbReconnectInterval);
     }
 

--- a/src/main/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreServiceImpl.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreServiceImpl.java
@@ -72,7 +72,7 @@ public class HarvestScheduleStoreServiceImpl implements HarvestScheduleStoreServ
      * The select query for all institutions.
      */
     private static final String LIST_INSTS = """
-        SELECT name, description, location, email, phone, webcontact AS "webContact", website
+        SELECT id, name, description, location, email, phone, webcontact AS "webContact", website
         FROM public.institutions
         ORDER BY name
         """;

--- a/src/main/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreServiceImpl.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreServiceImpl.java
@@ -55,9 +55,10 @@ public class HarvestScheduleStoreServiceImpl implements HarvestScheduleStoreServ
      * The select-one query for institutions.
      */
     private static final String GET_INST = """
-        SELECT name, description, location, email, phone, webContact AS "webContact",
-               website FROM public.institutions WHERE id = $1
-               """;
+        SELECT name, description, location, email, phone, webcontact AS "webContact", website
+        FROM public.institutions
+        WHERE id = $1
+        """;
 
     /**
      * The insert query for institutions.
@@ -71,9 +72,10 @@ public class HarvestScheduleStoreServiceImpl implements HarvestScheduleStoreServ
      * The select query for all institutions.
      */
     private static final String LIST_INSTS = """
-        SELECT name, description, location, email, phone,
-               webContact AS "webContact", website FROM public.institutions ORDER BY name
-               """;
+        SELECT name, description, location, email, phone, webcontact AS "webContact", website
+        FROM public.institutions
+        ORDER BY name
+        """;
 
     /**
      * The delete query for an institution.
@@ -92,9 +94,12 @@ public class HarvestScheduleStoreServiceImpl implements HarvestScheduleStoreServ
      * The select-one query for jobs.
      */
     private static final String GET_JOB = """
-        SELECT institutionId AS "institutionID", repositoryBaseUrl AS "repositoryBaseURL",
-        metadataPrefix AS "metadataPrefix", sets, lastSuccessfulRun AS "lastSuccessfulRun",
-        scheduleCronExpression AS "scheduleCronExpression" FROM public.harvestjobs WHERE id = $1
+        SELECT
+            institutionid AS "institutionID", repositorybaseurl AS "repositoryBaseURL",
+            metadataprefix AS "metadataPrefix", sets, lastsuccessfulrun AS "lastSuccessfulRun",
+            schedulecronexpression AS "scheduleCronExpression"
+        FROM public.harvestjobs
+        WHERE id = $1
         """;
 
     /**
@@ -109,10 +114,13 @@ public class HarvestScheduleStoreServiceImpl implements HarvestScheduleStoreServ
      * The select query for all jobs.
      */
     private static final String LIST_JOBS = """
-        SELECT institutionId AS "institutionID", repositoryBaseUrl AS "repositoryBaseURL",
-               metadataPrefix AS "metadataPrefix", sets, lastSuccessfulRun AS "lastSuccessfulRun",
-               scheduleCronExpression AS "scheduleCronExpression" FROM public.harvestjobs ORDER BY "institutionID"
-               """;
+        SELECT
+            institutionid AS "institutionID", repositorybaseurl AS "repositoryBaseURL",
+            metadataprefix AS "metadataPrefix", sets, lastsuccessfulrun AS "lastSuccessfulRun",
+            schedulecronexpression AS "scheduleCronExpression"
+        FROM public.harvestjobs
+        ORDER BY "institutionID"
+        """;
 
     /**
      * The delete query for a job.

--- a/src/main/resources/prl-harvester_messages.xml
+++ b/src/main/resources/prl-harvester_messages.xml
@@ -24,5 +24,6 @@
   <entry key="PRL_016">Job found for fake nstitution ID: {}</entry>
   <entry key="PRL_017">{} {} -> HTTP {} ({})</entry>
   <entry key="PRL_018">Thumbnail image for {} found at: {}</entry>
+  <entry key="PRL_019">Failed institution update: no match for institution ID {}</entry>
 
 </properties>

--- a/src/test/java/edu/ucla/library/prl/harvester/InstitutionTest.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/InstitutionTest.java
@@ -2,6 +2,7 @@
 package edu.ucla.library.prl.harvester;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.net.MalformedURLException;
@@ -121,6 +122,42 @@ public class InstitutionTest {
                         Optional.empty(), exampleWebsite),
                 Arguments.of(exampleName, exampleDescription, exampleLocation, Optional.empty(), Optional.empty(),
                         exampleWebContact, exampleWebsite));
+    }
+
+    /**
+     * Tests that {@link Institution#withID} adds an ID to the otherwise-unchanged {@link Institution}.
+     *
+     * @param aName The institution's name
+     * @param aDescription The institution's description
+     * @param aLocation The institution's human-readable location
+     * @param anEmail The institution's optional email contact
+     * @param aPhone The institution's optional phone contact
+     * @param aWebContact The institution's optional web contact
+     * @param aWebsite The institiution's website
+     */
+    @ParameterizedTest
+    @MethodSource
+    void testInstitutionWithID(final String aName, final String aDescription, final String aLocation,
+            final Optional<InternetAddress> anEmail, final Optional<PhoneNumber> aPhone,
+            final Optional<URL> aWebContact, final URL aWebsite) {
+        final Institution institution =
+                new Institution(aName, aDescription, aLocation, anEmail, aPhone, aWebContact, aWebsite);
+        final int institutionID = 1;
+        final Institution institutionWithID = Institution.withID(institution, institutionID);
+
+        assertNotEquals(institution.toJson(), institutionWithID.toJson());
+        assertEquals(institution.toJson().put("id", institutionID), institutionWithID.toJson());
+    }
+
+    /**
+     * @return The arguments for the corresponding {@link ParameterizedTest}
+     * @throws AddressException
+     * @throws MalformedURLException
+     * @throws NumberParseException
+     */
+    static Stream<Arguments> testInstitutionWithID()
+            throws AddressException, MalformedURLException, NumberParseException {
+        return testInstitutionSerDe();
     }
 
     /**

--- a/src/test/java/edu/ucla/library/prl/harvester/JobTest.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/JobTest.java
@@ -2,6 +2,7 @@
 package edu.ucla.library.prl.harvester;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.net.MalformedURLException;
@@ -92,6 +93,37 @@ public class JobTest {
                 Arguments.of(3, exampleURL, List.of(), exampleSchedule, exampleTimestamp), //
                 Arguments.of(4, exampleURL, exampleSets, exampleSchedule, null), //
                 Arguments.of(5, exampleURL, exampleSets, exampleSchedule, exampleTimestamp));
+    }
+
+    /**
+     * Tests that {@link Job#withID} adds an ID to the otherwise-unchanged {@link Job}.
+     *
+     * @param anInstitutionID The identifier of the institution that this job should be associated with
+     * @param aRepositoryBaseURL The base URL of the OAI-PMH repository
+     * @param aSets The list of sets to harvest; if empty, assume all sets should be harvested
+     * @param aScheduleCronExpression The schedule on which this job should be run
+     * @param aLastSuccessfulRun The timestamp of the last successful run of this job; will be null at first
+     */
+    @ParameterizedTest
+    @MethodSource
+    void testJobWithID(final int anInstitutionID, final URL aRepositoryBaseURL, final List<String> aSets,
+            final CronExpression aScheduleCronExpression, final OffsetDateTime aLastSuccessfulRun) {
+        final Job job =
+                new Job(anInstitutionID, aRepositoryBaseURL, aSets, aScheduleCronExpression, aLastSuccessfulRun);
+        final int jobID = 1;
+        final Job jobWithID = Job.withID(job, jobID);
+
+        assertNotEquals(job.toJson(), jobWithID.toJson());
+        assertEquals(job.toJson().put("id", jobID), jobWithID.toJson());
+    }
+
+    /**
+     * @return The arguments for the corresponding {@link ParameterizedTest}
+     * @throws MalformedURLException
+     * @throws ParseException
+     */
+    static Stream<Arguments> testJobWithID() throws MalformedURLException, ParseException {
+        return testJobSerDe();
     }
 
     /**

--- a/src/test/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreServiceIT.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreServiceIT.java
@@ -170,6 +170,7 @@ public class HarvestScheduleStoreServiceIT {
                 assertTrue(instList != null);
                 assertTrue(instList.size() >= 3);
                 assertTrue(instList.get(0).getName().equals(SAMPLE_NAME));
+                assertTrue(instList.get(0).getID().isPresent());
             }).completeNow();
         }).onFailure(aContext::failNow);
     }

--- a/src/test/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreServiceIT.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreServiceIT.java
@@ -298,6 +298,7 @@ public class HarvestScheduleStoreServiceIT {
                 assertTrue(jobList != null);
                 assertTrue(jobList.size() >= 3);
                 assertTrue(jobList.get(0).getScheduleCronExpression().toString().equals(SAMPLE_CRON));
+                assertTrue(jobList.get(0).getID().isPresent());
             }).completeNow();
         }).onFailure(aContext::failNow);
     }

--- a/src/test/resources/db/prldb.sql
+++ b/src/test/resources/db/prldb.sql
@@ -191,7 +191,7 @@ GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO prl;
 -- sample entires for unit/integration test
 --
 
-INSERT INTO public.institutions(name, description, location, email, phone, webContact, website) VALUES('Sample 1', 'A sample institution', 'Here', 'this@that.com', '+1 888 123 4567', 'http://acme.edu/1/contact', 'http://acme.edu/1');
+INSERT INTO public.institutions(name, description, location, email, phone, webContact, website) VALUES('Sample 1', 'A sample institution', 'Here', 'this@that.com', null, 'http://acme.edu/1/contact', 'http://acme.edu/1');
 INSERT INTO public.institutions(name, description, location, email, phone, webContact, website) VALUES('Sample 2', 'Another sample', 'There', 'that@theother.com', '+1 888 890 1234', 'http://acme.edu/1/contact', 'http://acme.edu/1');
 INSERT INTO public.institutions(name, description, location, email, phone, webContact, website) VALUES('Sample 3', 'A third sample', 'Everywhere', 'no@where.com', '+1 888 567 8901', 'http://acme.edu/1/contact', 'http://acme.edu/1');
 

--- a/src/test/resources/db/prldb.sql
+++ b/src/test/resources/db/prldb.sql
@@ -41,18 +41,18 @@ CREATE TABLE public.institutions (
     location text NOT NULL,
     email text,
     phone text,
-    webcontact text,
+    webContact text,
     website text NOT NULL
 );
 
 CREATE TABLE public.harvestjobs (
     id SERIAL PRIMARY KEY,
-    institutionid INT,
-    repositorybaseurl TEXT NOT NULL,
-    metadataprefix TEXT NOT NULL,
+    institutionID INT,
+    repositoryBaseURL TEXT NOT NULL,
+    metadataPrefix TEXT NOT NULL,
     sets TEXT [],
-    lastsuccessfulrun TIMESTAMPTZ,
-    schedulecronexpression TEXT NOT NULL
+    lastSuccessfulRun TIMESTAMPTZ,
+    scheduleCronExpression TEXT NOT NULL
 );
 
 ALTER TABLE public.institutions OWNER TO postgres;
@@ -96,10 +96,10 @@ COMMENT ON COLUMN public.institutions.email IS 'The email contact for an institu
 COMMENT ON COLUMN public.institutions.phone IS 'The phone contact for an institution';
 
 --
--- Name: COLUMN institutions.webcontact; Type: COMMENT; Schema: public; Owner: postgres
+-- Name: COLUMN institutions.webContact; Type: COMMENT; Schema: public; Owner: postgres
 --
 
-COMMENT ON COLUMN public.institutions.webcontact IS 'The Web contact for an institution';
+COMMENT ON COLUMN public.institutions.webContact IS 'The Web contact for an institution';
 
 --
 -- Name: COLUMN institutions.website; Type: COMMENT; Schema: public; Owner: postgres
@@ -114,22 +114,22 @@ COMMENT ON COLUMN public.institutions.website IS 'The website for an institution
 COMMENT ON COLUMN public.harvestjobs.id IS 'The unique identifier for a harvest job';
 
 --
--- Name: COLUMN harvestjobs.institutionid; Type: COMMENT; Schema: public; Owner: postgres
+-- Name: COLUMN harvestjobs.institutionID; Type: COMMENT; Schema: public; Owner: postgres
 --
 
-COMMENT ON COLUMN public.harvestjobs.institutionid IS 'The unique identifier for a related institution';
+COMMENT ON COLUMN public.harvestjobs.institutionID IS 'The unique identifier for a related institution';
 
 --
--- Name: COLUMN harvestjobs.repositorybaseurl; Type: COMMENT; Schema: public; Owner: postgres
+-- Name: COLUMN harvestjobs.repositoryBaseURL; Type: COMMENT; Schema: public; Owner: postgres
 --
 
-COMMENT ON COLUMN public.harvestjobs.repositorybaseurl IS 'The base URL for a harvested repository';
+COMMENT ON COLUMN public.harvestjobs.repositoryBaseURL IS 'The base URL for a harvested repository';
 
 --
--- Name: COLUMN harvestjobs.metadataprefix; Type: COMMENT; Schema: public; Owner: postgres
+-- Name: COLUMN harvestjobs.metadataPrefix; Type: COMMENT; Schema: public; Owner: postgres
 --
 
-COMMENT ON COLUMN public.harvestjobs.metadataprefix IS 'The metadata prefix for a harvest job';
+COMMENT ON COLUMN public.harvestjobs.metadataPrefix IS 'The metadata prefix for a harvest job';
 
 --
 -- Name: COLUMN harvestjobs.sets; Type: COMMENT; Schema: public; Owner: postgres
@@ -138,30 +138,30 @@ COMMENT ON COLUMN public.harvestjobs.metadataprefix IS 'The metadata prefix for 
 COMMENT ON COLUMN public.harvestjobs.sets IS 'The array of harvest sets';
 
 --
--- Name: COLUMN harvestjobs.lastsuccessfulrun; Type: COMMENT; Schema: public; Owner: postgres
+-- Name: COLUMN harvestjobs.lastSuccessfulRun; Type: COMMENT; Schema: public; Owner: postgres
 --
 
-COMMENT ON COLUMN public.harvestjobs.lastsuccessfulrun IS 'The timestamp for the last successful harvest';
+COMMENT ON COLUMN public.harvestjobs.lastSuccessfulRun IS 'The timestamp for the last successful harvest';
 
 --
--- Name: COLUMN harvestjobs.schedulecronexpression; Type: COMMENT; Schema: public; Owner: postgres
+-- Name: COLUMN harvestjobs.scheduleCronExpression; Type: COMMENT; Schema: public; Owner: postgres
 --
 
-COMMENT ON COLUMN public.harvestjobs.schedulecronexpression IS 'The cron expression for a harvest job';
+COMMENT ON COLUMN public.harvestjobs.scheduleCronExpression IS 'The cron expression for a harvest job';
 
 --
 -- Name: items; Type: TABLE DATA; Schema: public; Owner: postgres
 --
 
-COPY public.institutions (id, name, description, location, email, phone, webcontact, website) FROM stdin;
+COPY public.institutions (id, name, description, location, email, phone, webContact, website) FROM stdin;
 \.
 
 --
 -- Name: origins; Type: TABLE DATA; Schema: public; Owner: postgres
 --
 
-COPY public.harvestjobs (id, institutionid, repositorybaseurl, metadataprefix, sets, lastsuccessfulrun,
-  schedulecronexpression) FROM stdin;
+COPY public.harvestjobs (id, institutionID, repositoryBaseURL, metadataPrefix, sets, lastSuccessfulRun,
+  scheduleCronExpression) FROM stdin;
 \.
 
 --
@@ -169,7 +169,7 @@ COPY public.harvestjobs (id, institutionid, repositorybaseurl, metadataprefix, s
 --
 
 ALTER TABLE ONLY public.harvestjobs
-    ADD CONSTRAINT harvestjobs_fkey FOREIGN KEY(institutionid) REFERENCES public.institutions(id);
+    ADD CONSTRAINT harvestjobs_fkey FOREIGN KEY(institutionID) REFERENCES public.institutions(id);
 
 --
 -- Name: TABLE institutions; Type: ACL; Schema: public; Owner: postgres
@@ -191,13 +191,13 @@ GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO prl;
 -- sample entires for unit/integration test
 --
 
-INSERT INTO public.institutions (name, description, location, email, phone, webcontact, website) VALUES ('Sample 1', 'A sample institution', 'Here', 'this@that.com', null, 'http://acme.edu/1/contact', 'http://acme.edu/1');
-INSERT INTO public.institutions (name, description, location, email, phone, webcontact, website) VALUES ('Sample 2', 'Another sample', 'There', 'that@theother.com', '+1 888 890 1234', 'http://acme.edu/1/contact', 'http://acme.edu/1');
-INSERT INTO public.institutions (name, description, location, email, phone, webcontact, website) VALUES ('Sample 3', 'A third sample', 'Everywhere', 'no@where.com', '+1 888 567 8901', 'http://acme.edu/1/contact', 'http://acme.edu/1');
+INSERT INTO public.institutions (name, description, location, email, phone, webContact, website) VALUES ('Sample 1', 'A sample institution', 'Here', 'this@that.com', null, 'http://acme.edu/1/contact', 'http://acme.edu/1');
+INSERT INTO public.institutions (name, description, location, email, phone, webContact, website) VALUES ('Sample 2', 'Another sample', 'There', 'that@theother.com', '+1 888 890 1234', 'http://acme.edu/1/contact', 'http://acme.edu/1');
+INSERT INTO public.institutions (name, description, location, email, phone, webContact, website) VALUES ('Sample 3', 'A third sample', 'Everywhere', 'no@where.com', '+1 888 567 8901', 'http://acme.edu/1/contact', 'http://acme.edu/1');
 
 
-INSERT INTO public.harvestjobs (institutionid, repositorybaseurl, metadataprefix, sets, lastsuccessfulrun, schedulecronexpression) VALUES (1, 'http://acme.edu/', 'oai_dc', '{this, that, the_other}', '2020-01-08 04:05:06 -8:00', '0 0/30 8-9 5,20 * ?');
-INSERT INTO public.harvestjobs (institutionid, repositorybaseurl, metadataprefix, sets, lastsuccessfulrun, schedulecronexpression) VALUES (2, 'http://acme.edu/', 'oai_dc', '{this, that, the_other}', '2020-01-08 04:05:06 -8:00', '0 0/30 8-9 5,20 * ?');
-INSERT INTO public.harvestjobs (institutionid, repositorybaseurl, metadataprefix, sets, lastsuccessfulrun, schedulecronexpression) VALUES (3, 'http://acme.edu/', 'oai_dc', '{this, that, the_other}', '2020-01-08 04:05:06 -8:00', '0 0/30 8-9 5,20 * ?');
+INSERT INTO public.harvestjobs (institutionID, repositoryBaseURL, metadataPrefix, sets, lastSuccessfulRun, scheduleCronExpression) VALUES (1, 'http://acme.edu/', 'oai_dc', '{this, that, the_other}', '2020-01-08 04:05:06 -8:00', '0 0/30 8-9 5,20 * ?');
+INSERT INTO public.harvestjobs (institutionID, repositoryBaseURL, metadataPrefix, sets, lastSuccessfulRun, scheduleCronExpression) VALUES (2, 'http://acme.edu/', 'oai_dc', '{this, that, the_other}', '2020-01-08 04:05:06 -8:00', '0 0/30 8-9 5,20 * ?');
+INSERT INTO public.harvestjobs (institutionID, repositoryBaseURL, metadataPrefix, sets, lastSuccessfulRun, scheduleCronExpression) VALUES (3, 'http://acme.edu/', 'oai_dc', '{this, that, the_other}', '2020-01-08 04:05:06 -8:00', '0 0/30 8-9 5,20 * ?');
 
 

--- a/src/test/resources/db/prldb.sql
+++ b/src/test/resources/db/prldb.sql
@@ -41,18 +41,18 @@ CREATE TABLE public.institutions (
     location text NOT NULL,
     email text,
     phone text,
-    webContact text,
+    webcontact text,
     website text NOT NULL
 );
 
 CREATE TABLE public.harvestjobs (
     id SERIAL PRIMARY KEY,
-    institutionID INT,
-    repositoryBaseURL TEXT NOT NULL,
-    metadataPrefix TEXT NOT NULL,
+    institutionid INT,
+    repositorybaseurl TEXT NOT NULL,
+    metadataprefix TEXT NOT NULL,
     sets TEXT [],
-    lastSuccessfulRun TIMESTAMPTZ,
-    scheduleCronExpression TEXT NOT NULL
+    lastsuccessfulrun TIMESTAMPTZ,
+    schedulecronexpression TEXT NOT NULL
 );
 
 ALTER TABLE public.institutions OWNER TO postgres;
@@ -96,10 +96,10 @@ COMMENT ON COLUMN public.institutions.email IS 'The email contact for an institu
 COMMENT ON COLUMN public.institutions.phone IS 'The phone contact for an institution';
 
 --
--- Name: COLUMN institutions.webContact; Type: COMMENT; Schema: public; Owner: postgres
+-- Name: COLUMN institutions.webcontact; Type: COMMENT; Schema: public; Owner: postgres
 --
 
-COMMENT ON COLUMN public.institutions.webContact IS 'The Web contact for an institution';
+COMMENT ON COLUMN public.institutions.webcontact IS 'The Web contact for an institution';
 
 --
 -- Name: COLUMN institutions.website; Type: COMMENT; Schema: public; Owner: postgres
@@ -114,22 +114,22 @@ COMMENT ON COLUMN public.institutions.website IS 'The website for an institution
 COMMENT ON COLUMN public.harvestjobs.id IS 'The unique identifier for a harvest job';
 
 --
--- Name: COLUMN harvestjobs.institutionID; Type: COMMENT; Schema: public; Owner: postgres
+-- Name: COLUMN harvestjobs.institutionid; Type: COMMENT; Schema: public; Owner: postgres
 --
 
-COMMENT ON COLUMN public.harvestjobs.institutionID IS 'The unique identifier for a related institution';
+COMMENT ON COLUMN public.harvestjobs.institutionid IS 'The unique identifier for a related institution';
 
 --
--- Name: COLUMN harvestjobs.repositoryBaseURL; Type: COMMENT; Schema: public; Owner: postgres
+-- Name: COLUMN harvestjobs.repositorybaseurl; Type: COMMENT; Schema: public; Owner: postgres
 --
 
-COMMENT ON COLUMN public.harvestjobs.repositoryBaseURL IS 'The base URL for a harvested repository';
+COMMENT ON COLUMN public.harvestjobs.repositorybaseurl IS 'The base URL for a harvested repository';
 
 --
--- Name: COLUMN harvestjobs.metadataPrefix; Type: COMMENT; Schema: public; Owner: postgres
+-- Name: COLUMN harvestjobs.metadataprefix; Type: COMMENT; Schema: public; Owner: postgres
 --
 
-COMMENT ON COLUMN public.harvestjobs.metadataPrefix IS 'The metadata prefix for a harvest job';
+COMMENT ON COLUMN public.harvestjobs.metadataprefix IS 'The metadata prefix for a harvest job';
 
 --
 -- Name: COLUMN harvestjobs.sets; Type: COMMENT; Schema: public; Owner: postgres
@@ -138,30 +138,30 @@ COMMENT ON COLUMN public.harvestjobs.metadataPrefix IS 'The metadata prefix for 
 COMMENT ON COLUMN public.harvestjobs.sets IS 'The array of harvest sets';
 
 --
--- Name: COLUMN harvestjobs.lastSuccessfulRun; Type: COMMENT; Schema: public; Owner: postgres
+-- Name: COLUMN harvestjobs.lastsuccessfulrun; Type: COMMENT; Schema: public; Owner: postgres
 --
 
-COMMENT ON COLUMN public.harvestjobs.lastSuccessfulRun IS 'The timestamp for the last successful harvest';
+COMMENT ON COLUMN public.harvestjobs.lastsuccessfulrun IS 'The timestamp for the last successful harvest';
 
 --
--- Name: COLUMN harvestjobs.scheduleCronExpression; Type: COMMENT; Schema: public; Owner: postgres
+-- Name: COLUMN harvestjobs.schedulecronexpression; Type: COMMENT; Schema: public; Owner: postgres
 --
 
-COMMENT ON COLUMN public.harvestjobs.scheduleCronExpression IS 'The cron expression for a harvest job';
+COMMENT ON COLUMN public.harvestjobs.schedulecronexpression IS 'The cron expression for a harvest job';
 
 --
 -- Name: items; Type: TABLE DATA; Schema: public; Owner: postgres
 --
 
-COPY public.institutions (id, name, description, location, email, phone, webContact, website) FROM stdin;
+COPY public.institutions (id, name, description, location, email, phone, webcontact, website) FROM stdin;
 \.
 
 --
 -- Name: origins; Type: TABLE DATA; Schema: public; Owner: postgres
 --
 
-COPY public.harvestjobs (id, institutionID, repositoryBaseURL, metadataPrefix, sets, lastSuccessfulRun,
-  scheduleCronExpression) FROM stdin;
+COPY public.harvestjobs (id, institutionid, repositorybaseurl, metadataprefix, sets, lastsuccessfulrun,
+  schedulecronexpression) FROM stdin;
 \.
 
 --
@@ -169,7 +169,7 @@ COPY public.harvestjobs (id, institutionID, repositoryBaseURL, metadataPrefix, s
 --
 
 ALTER TABLE ONLY public.harvestjobs
-    ADD CONSTRAINT harvestjobs_fkey FOREIGN KEY(institutionID) REFERENCES public.institutions(id);
+    ADD CONSTRAINT harvestjobs_fkey FOREIGN KEY(institutionid) REFERENCES public.institutions(id);
 
 --
 -- Name: TABLE institutions; Type: ACL; Schema: public; Owner: postgres
@@ -191,13 +191,13 @@ GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO prl;
 -- sample entires for unit/integration test
 --
 
-INSERT INTO public.institutions(name, description, location, email, phone, webContact, website) VALUES('Sample 1', 'A sample institution', 'Here', 'this@that.com', null, 'http://acme.edu/1/contact', 'http://acme.edu/1');
-INSERT INTO public.institutions(name, description, location, email, phone, webContact, website) VALUES('Sample 2', 'Another sample', 'There', 'that@theother.com', '+1 888 890 1234', 'http://acme.edu/1/contact', 'http://acme.edu/1');
-INSERT INTO public.institutions(name, description, location, email, phone, webContact, website) VALUES('Sample 3', 'A third sample', 'Everywhere', 'no@where.com', '+1 888 567 8901', 'http://acme.edu/1/contact', 'http://acme.edu/1');
+INSERT INTO public.institutions (name, description, location, email, phone, webcontact, website) VALUES ('Sample 1', 'A sample institution', 'Here', 'this@that.com', null, 'http://acme.edu/1/contact', 'http://acme.edu/1');
+INSERT INTO public.institutions (name, description, location, email, phone, webcontact, website) VALUES ('Sample 2', 'Another sample', 'There', 'that@theother.com', '+1 888 890 1234', 'http://acme.edu/1/contact', 'http://acme.edu/1');
+INSERT INTO public.institutions (name, description, location, email, phone, webcontact, website) VALUES ('Sample 3', 'A third sample', 'Everywhere', 'no@where.com', '+1 888 567 8901', 'http://acme.edu/1/contact', 'http://acme.edu/1');
 
 
-INSERT INTO public.harvestjobs(institutionID, repositoryBaseURL, metadataPrefix, sets, lastSuccessfulRun, scheduleCronExpression) VALUES(1, 'http://acme.edu/', 'oai_dc', '{this, that, the_other}', '2020-01-08 04:05:06 -8:00', '0 0/30 8-9 5,20 * ?');
-INSERT INTO public.harvestjobs(institutionID, repositoryBaseURL, metadataPrefix, sets, lastSuccessfulRun, scheduleCronExpression) VALUES(2, 'http://acme.edu/', 'oai_dc', '{this, that, the_other}', '2020-01-08 04:05:06 -8:00', '0 0/30 8-9 5,20 * ?');
-INSERT INTO public.harvestjobs(institutionID, repositoryBaseURL, metadataPrefix, sets, lastSuccessfulRun, scheduleCronExpression) VALUES(3, 'http://acme.edu/', 'oai_dc', '{this, that, the_other}', '2020-01-08 04:05:06 -8:00', '0 0/30 8-9 5,20 * ?');
+INSERT INTO public.harvestjobs (institutionid, repositorybaseurl, metadataprefix, sets, lastsuccessfulrun, schedulecronexpression) VALUES (1, 'http://acme.edu/', 'oai_dc', '{this, that, the_other}', '2020-01-08 04:05:06 -8:00', '0 0/30 8-9 5,20 * ?');
+INSERT INTO public.harvestjobs (institutionid, repositorybaseurl, metadataprefix, sets, lastsuccessfulrun, schedulecronexpression) VALUES (2, 'http://acme.edu/', 'oai_dc', '{this, that, the_other}', '2020-01-08 04:05:06 -8:00', '0 0/30 8-9 5,20 * ?');
+INSERT INTO public.harvestjobs (institutionid, repositorybaseurl, metadataprefix, sets, lastsuccessfulrun, schedulecronexpression) VALUES (3, 'http://acme.edu/', 'oai_dc', '{this, that, the_other}', '2020-01-08 04:05:06 -8:00', '0 0/30 8-9 5,20 * ?');
 
 


### PR DESCRIPTION
The main change here is in the way that prepared queries are constructed for insert and update operations. The database service no longer implements its own "&lt;type&gt;-to-parameters" logic; this is now (re-)implemented as static methods on Institution and Job, and which each `toJson` is now implemented in terms of:

- For Institution, this is trivial; it simply wraps the parameters map in a JsonObject;
- For Job, there is a slight wrinkle due to the types of objects that Vert.x SQL templates expects arrays and timestamps to be represented as, but I think it's still rather straightforward (and I've left some comments that attempt to explain).

This new approach was possible by changing the prepared query templates from using positional parameters (e.g. `$1`) to named parameters (e.g. `${institutionID}`). Each of these names must match a key in the parameters map. This is why, although it seems like a pre-emptive change, I have added record IDs to Institution and Job; the update queries now expect the maps to have an `id` key. Consequently, the database service has been changed so that listInstitutions and listJobs return Institutions and Jobs that contain the ids assigned by the database.

Non-essential changes:

- Utilizing the fact that we're using standard Postgres env vars to configure the app, the database connection is simply configured using `PgConnectOptions#fromEnv` (407f43bd3f12f9748dbc668d8446ea5e23a48796);
- I lowercased all column name references to make it more apparent that this is how Postgres represents them (1e32577f25efeaabf01566d9fb2e5e2eb904b50f) -- of course the benefit of this is debatable because it's a no-op, and camelCase is perhaps easier for the eye to parse even if slightly misleading;
- I formatted the rest of the SQL query Heredocs to make them easier to read (716e9f351173e5a16f8a5a300494c5cf91ad80a8).