### PR TITLE
[SERV-558] Implement HTTP request handler for getJob

### DIFF
--- a/src/main/java/edu/ucla/library/prl/harvester/Op.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/Op.java
@@ -19,5 +19,5 @@ public enum Op {
     /**
      * Job operations.
      */
-    addJob, listJobs
+    addJob, getJob, listJobs
 }

--- a/src/main/java/edu/ucla/library/prl/harvester/handlers/GetJobHandler.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/handlers/GetJobHandler.java
@@ -1,0 +1,42 @@
+
+package edu.ucla.library.prl.harvester.handlers;
+
+import org.apache.http.HttpStatus;
+
+import edu.ucla.library.prl.harvester.MediaType;
+import edu.ucla.library.prl.harvester.Param;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.web.RoutingContext;
+
+/**
+ * A handler for getting jobs.
+ */
+public final class GetJobHandler extends AbstractJobRequestHandler {
+
+    /**
+     * @param aVertx A Vert.x instance
+     */
+    public GetJobHandler(final Vertx aVertx) {
+        super(aVertx);
+    }
+
+    @Override
+    public void handle(final RoutingContext aContext) {
+        final HttpServerResponse response = aContext.response();
+
+        try {
+            final int id = Integer.parseInt(aContext.request().getParam(Param.id.name()));
+
+            myHarvestScheduleStoreService.getJob(id).onSuccess(job -> {
+                response.setStatusCode(HttpStatus.SC_OK)
+                        .putHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON.toString())
+                        .end(job.toJson().encode());
+            }).onFailure(details -> handleError(aContext, details));
+        } catch (final NumberFormatException details) {
+            response.setStatusCode(HttpStatus.SC_BAD_REQUEST).end(details.getMessage());
+        }
+    }
+}

--- a/src/main/java/edu/ucla/library/prl/harvester/verticles/MainVerticle.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/verticles/MainVerticle.java
@@ -13,6 +13,7 @@ import edu.ucla.library.prl.harvester.Op;
 import edu.ucla.library.prl.harvester.handlers.AddInstitutionHandler;
 import edu.ucla.library.prl.harvester.handlers.AddJobHandler;
 import edu.ucla.library.prl.harvester.handlers.GetInstitutionHandler;
+import edu.ucla.library.prl.harvester.handlers.GetJobHandler;
 import edu.ucla.library.prl.harvester.handlers.ListInstitutionsHandler;
 import edu.ucla.library.prl.harvester.handlers.ListJobsHandler;
 import edu.ucla.library.prl.harvester.handlers.RemoveInstitutionHandler;
@@ -123,6 +124,7 @@ public class MainVerticle extends AbstractVerticle {
 
             // Job operations
             routeBuilder.operation(Op.addJob.name()).handler(new AddJobHandler(vertx));
+            routeBuilder.operation(Op.getJob.name()).handler(new GetJobHandler(vertx));
             routeBuilder.operation(Op.listJobs.name()).handler(new ListJobsHandler(vertx));
 
             return routeBuilder.createRouter();

--- a/src/test/java/edu/ucla/library/prl/harvester/InstitutionRequestsFT.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/InstitutionRequestsFT.java
@@ -118,16 +118,19 @@ public class InstitutionRequestsFT {
      *
      * @param aVertx A Vert.x instance
      * @param aContext A test context
-     * @throws AddressException
-     * @throws MalformedURLException
-     * @throws NumberParseException
      */
     @Test
-    void testListAfterAdd(final Vertx aVertx, final VertxTestContext aContext)
-            throws AddressException, MalformedURLException, NumberParseException {
+    void testListAfterAdd(final Vertx aVertx, final VertxTestContext aContext) {
         final Checkpoint responseVerified = aContext.checkpoint(2);
-        final Institution institution = TestUtils.getRandomInstitution();
+        final Institution institution;
         final Future<HttpResponse<Buffer>> addInstitution;
+
+        try {
+            institution = TestUtils.getRandomInstitution();
+        } catch (final AddressException | MalformedURLException | NumberParseException details) {
+            aContext.failNow(details);
+            return;
+        }
 
         // First request
         addInstitution = myWebClient.post(INSTITUTIONS).expect(ResponsePredicate.JSON).sendJson(institution.toJson());
@@ -167,16 +170,19 @@ public class InstitutionRequestsFT {
      *
      * @param aVertx A Vert.x instance
      * @param aContext A test context
-     * @throws AddressException
-     * @throws MalformedURLException
-     * @throws NumberParseException
      */
     @Test
-    void testGetAfterAdd(final Vertx aVertx, final VertxTestContext aContext)
-            throws AddressException, MalformedURLException, NumberParseException {
+    void testGetAfterAdd(final Vertx aVertx, final VertxTestContext aContext) {
         final Checkpoint responseVerified = aContext.checkpoint(2);
-        final Institution institution = TestUtils.getRandomInstitution();
+        final Institution institution;
         final Future<HttpResponse<Buffer>> addInstitution;
+
+        try {
+            institution = TestUtils.getRandomInstitution();
+        } catch (final AddressException | MalformedURLException | NumberParseException details) {
+            aContext.failNow(details);
+            return;
+        }
 
         // First request
         addInstitution = myWebClient.post(INSTITUTIONS).expect(ResponsePredicate.JSON).sendJson(institution.toJson());
@@ -214,16 +220,26 @@ public class InstitutionRequestsFT {
     }
 
     /**
+     * Tests that {@link Op#getInstitution} after {@link Op#updateInstitution} retrieves different data than was sent in
+     * the initial {@link Op#addInstitution}.
+     *
      * @param aVertx A Vert.x instance
      * @param aContext A test context
      */
     @Test
-    void testGetAfterUpdateAfterAdd(final Vertx aVertx, final VertxTestContext aContext)
-            throws AddressException, MalformedURLException, NumberParseException {
+    void testGetAfterUpdateAfterAdd(final Vertx aVertx, final VertxTestContext aContext) {
         final Checkpoint responseVerified = aContext.checkpoint(3);
-        final Institution institution = TestUtils.getRandomInstitution();
-        final Institution updatedInstitution = TestUtils.getRandomInstitution();
+        final Institution institution;
+        final Institution updatedInstitution;
         final Future<HttpResponse<Buffer>> addInstitution;
+
+        try {
+            institution = TestUtils.getRandomInstitution();
+            updatedInstitution = TestUtils.getRandomInstitution();
+        } catch (final AddressException | MalformedURLException | NumberParseException details) {
+            aContext.failNow(details);
+            return;
+        }
 
         // First request
         addInstitution = myWebClient.post(INSTITUTIONS).expect(ResponsePredicate.JSON).sendJson(institution.toJson());
@@ -277,15 +293,24 @@ public class InstitutionRequestsFT {
     }
 
     /**
+     * Tests that {@link Op#getInstitution} after {@link Op#removeInstitution} after {@link Op#addInstitution} results
+     * in HTTP 404.
+     *
      * @param aVertx A Vert.x instance
      * @param aContext A test context
      */
     @Test
-    void testGetAfterRemoveAfterAdd(final Vertx aVertx, final VertxTestContext aContext)
-            throws AddressException, MalformedURLException, NumberParseException {
+    void testGetAfterRemoveAfterAdd(final Vertx aVertx, final VertxTestContext aContext) {
         final Checkpoint responseVerified = aContext.checkpoint(3);
-        final Institution institution = TestUtils.getRandomInstitution();
+        final Institution institution;
         final Future<HttpResponse<Buffer>> addInstitution;
+
+        try {
+            institution = TestUtils.getRandomInstitution();
+        } catch (final AddressException | MalformedURLException | NumberParseException details) {
+            aContext.failNow(details);
+            return;
+        }
 
         // First request
         addInstitution = myWebClient.post(INSTITUTIONS).expect(ResponsePredicate.JSON).sendJson(institution.toJson());
@@ -353,11 +378,19 @@ public class InstitutionRequestsFT {
      * @param aContext A test context
      */
     @Test
-    void testUpdateBeforeAdd(final Vertx aVertx, final VertxTestContext aContext)
-            throws AddressException, MalformedURLException, NumberParseException {
-        final Institution institution = TestUtils.getRandomInstitution();
-        final Future<HttpResponse<Buffer>> updateInstitution = myWebClient
-                .put(INSTITUTION.expandToString(TestUtils.getUriTemplateVars(1))).sendJson(institution.toJson());
+    void testUpdateBeforeAdd(final Vertx aVertx, final VertxTestContext aContext) {
+        final Institution institution;
+        final Future<HttpResponse<Buffer>> updateInstitution;
+
+        try {
+            institution = TestUtils.getRandomInstitution();
+        } catch (final AddressException | MalformedURLException | NumberParseException details) {
+            aContext.failNow(details);
+            return;
+        }
+
+        updateInstitution = myWebClient.put(INSTITUTION.expandToString(TestUtils.getUriTemplateVars(1)))
+                .sendJson(institution.toJson());
 
         updateInstitution.onSuccess(response -> {
             aContext.verify(() -> {
@@ -386,15 +419,20 @@ public class InstitutionRequestsFT {
      *
      * @param aVertx A Vert.x instance
      * @param aContext A test context
-     * @throws NumberParseException
-     * @throws MalformedURLException
-     * @throws AddressException
      */
     @Test
-    void testAddInvalidInstitution(final Vertx aVertx, final VertxTestContext aContext)
-            throws AddressException, MalformedURLException, NumberParseException {
-        final Institution validInstitution = TestUtils.getRandomInstitution();
-        final JsonObject invalidInstitutionJson = validInstitution.toJson().put(Institution.NAME, null);
+    void testAddInvalidInstitution(final Vertx aVertx, final VertxTestContext aContext) {
+        final Institution validInstitution;
+        final JsonObject invalidInstitutionJson;
+
+        try {
+            validInstitution = TestUtils.getRandomInstitution();
+        } catch (final AddressException | MalformedURLException | NumberParseException details) {
+            aContext.failNow(details);
+            return;
+        }
+
+        invalidInstitutionJson = validInstitution.toJson().put(Institution.NAME, null);
 
         myWebClient.post(INSTITUTIONS).sendJson(invalidInstitutionJson).onSuccess(response -> {
             aContext.verify(() -> {
@@ -409,16 +447,19 @@ public class InstitutionRequestsFT {
      *
      * @param aVertx A Vert.x instance
      * @param aContext A test context
-     * @throws NumberParseException
-     * @throws MalformedURLException
-     * @throws AddressException
      */
     @Test
-    void testUpdateInvalidInstitutionAfterAdd(final Vertx aVertx, final VertxTestContext aContext)
-            throws AddressException, MalformedURLException, NumberParseException {
+    void testUpdateInvalidInstitutionAfterAdd(final Vertx aVertx, final VertxTestContext aContext) {
         final Checkpoint responseVerified = aContext.checkpoint(2);
-        final Institution validInstitution = TestUtils.getRandomInstitution();
+        final Institution validInstitution;
         final Future<HttpResponse<Buffer>> addInstitution;
+
+        try {
+            validInstitution = TestUtils.getRandomInstitution();
+        } catch (final AddressException | MalformedURLException | NumberParseException details) {
+            aContext.failNow(details);
+            return;
+        }
 
         // First request
         addInstitution =

--- a/src/test/java/edu/ucla/library/prl/harvester/JobRequestsFT.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/JobRequestsFT.java
@@ -85,14 +85,19 @@ public class JobRequestsFT {
     /**
      * @param aVertx A Vert.x instance
      * @param aContext A test context
-     * @throws AddressException
-     * @throws MalformedURLException
-     * @throws NumberParseException
      */
     @BeforeEach
-    public void beforeEach(final Vertx aVertx, final VertxTestContext aContext)
-            throws AddressException, MalformedURLException, NumberParseException {
-        myWebClient.post(INSTITUTIONS).sendJson(TestUtils.getRandomInstitution().toJson()).onSuccess(response -> {
+    public void beforeEach(final Vertx aVertx, final VertxTestContext aContext) {
+        final Institution institution;
+
+        try {
+            institution = TestUtils.getRandomInstitution();
+        } catch (final AddressException | MalformedURLException | NumberParseException details) {
+            aContext.failNow(details);
+            return;
+        }
+
+        myWebClient.post(INSTITUTIONS).sendJson(institution.toJson()).onSuccess(response -> {
             myInstitutionID = new Institution(response.bodyAsJsonObject()).getID().get();
 
             aContext.completeNow();
@@ -140,15 +145,19 @@ public class JobRequestsFT {
      *
      * @param aVertx A Vert.x instance
      * @param aContext A test context
-     * @throws MalformedURLException
-     * @throws ParseException
      */
     @Test
-    void testListAfterAdd(final Vertx aVertx, final VertxTestContext aContext)
-            throws MalformedURLException, ParseException {
+    void testListAfterAdd(final Vertx aVertx, final VertxTestContext aContext) {
         final Checkpoint responseVerified = aContext.checkpoint(2);
-        final Job job = TestUtils.getRandomJob(myInstitutionID);
+        final Job job;
         final Future<HttpResponse<Buffer>> addJob;
+
+        try {
+            job = TestUtils.getRandomJob(myInstitutionID);
+        } catch (final MalformedURLException | ParseException details) {
+            aContext.failNow(details);
+            return;
+        }
 
         // First request
         addJob = myWebClient.post(JOBS).sendJson(job.toJson());
@@ -187,15 +196,19 @@ public class JobRequestsFT {
      *
      * @param aVertx A Vert.x instance
      * @param aContext A test context
-     * @throws MalformedURLException
-     * @throws ParseException
      */
     @Test
-    void testGetAfterAdd(final Vertx aVertx, final VertxTestContext aContext)
-            throws MalformedURLException, ParseException {
+    void testGetAfterAdd(final Vertx aVertx, final VertxTestContext aContext) {
         final Checkpoint responseVerified = aContext.checkpoint(2);
-        final Job job = TestUtils.getRandomJob(myInstitutionID);
+        final Job job;
         final Future<HttpResponse<Buffer>> addJob;
+
+        try {
+            job = TestUtils.getRandomJob(myInstitutionID);
+        } catch (final MalformedURLException | ParseException details) {
+            aContext.failNow(details);
+            return;
+        }
 
         // First request
         addJob = myWebClient.post(JOBS).sendJson(job.toJson());
@@ -251,14 +264,20 @@ public class JobRequestsFT {
      *
      * @param aVertx A Vert.x instance
      * @param aContext A test context
-     * @throws MalformedURLException
-     * @throws ParseException
      */
     @Test
-    void testAddInvalidJob(final Vertx aVertx, final VertxTestContext aContext)
-            throws MalformedURLException, ParseException {
-        final Job validJob = TestUtils.getRandomJob(myInstitutionID);
-        final JsonObject invalidJobJson = validJob.toJson().put(Job.INSTITUTION_ID, null);
+    void testAddInvalidJob(final Vertx aVertx, final VertxTestContext aContext) {
+        final Job validJob;
+        final JsonObject invalidJobJson;
+
+        try {
+            validJob = TestUtils.getRandomJob(myInstitutionID);
+        } catch (final MalformedURLException | ParseException details) {
+            aContext.failNow(details);
+            return;
+        }
+
+        invalidJobJson = validJob.toJson().put(Job.INSTITUTION_ID, null);
 
         myWebClient.post(JOBS).sendJson(invalidJobJson).onSuccess(response -> {
             aContext.verify(() -> {


### PR DESCRIPTION
Adds two tests.

Also tweaks all the methods in the RequestsFT tests to not throw checked exceptions. This should make the tests terminate faster in the event that these exceptions occur, anyway.