### PR TITLE
[SERV-547] Implement Job Scheduler Service constructor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -395,6 +395,9 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <argLine>${jacoco.agent.arg}</argLine>
+          <configuration>
+            <parallel>all</parallel>
+          </configuration>
           <systemPropertyVariables>
             <vertx.logger-delegate-factory-class-name>io.vertx.core.logging.SLF4JLogDelegateFactory</vertx.logger-delegate-factory-class-name>
           </systemPropertyVariables>
@@ -409,6 +412,9 @@
         <artifactId>maven-failsafe-plugin</artifactId>
         <configuration>
           <argLine>${jacoco.agent.arg}</argLine>
+          <configuration>
+            <parallel>none</parallel><!-- This is intended to allow test classes to use shared database/HTTP connection pools without throwing IllegalStateException -->
+          </configuration>
           <environmentVariables>
             <HARVEST_TIMEOUT>86400000</HARVEST_TIMEOUT><!-- 1 day -->
             <HTTP_PORT>${test.harvester.port}</HTTP_PORT>

--- a/pom.xml
+++ b/pom.xml
@@ -445,7 +445,7 @@
         <executions>
           <execution>
             <id>joai-checkout</id>
-            <phase>generate-test-resources</phase>
+            <phase>pre-integration-test</phase>
             <goals>
               <goal>checkout</goal>
             </goals>
@@ -475,7 +475,7 @@
         <executions>
           <execution>
             <id>patch-joai-Dockerfile</id>
-            <phase>generate-test-resources</phase>
+            <phase>pre-integration-test</phase>
             <goals>
               <goal>apply</goal>
             </goals>

--- a/src/main/java/edu/ucla/library/prl/harvester/Institution.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/Institution.java
@@ -149,9 +149,6 @@ public final class Institution {
      * Instantiates an institution from its JSON representation.
      * <p>
      * Note that the JSON representation may contain an ID, which must have been assigned by the database.
-     * <p>
-     * <b>This constructor is meant to be used only by the service code (generated or otherwise)!</b>
-     * {@link #Institution(String, String, String, Optional, Optional, Optional, URL)} should be used everywhere else.
      *
      * @param aJsonObject An institution represented as JSON
      * @throws InvalidInstitutionJsonException If the JSON representation is invalid

--- a/src/main/java/edu/ucla/library/prl/harvester/Job.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/Job.java
@@ -114,9 +114,6 @@ public final class Job {
      * Instantiates a job from its JSON representation.
      * <p>
      * Note that the JSON representation may contain an ID, which must have been assigned by the database.
-     * <p>
-     * <b>This constructor is meant to be used only by the service code (generated or otherwise)!</b>
-     * {@link #Job(int, URL, List, CronExpression, OffsetDateTime)} should be used everywhere else.
      *
      * @param aJsonObject A job represented as JSON
      * @throws InvalidJobJsonException If the JSON representation is invalid

--- a/src/main/java/edu/ucla/library/prl/harvester/JobResult.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/JobResult.java
@@ -59,9 +59,6 @@ public class JobResult {
 
     /**
      * Instantiates a job result from its JSON representation.
-     * <p>
-     * <b>This constructor is meant to be used only by generated service proxy code!</b>
-     * {@link #JobResult(int, OffsetDateTime, int)} should be used everywhere else.
      *
      * @param aJsonObject A job result represented as JSON
      * @throws InvalidJobResultJsonException If the JSON representation is invalid

--- a/src/main/java/edu/ucla/library/prl/harvester/JobResult.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/JobResult.java
@@ -15,6 +15,11 @@ import io.vertx.core.json.JsonObject;
 public class JobResult {
 
     /**
+     * The JSON key for the job ID.
+     */
+    static final String JOB_ID = "jobID";
+
+    /**
      * The JSON key for the start time.
      */
     static final String START_TIME = "startTime";
@@ -23,6 +28,11 @@ public class JobResult {
      * The JSON key for the record count.
      */
     static final String RECORD_COUNT = "recordCount";
+
+    /**
+     * The ID of the associated job.
+     */
+    private final int myJobID;
 
     /**
      * The time when the job was started.
@@ -37,10 +47,12 @@ public class JobResult {
     /**
      * Instantiates a job result.
      *
+     * @param aJobID The ID of the associated job
      * @param aStartTime The time when the job was started
      * @param aRecordCount The number of records harvested
      */
-    public JobResult(final OffsetDateTime aStartTime, final int aRecordCount) {
+    public JobResult(final int aJobID, final OffsetDateTime aStartTime, final int aRecordCount) {
+        myJobID = aJobID;
         myStartTime = Objects.requireNonNull(aStartTime);
         myRecordCount = aRecordCount;
     }
@@ -49,16 +61,28 @@ public class JobResult {
      * Instantiates a job result from its JSON representation.
      * <p>
      * <b>This constructor is meant to be used only by generated service proxy code!</b>
-     * {@link #JobResult(OffsetDateTime, int)} should be used everywhere else.
+     * {@link #JobResult(int, OffsetDateTime, int)} should be used everywhere else.
      *
      * @param aJsonObject A job result represented as JSON
      * @throws InvalidJobResultJsonException If the JSON representation is invalid
      */
+    @SuppressWarnings({ "PMD.AvoidLiteralsInIfCondition", "PMD.CyclomaticComplexity" })
     public JobResult(final JsonObject aJsonObject) {
         Objects.requireNonNull(aJsonObject);
 
+        final Integer jobID = aJsonObject.getInteger(JOB_ID);
         final String startTime = aJsonObject.getString(START_TIME);
         final Integer recordCount = aJsonObject.getInteger(RECORD_COUNT);
+
+        if (jobID != null) {
+            if (jobID >= 1) {
+                myJobID = jobID.intValue();
+            } else {
+                throw new InvalidJobResultJsonException(MessageCodes.PRL_004, JOB_ID, jobID);
+            }
+        } else {
+            throw new InvalidJobResultJsonException(MessageCodes.PRL_002, JOB_ID);
+        }
 
         if (startTime != null) {
             try {
@@ -86,7 +110,17 @@ public class JobResult {
      * @return The JSON representation of the job result
      */
     public JsonObject toJson() {
-        return new JsonObject().put(START_TIME, getStartTime().toString()).put(RECORD_COUNT, getRecordCount());
+        return new JsonObject() //
+                .put(JOB_ID, getJobID()) //
+                .put(START_TIME, getStartTime().toString()) //
+                .put(RECORD_COUNT, getRecordCount());
+    }
+
+    /**
+     * @return The job ID
+     */
+    public int getJobID() {
+        return myJobID;
     }
 
     /**

--- a/src/main/java/edu/ucla/library/prl/harvester/services/HarvestJobSchedulerService.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/services/HarvestJobSchedulerService.java
@@ -11,7 +11,6 @@ import io.vertx.codegen.annotations.ProxyClose;
 import io.vertx.codegen.annotations.ProxyGen;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.Future;
-import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 import io.vertx.serviceproxy.ServiceProxyBuilder;
@@ -46,15 +45,15 @@ public interface HarvestJobSchedulerService {
      * @return A Future that resolves to the service if it could be instantiated
      */
     static Future<HarvestJobSchedulerService> create(final Vertx aVertx, final JsonObject aConfig) {
-        final Promise<HarvestJobSchedulerService> promise = Promise.promise();
+        final HarvestJobSchedulerServiceImpl service;
 
         try {
-            new HarvestJobSchedulerServiceImpl(aVertx, aConfig, promise);
+            service = new HarvestJobSchedulerServiceImpl(aVertx, aConfig);
         } catch (SchedulerException details) {
-            promise.fail(details);
+            return Future.failedFuture(details);
         }
 
-        return promise.future();
+        return service.initializeScheduler().map(service);
     }
 
     /**

--- a/src/main/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreService.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreService.java
@@ -16,6 +16,7 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.pgclient.PgConnectOptions;
 import io.vertx.pgclient.PgPool;
 import io.vertx.serviceproxy.ServiceProxyBuilder;
+import io.vertx.sqlclient.Pool;
 import io.vertx.sqlclient.PoolOptions;
 
 /**
@@ -36,7 +37,7 @@ public interface HarvestScheduleStoreService {
      * @param aDbConnectionPool A database connection pool
      * @return The service instance
      */
-    static HarvestScheduleStoreService create(final PgPool aDbConnectionPool) {
+    static HarvestScheduleStoreService create(final Pool aDbConnectionPool) {
         return new HarvestScheduleStoreServiceImpl(aDbConnectionPool);
     }
 
@@ -145,7 +146,7 @@ public interface HarvestScheduleStoreService {
      * @param aConfig A configuration
      * @return A connection pool
      */
-    static PgPool getConnectionPool(final Vertx aVertx, JsonObject aConfig) {
+    static Pool getConnectionPool(final Vertx aVertx, JsonObject aConfig) {
         final int dbReconnectAttempts = aConfig.getInteger(Config.DB_RECONNECT_ATTEMPTS, 2);
         final long dbReconnectInterval = aConfig.getInteger(Config.DB_RECONNECT_INTERVAL, 1000);
         final int dbConnectionPoolMaxSize = aConfig.getInteger(Config.DB_CONNECTION_POOL_MAX_SIZE, 5);

--- a/src/main/java/edu/ucla/library/prl/harvester/services/HarvestService.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/services/HarvestService.java
@@ -54,7 +54,7 @@ public interface HarvestService {
     /**
      * Runs a harvest job.
      *
-     * @param aJob The harvest job to run
+     * @param aJob The harvest job to run; this job must have a {@link Job.ID} key
      * @return A Future that succeeds if the harvest job succeeded
      */
     Future<JobResult> run(Job aJob);

--- a/src/main/java/edu/ucla/library/prl/harvester/services/HarvestService.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/services/HarvestService.java
@@ -54,7 +54,7 @@ public interface HarvestService {
     /**
      * Runs a harvest job.
      *
-     * @param aJob The harvest job to run; this job must have a {@link Job.ID} key
+     * @param aJob The harvest job to run; this job must have a {@link Job#ID} key
      * @return A Future that succeeds if the harvest job succeeded
      */
     Future<JobResult> run(Job aJob);

--- a/src/test/java/edu/ucla/library/prl/harvester/JobResultTest.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/JobResultTest.java
@@ -37,11 +37,13 @@ public class JobResultTest {
      */
     @Test
     void testJobResultSerDe() {
+        final int exampleJobID = 1;
         final OffsetDateTime exampleStartTime = OffsetDateTime.parse("2000-01-01T00:00Z");
         final int exampleRecordCount = 10;
 
-        final JobResult jobResult = new JobResult(exampleStartTime, exampleRecordCount);
+        final JobResult jobResult = new JobResult(exampleJobID, exampleStartTime, exampleRecordCount);
         final JsonObject json = new JsonObject() //
+                .put(JobResult.JOB_ID, exampleJobID) //
                 .put(JobResult.START_TIME, exampleStartTime.toString()) //
                 .put(JobResult.RECORD_COUNT, exampleRecordCount);
         final JobResult jobResultFromJson = new JobResult(json);
@@ -58,15 +60,17 @@ public class JobResultTest {
     /**
      * Tests that a {@link JobResult} cannot be instantiated from an invalid JSON representation.
      *
+     * @param aJobID The ID of the associated job
      * @param aStartTime The time when the job was started
      * @param aRecordCount The number of records harvested for the job
      * @param anErrorClass The class of error that we expect instantiation with the above arguments to throw
      */
     @ParameterizedTest
     @MethodSource
-    void testJobResultInvalidJsonRepresentation(final String aStartTime, final Integer aRecordCount,
-            final Class<Exception> anErrorClass) {
+    void testJobResultInvalidJsonRepresentation(final Integer aJobID, final String aStartTime,
+            final Integer aRecordCount, final Class<Exception> anErrorClass) {
         final JsonObject json = new JsonObject() //
+                .put(JobResult.JOB_ID, aJobID) //
                 .put(JobResult.START_TIME, aStartTime) //
                 .put(JobResult.RECORD_COUNT, aRecordCount);
         final Exception error = assertThrows(InvalidJobResultJsonException.class, () -> new JobResult(json));
@@ -87,10 +91,11 @@ public class JobResultTest {
         final String invalidTimestamp = LocalDate.of(2020, 1, 1).toString(); // Missing time component
 
         return Stream.of( //
-                Arguments.of(null, 10, null), //
-                Arguments.of(invalidTimestamp, 50, DateTimeParseException.class), //
-                Arguments.of(validTimestamp, null, null), //
-                Arguments.of(validTimestamp, -1, null));
+                Arguments.of(0, validTimestamp, 5, null), //
+                Arguments.of(1, null, 10, null), //
+                Arguments.of(2, invalidTimestamp, 50, DateTimeParseException.class), //
+                Arguments.of(3, validTimestamp, null, null), //
+                Arguments.of(4, validTimestamp, -1, null));
     }
 
     /**
@@ -98,7 +103,7 @@ public class JobResultTest {
      */
     @Test
     void testJobResultNullArguments() {
-        assertThrows(NullPointerException.class, () -> new JobResult(null, 10));
+        assertThrows(NullPointerException.class, () -> new JobResult(1, null, 10));
     }
 
     /**

--- a/src/test/java/edu/ucla/library/prl/harvester/services/HarvestJobSchedulerServiceIT.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/services/HarvestJobSchedulerServiceIT.java
@@ -1,0 +1,263 @@
+
+package edu.ucla.library.prl.harvester.services;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.text.ParseException;
+import java.time.OffsetDateTime;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+import javax.mail.internet.AddressException;
+
+import org.apache.solr.common.SolrDocumentList;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.quartz.CronExpression;
+import org.quartz.CronScheduleBuilder;
+import org.quartz.CronTrigger;
+import org.quartz.TriggerBuilder;
+
+import com.google.i18n.phonenumbers.NumberParseException;
+
+import edu.ucla.library.prl.harvester.Config;
+import edu.ucla.library.prl.harvester.Institution;
+import edu.ucla.library.prl.harvester.Job;
+import edu.ucla.library.prl.harvester.JobResult;
+import edu.ucla.library.prl.harvester.MessageCodes;
+import edu.ucla.library.prl.harvester.utils.TestUtils;
+
+import info.freelibrary.util.Logger;
+import info.freelibrary.util.LoggerFactory;
+
+import io.ino.solrs.JavaAsyncSolrClient;
+import io.vertx.config.ConfigRetriever;
+import io.vertx.core.CompositeFuture;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.eventbus.EventBus;
+import io.vertx.core.eventbus.MessageConsumer;
+import io.vertx.core.json.JsonObject;
+import io.vertx.junit5.Checkpoint;
+import io.vertx.junit5.Timeout;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import io.vertx.serviceproxy.ServiceBinder;
+import io.vertx.sqlclient.Pool;
+
+/**
+ * Tests {@link HarvestJobSchedulerService}.
+ */
+@ExtendWith(VertxExtension.class)
+@TestInstance(Lifecycle.PER_CLASS)
+public class HarvestJobSchedulerServiceIT {
+
+    private static final Logger LOGGER =
+            LoggerFactory.getLogger(HarvestJobSchedulerServiceIT.class, MessageCodes.BUNDLE);
+
+    private JsonObject myConfig;
+
+    private Pool myDbConnectionPool;
+
+    private JavaAsyncSolrClient mySolrClient;
+
+    private HarvestJobSchedulerService myService;
+
+    private HarvestScheduleStoreService myHarvestScheduleStoreServiceProxy;
+
+    private MessageConsumer<JsonObject> myHarvestService;
+
+    private MessageConsumer<JsonObject> myHarvestScheduleStoreService;
+
+    private URL myTestProviderBaseURL;
+
+    /**
+     * @param aVertx A Vert.x instance
+     * @param aContext A test context
+     */
+    @BeforeAll
+    public void setUp(final Vertx aVertx, final VertxTestContext aContext) {
+        ConfigRetriever.create(aVertx).getConfig().compose(config -> {
+            final ServiceBinder binder = new ServiceBinder(aVertx);
+            final Pool dbConnectionPool = HarvestScheduleStoreService.getConnectionPool(aVertx, config);
+
+            myConfig = config;
+            myDbConnectionPool = dbConnectionPool;
+            mySolrClient = JavaAsyncSolrClient.create(config.getString(Config.SOLR_CORE_URL));
+
+            // Set up HarvestScheduleStoreService
+            final HarvestScheduleStoreService dbService = HarvestScheduleStoreService.create(dbConnectionPool);
+
+            myHarvestScheduleStoreService = binder.setAddress(HarvestScheduleStoreService.ADDRESS)
+                    .register(HarvestScheduleStoreService.class, dbService);
+            myHarvestScheduleStoreServiceProxy = HarvestScheduleStoreService.createProxy(aVertx);
+
+            // Set up HarvestService
+            final HarvestService harvestService = HarvestService.create(aVertx, config);
+
+            myHarvestService = binder.setAddress(HarvestService.ADDRESS).register(HarvestService.class, harvestService);
+
+            try {
+                myTestProviderBaseURL = new URL(config.getString(Config.TEST_PROVIDER_BASE_URL));
+            } catch (final MalformedURLException details) {
+                return Future.failedFuture(details);
+            }
+
+            return Future.succeededFuture();
+        }).onSuccess(nil -> aContext.completeNow()).onFailure(aContext::failNow);
+    }
+
+    /**
+     * @param aVertx A Vert.x instance
+     * @param aContext A test context
+     */
+    @AfterEach
+    public void afterEach(final Vertx aVertx, final VertxTestContext aContext) {
+        final CompositeFuture wipeBackingServices =
+                CompositeFuture.all(TestUtils.wipeDatabase(myDbConnectionPool), TestUtils.wipeSolr(mySolrClient));
+
+        wipeBackingServices.compose(nil -> {
+            if (myService != null) {
+                return myService.close();
+            } else {
+                return Future.succeededFuture();
+            }
+        }).onSuccess(nil -> aContext.completeNow()).onFailure(aContext::failNow);
+    }
+
+    /**
+     * @param aVertx A Vert.x instance
+     * @param aContext A test context
+     */
+    @AfterAll
+    public void tearDown(final Vertx aVertx, final VertxTestContext aContext) {
+        myHarvestScheduleStoreServiceProxy.close().compose(nil -> {
+            mySolrClient.shutdown();
+
+            return myDbConnectionPool.close();
+        }).onSuccess(nil -> aContext.completeNow()).onFailure(aContext::failNow);
+    }
+
+    /**
+     * Tests that a service instance triggers the near-future job(s) that were already in the database before
+     * instantiation.
+     *
+     * @param aVertx A Vert.x instance
+     * @param aContext A test context
+     */
+    @Test
+    @Timeout(value = 90, timeUnit = TimeUnit.SECONDS)
+    public void testInstantiationExistingJob(final Vertx aVertx, final VertxTestContext aContext) {
+        final Checkpoint serviceSaved = aContext.checkpoint();
+
+        // Add jobs before instantiation of the service
+        initDB().compose(numberOfJobsCreated -> {
+            final Checkpoint jobResultReceived = aContext.checkpoint(numberOfJobsCreated);
+            final EventBus eb = aVertx.eventBus();
+
+            LOGGER.debug("Database initialized");
+
+            eb.<JsonObject>consumer(HarvestJobSchedulerService.JOB_RESULT_ADDRESS, message -> {
+                final JobResult jobResult = new JobResult(message.body());
+                final CompositeFuture queryBackingServices =
+                        CompositeFuture.all(myHarvestScheduleStoreServiceProxy.getJob(jobResult.getJobID()),
+                                TestUtils.getAllDocuments(mySolrClient));
+
+                queryBackingServices.onSuccess(results -> {
+                    final Job job = results.resultAt(0);
+                    final SolrDocumentList solrDocs = results.resultAt(1);
+
+                    aContext.verify(() -> {
+                        assertEquals(jobResult.getRecordCount(), solrDocs.getNumFound());
+                        assertTrue(job.getLastSuccessfulRun().isPresent());
+                        assertEquals(jobResult.getStartTime().withNano(0).toInstant(),
+                                job.getLastSuccessfulRun().get().withNano(0).toInstant());
+
+                        jobResultReceived.flag();
+                    });
+                });
+            });
+
+            eb.<String>consumer(HarvestJobSchedulerService.ERROR_ADDRESS, message -> {
+                aContext.failNow(message.body());
+            });
+
+            // Instantiate the service after jobs have been added to the database
+            return HarvestJobSchedulerService.create(aVertx, myConfig).onSuccess(service -> {
+                LOGGER.debug("Service instantiated");
+
+                myService = service;
+
+                serviceSaved.flag();
+
+                LOGGER.info("This test may take over a minute to complete, please wait...");
+            });
+        }).onFailure(aContext::failNow);
+    }
+
+    /**
+     * Gets a Cron expression that will match some time in the future.
+     *
+     * @param aMinutesLater The number of minutes in the future to create an hourly Cron expression for
+     * @return The Cron expression
+     * @throws ParseException
+     */
+    private static CronExpression getFutureCronExpression(final int aMinutesLater) throws ParseException {
+        final OffsetDateTime futureTime = OffsetDateTime.now().plusMinutes(aMinutesLater);
+        final CronScheduleBuilder scheduleBuilder =
+                CronScheduleBuilder.dailyAtHourAndMinute(futureTime.getHour(), futureTime.getMinute());
+        final CronTrigger trigger = TriggerBuilder.newTrigger().withSchedule(scheduleBuilder).build();
+
+        LOGGER.debug("Cron expression that will trigger an event in {} minute(s) or less: {}", aMinutesLater,
+                trigger.getCronExpression());
+
+        return new CronExpression(trigger.getCronExpression());
+    }
+
+    /**
+     * @return A Future that resolves to the number of jobs added to the database
+     */
+    private Future<Integer> initDB() {
+        return addInstitution().compose(institutionID -> {
+            @SuppressWarnings("rawtypes")
+            final Function<Job, Future> addJob = aJob -> (Future) myHarvestScheduleStoreServiceProxy.addJob(aJob);
+            final List<Job> jobs = new LinkedList<>();
+            final Job job;
+
+            LOGGER.debug("Institution ID: {}", institutionID);
+
+            try {
+                job = new Job(institutionID, myTestProviderBaseURL, null, getFutureCronExpression(1), null);
+            } catch (final ParseException details) {
+                return Future.failedFuture(details);
+            }
+
+            jobs.add(job);
+
+            return CompositeFuture.all(jobs.stream().map(addJob).toList()).map(jobs.size());
+        });
+    }
+
+    private Future<Integer> addInstitution() {
+        final Institution institution;
+
+        try {
+            institution = TestUtils.getRandomInstitution();
+        } catch (AddressException | MalformedURLException | NumberParseException details) {
+            return Future.failedFuture(details);
+        }
+
+        return myHarvestScheduleStoreServiceProxy.addInstitution(institution);
+    }
+}

--- a/src/test/java/edu/ucla/library/prl/harvester/services/HarvestJobSchedulerServiceIT.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/services/HarvestJobSchedulerServiceIT.java
@@ -46,7 +46,6 @@ import io.vertx.config.ConfigRetriever;
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
-import io.vertx.core.eventbus.EventBus;
 import io.vertx.core.eventbus.MessageConsumer;
 import io.vertx.core.json.JsonObject;
 import io.vertx.junit5.Checkpoint;
@@ -164,11 +163,10 @@ public class HarvestJobSchedulerServiceIT {
         // Add jobs before instantiation of the service
         initDB().compose(numberOfJobsCreated -> {
             final Checkpoint jobResultReceived = aContext.checkpoint(numberOfJobsCreated);
-            final EventBus eb = aVertx.eventBus();
 
             LOGGER.debug("Database initialized");
 
-            eb.<JsonObject>consumer(HarvestJobSchedulerService.JOB_RESULT_ADDRESS, message -> {
+            aVertx.eventBus().<JsonObject>consumer(HarvestJobSchedulerService.JOB_RESULT_ADDRESS, message -> {
                 final JobResult jobResult = new JobResult(message.body());
                 final CompositeFuture queryBackingServices =
                         CompositeFuture.all(myHarvestScheduleStoreServiceProxy.getJob(jobResult.getJobID()),
@@ -189,7 +187,7 @@ public class HarvestJobSchedulerServiceIT {
                 });
             });
 
-            eb.<String>consumer(HarvestJobSchedulerService.ERROR_ADDRESS, message -> {
+            aVertx.eventBus().<String>consumer(HarvestJobSchedulerService.ERROR_ADDRESS, message -> {
                 aContext.failNow(message.body());
             });
 

--- a/src/test/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreServiceIT.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreServiceIT.java
@@ -224,9 +224,9 @@ public class HarvestScheduleStoreServiceIT {
             throws AddressException, MalformedURLException, NumberParseException {
         final Institution toAdd = TestUtils.getRandomInstitution();
 
-        myScheduleStoreProxy.addInstitution(toAdd).onSuccess(result -> {
+        myScheduleStoreProxy.addInstitution(toAdd).onSuccess(institutionID -> {
             aContext.verify(() -> {
-                assertTrue(result.intValue() >= 1);
+                assertTrue(institutionID.intValue() > myTestInstitutionIDs.get(myTestInstitutionIDs.size() - 1));
             }).completeNow();
         }).onFailure(aContext::failNow);
     }
@@ -401,7 +401,7 @@ public class HarvestScheduleStoreServiceIT {
     @Test
     public final void testAddJob(final Vertx aVertx, final VertxTestContext aContext)
             throws AddressException, MalformedURLException, NumberParseException, ParseException {
-        final Job toAdd = TestUtils.getRandomJob();
+        final Job toAdd = TestUtils.getRandomJob(myTestInstitutionIDs.get(0));
 
         myScheduleStoreProxy.addJob(toAdd).onSuccess(result -> {
             aContext.verify(() -> {
@@ -438,7 +438,7 @@ public class HarvestScheduleStoreServiceIT {
     @Test
     public final void testDeleteJob(final Vertx aVertx, final VertxTestContext aContext)
             throws AddressException, MalformedURLException, NumberParseException, ParseException {
-        final Job toDelete = TestUtils.getRandomJob();
+        final Job toDelete = TestUtils.getRandomJob(myTestInstitutionIDs.get(0));
 
         myScheduleStoreProxy.addJob(toDelete).onSuccess(newID -> {
             myScheduleStoreProxy.removeJob(newID).onSuccess(result -> {

--- a/src/test/java/edu/ucla/library/prl/harvester/services/HarvestServiceIT.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/services/HarvestServiceIT.java
@@ -152,8 +152,9 @@ public class HarvestServiceIT {
     public void testRun(final List<String> aSets, final CronExpression aScheduleCronExpression,
             final OffsetDateTime aLastSuccessfulRun, final int anExpectedRecordCount, final Vertx aVertx,
             final VertxTestContext aContext) {
-        final Job job =
-                new Job(myTestInstitutionID, myTestProviderBaseURL, aSets, aScheduleCronExpression, aLastSuccessfulRun);
+        final Job job = Job.withID(
+                new Job(myTestInstitutionID, myTestProviderBaseURL, aSets, aScheduleCronExpression, aLastSuccessfulRun),
+                1);
 
         myHarvestServiceProxy.run(job).onSuccess(jobResult -> {
             TestUtils.getAllDocuments(mySolrClient).onSuccess(queryResults -> {
@@ -226,7 +227,7 @@ public class HarvestServiceIT {
         final CronExpression schedule = new CronExpression("0 * * * * ?");
 
         return Stream.of( //
-                Arguments.of(new Job(1, baseURL, List.of(huxley), schedule, null)));
+                Arguments.of(Job.withID(new Job(1, baseURL, List.of(huxley), schedule, null), 1)));
     }
 
     /**
@@ -239,8 +240,8 @@ public class HarvestServiceIT {
      */
     public void testRunInvalidbaseURL(final Vertx aVertx, final VertxTestContext aContext)
             throws MalformedURLException, ParseException {
-        final Job job = new Job(myTestInstitutionID, new URL("http://example.com"), null,
-                new CronExpression("0 0 * * * ?"), null);
+        final Job job = Job.withID(new Job(myTestInstitutionID, new URL("http://example.com"), null,
+                new CronExpression("0 0 * * * ?"), null), 1);
 
         myHarvestServiceProxy.run(job).onFailure(details -> {
             LOGGER.debug(details.toString());

--- a/src/test/java/edu/ucla/library/prl/harvester/utils/TestUtils.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/utils/TestUtils.java
@@ -98,12 +98,12 @@ public final class TestUtils {
     /**
      * Gets a random {@link Job} for testing.
      *
+     * @param anInstitutionID The ID of the institution to associate the job with
      * @return A random Job object
      */
-    public static Job getRandomJob() throws MalformedURLException, ParseException {
+    public static Job getRandomJob(final Integer anInstitutionID) throws MalformedURLException, ParseException {
 
         final int randListSize = RANDOMIZER.nextInt(5) + 1;
-        final int randID = RANDOMIZER.nextInt(3) + 1;
         final URL randURL = new URL(URL_PREFIX.concat(RAND_URL.getRandomValue()));
         final List<String> randSets = new ArrayList<>(randListSize);
         final OffsetDateTime randDate = RAND_DATE.getRandomValue();
@@ -113,7 +113,7 @@ public final class TestUtils {
             randSets.add(RAND_STRING.getRandomValue().replaceAll("\\s", ""));
         }
 
-        return new Job(randID, randURL, randSets, randCron, randDate);
+        return new Job(anInstitutionID, randURL, randSets, randCron, randDate);
     }
 
     private static String buildCron(final OffsetDateTime aSourceDate) {

--- a/src/test/java/edu/ucla/library/prl/harvester/utils/TestUtils.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/utils/TestUtils.java
@@ -4,12 +4,18 @@ package edu.ucla.library.prl.harvester.utils;
 import edu.ucla.library.prl.harvester.Institution;
 import edu.ucla.library.prl.harvester.Job;
 
+import io.vertx.core.Future;
+import io.vertx.sqlclient.Pool;
+import io.vertx.sqlclient.SqlResult;
+import io.vertx.sqlclient.templates.SqlTemplate;
+
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.text.ParseException;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Random;
 
@@ -111,4 +117,18 @@ public final class TestUtils {
         cronExpression.append(QUESTION);
         return cronExpression.toString();
     }
+
+    /**
+     * Clears out the database.
+     *
+     * @param aConnectionPool A database connection pool
+     * @return A Future that succeeds if the database was wiped successfully, and fails otherwise
+     */
+    public static Future<SqlResult<Void>> wipeDatabase(final Pool aConnectionPool) {
+        return aConnectionPool.withConnection(connection -> {
+            return SqlTemplate.forUpdate(connection, "TRUNCATE public.harvestjobs, public.institutions")
+                    .execute(Map.of());
+        });
+    }
+
 }

--- a/src/test/resources/db/prldb.sql
+++ b/src/test/resources/db/prldb.sql
@@ -186,18 +186,3 @@ GRANT ALL ON TABLE public.harvestjobs TO prl;
 --
 
 GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO prl;
-
---
--- sample entires for unit/integration test
---
-
-INSERT INTO public.institutions (name, description, location, email, phone, webContact, website) VALUES ('Sample 1', 'A sample institution', 'Here', 'this@that.com', null, 'http://acme.edu/1/contact', 'http://acme.edu/1');
-INSERT INTO public.institutions (name, description, location, email, phone, webContact, website) VALUES ('Sample 2', 'Another sample', 'There', 'that@theother.com', '+1 888 890 1234', 'http://acme.edu/1/contact', 'http://acme.edu/1');
-INSERT INTO public.institutions (name, description, location, email, phone, webContact, website) VALUES ('Sample 3', 'A third sample', 'Everywhere', 'no@where.com', '+1 888 567 8901', 'http://acme.edu/1/contact', 'http://acme.edu/1');
-
-
-INSERT INTO public.harvestjobs (institutionID, repositoryBaseURL, metadataPrefix, sets, lastSuccessfulRun, scheduleCronExpression) VALUES (1, 'http://acme.edu/', 'oai_dc', '{this, that, the_other}', '2020-01-08 04:05:06 -8:00', '0 0/30 8-9 5,20 * ?');
-INSERT INTO public.harvestjobs (institutionID, repositoryBaseURL, metadataPrefix, sets, lastSuccessfulRun, scheduleCronExpression) VALUES (2, 'http://acme.edu/', 'oai_dc', '{this, that, the_other}', '2020-01-08 04:05:06 -8:00', '0 0/30 8-9 5,20 * ?');
-INSERT INTO public.harvestjobs (institutionID, repositoryBaseURL, metadataPrefix, sets, lastSuccessfulRun, scheduleCronExpression) VALUES (3, 'http://acme.edu/', 'oai_dc', '{this, that, the_other}', '2020-01-08 04:05:06 -8:00', '0 0/30 8-9 5,20 * ?');
-
-


### PR DESCRIPTION
The main objective necessitated a major refactor of the test suite (a183ef698c0333a94f5f116b12f7e878caa8da51) in order to isolate integration tests (by isolating their test data) from each other. So each integration test is expected to initialize Postgres and Solr in whichever way it finds desirable, as well as clearing out those backing services in an `@AfterAll` method. Additionally, the [Vert.x docs suggest](https://vertx.io/docs/vertx-pg-client/java/#_pool_sharing) managing database connection pools outside of verticles/services, hence 0d31274098baa8330bd2f77ea3de63804eb40809.

In implementing the job scheduler service, it became clear that a JobResult needs to contain the ID of the Job that it's associated with, since they're received on a different thread than the calling thread. Likewise, HarvestService#run will always be called with a Job that's been assigned an ID.

I moved plugin executions related to building the jOAI container later in the build lifecycle so that unit tests can be run much faster.