### PR TITLE
[SERV-745] Part 2: Keep Solr in sync with Postgres

### DIFF
--- a/src/main/java/edu/ucla/library/prl/harvester/handlers/AbstractSolrAwareWriteOperationHandler.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/handlers/AbstractSolrAwareWriteOperationHandler.java
@@ -1,0 +1,49 @@
+
+package edu.ucla.library.prl.harvester.handlers;
+
+import org.apache.solr.client.solrj.response.UpdateResponse;
+
+import edu.ucla.library.prl.harvester.Config;
+
+import io.ino.solrs.JavaAsyncSolrClient;
+
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.sqlclient.Tuple;
+
+/**
+ * An abstract base class for write operation request handlers that need to update Solr.
+ */
+public abstract class AbstractSolrAwareWriteOperationHandler extends AbstractRequestHandler {
+
+    /**
+     * A client for sending institution records to Solr.
+     */
+    protected final JavaAsyncSolrClient mySolrClient;
+
+    /**
+     * The Vert.x instance.
+     */
+    protected final Vertx myVertx;
+
+    /**
+     * @param aVertx A Vert.x instance
+     * @param aConfig A configuration
+     */
+    protected AbstractSolrAwareWriteOperationHandler(final Vertx aVertx, final JsonObject aConfig) {
+        super(aVertx);
+
+        mySolrClient = JavaAsyncSolrClient.create(aConfig.getString(Config.SOLR_CORE_URL));
+        myVertx = aVertx;
+    }
+
+    /**
+     * Performs a Solr update appropriate for the type of incoming request.
+     *
+     * @param aData The relevant data for the Solr operation; implementers may use as needed and are responsible for
+     *        reading it carefully
+     * @return The result of performing the Solr update
+     */
+    abstract Future<UpdateResponse> updateSolr(Tuple aData);
+}

--- a/src/main/java/edu/ucla/library/prl/harvester/handlers/AddInstitutionHandler.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/handlers/AddInstitutionHandler.java
@@ -1,28 +1,36 @@
 
 package edu.ucla.library.prl.harvester.handlers;
 
+import java.util.concurrent.CompletionStage;
+
 import org.apache.http.HttpStatus;
+import org.apache.solr.client.solrj.response.UpdateResponse;
 
 import edu.ucla.library.prl.harvester.Institution;
 import edu.ucla.library.prl.harvester.InvalidInstitutionJsonException;
 import edu.ucla.library.prl.harvester.MediaType;
 
+import io.ino.solrs.JavaAsyncSolrClient;
+
+import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.RoutingContext;
+import io.vertx.sqlclient.Tuple;
 
 /**
  * A handler for adding institutions.
  */
-public final class AddInstitutionHandler extends AbstractRequestHandler {
+public final class AddInstitutionHandler extends AbstractSolrAwareWriteOperationHandler {
 
     /**
      * @param aVertx A Vert.x instance
+     * @param aConfig A configuration
      */
-    public AddInstitutionHandler(final Vertx aVertx) {
-        super(aVertx);
+    public AddInstitutionHandler(final Vertx aVertx, final JsonObject aConfig) {
+        super(aVertx, aConfig);
     }
 
     @Override
@@ -30,9 +38,12 @@ public final class AddInstitutionHandler extends AbstractRequestHandler {
         final HttpServerResponse response = aContext.response();
 
         try {
-            final Institution institution = new Institution(aContext.body().asJsonObject());
+            final JsonObject institutionJSON = aContext.body().asJsonObject();
+            final Institution institution = new Institution(institutionJSON);
 
-            myHarvestScheduleStoreService.addInstitution(institution).onSuccess(institutionID -> {
+            myHarvestScheduleStoreService.addInstitution(institution).compose(institutionID -> {
+                return updateSolr(Tuple.of(institutionID, institutionJSON)).map(institutionID);
+            }).onSuccess(institutionID -> {
                 final JsonObject responseBody = Institution.withID(institution, institutionID).toJson();
 
                 response.setStatusCode(HttpStatus.SC_CREATED)
@@ -42,5 +53,33 @@ public final class AddInstitutionHandler extends AbstractRequestHandler {
         } catch (final InvalidInstitutionJsonException details) {
             response.setStatusCode(HttpStatus.SC_BAD_REQUEST).end(details.getMessage());
         }
+    }
+
+    /**
+     * Adds an institution doc to Solr.
+     *
+     * @param aData A Tuple of the ID of the institution to update, and its JSON representation
+     */
+    @Override
+    Future<UpdateResponse> updateSolr(final Tuple aData) {
+        final Institution institution =
+                Institution.withID(new Institution(aData.getJsonObject(1)), aData.getInteger(0));
+
+        return updateInstitutionDoc(mySolrClient, institution);
+    }
+
+    /**
+     * Adds or updates an institution doc in Solr.
+     *
+     * @param aSolrClient A Solr client
+     * @param anInstitution The institution
+     * @return The result of performing the Solr update
+     */
+    static Future<UpdateResponse> updateInstitutionDoc(final JavaAsyncSolrClient aSolrClient,
+            final Institution anInstitution) {
+        final CompletionStage<UpdateResponse> addInstitution =
+                aSolrClient.addDoc(anInstitution.toSolrDoc()).thenCompose(result -> aSolrClient.commit());
+
+        return Future.fromCompletionStage(addInstitution);
     }
 }

--- a/src/main/java/edu/ucla/library/prl/harvester/handlers/RemoveInstitutionHandler.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/handlers/RemoveInstitutionHandler.java
@@ -1,24 +1,36 @@
 
 package edu.ucla.library.prl.harvester.handlers;
 
-import org.apache.http.HttpStatus;
+import java.util.concurrent.CompletionStage;
+import java.util.stream.Stream;
 
+import org.apache.http.HttpStatus;
+import org.apache.solr.client.solrj.response.UpdateResponse;
+
+import edu.ucla.library.prl.harvester.Institution;
 import edu.ucla.library.prl.harvester.Param;
 
+import info.freelibrary.util.StringUtils;
+
+import io.vertx.core.CompositeFuture;
+import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.RoutingContext;
+import io.vertx.sqlclient.Tuple;
 
 /**
  * A handler for removing institutions.
  */
-public final class RemoveInstitutionHandler extends AbstractRequestHandler {
+public final class RemoveInstitutionHandler extends AbstractSolrAwareWriteOperationHandler {
 
     /**
      * @param aVertx A Vert.x instance
+     * @param aConfig A configuration
      */
-    public RemoveInstitutionHandler(final Vertx aVertx) {
-        super(aVertx);
+    public RemoveInstitutionHandler(final Vertx aVertx, final JsonObject aConfig) {
+        super(aVertx, aConfig);
     }
 
     @Override
@@ -28,11 +40,55 @@ public final class RemoveInstitutionHandler extends AbstractRequestHandler {
         try {
             final int id = Integer.parseInt(aContext.request().getParam(Param.id.name()));
 
-            myHarvestScheduleStoreService.removeInstitution(id).onSuccess(nil -> {
+            // Before modifying the database, get institution data so that we can update Solr accordingly
+            myHarvestScheduleStoreService.getInstitution(id).compose(institution -> {
+                // Get the list of Jobs that we need to remove
+                final Future<Void> removeAssociatedJobs = myHarvestScheduleStoreService.listJobs().compose(jobs -> {
+                    @SuppressWarnings({ "rawtypes", "unchecked" })
+                    final Stream<Future> associatedJobRemovals = jobs.parallelStream() //
+                            .filter(job -> job.getInstitutionID() == id) //
+                            .map(job -> {
+                                final int jobID = job.getID().get();
+
+                                return myHarvestScheduleStoreService.removeJob(jobID).compose(nil -> {
+                                    return (Future) myHarvestJobSchedulerService.removeJob(jobID);
+                                });
+                            });
+
+                    return CompositeFuture.all(associatedJobRemovals.toList()).mapEmpty();
+                });
+
+                // Remove the Jobs, then remove the Institution
+                return removeAssociatedJobs.compose(nil -> {
+                    return myHarvestScheduleStoreService.removeInstitution(id);
+                }).compose(nil -> {
+                    return updateSolr(Tuple.of(institution.toJson()));
+                });
+            }).onSuccess(solrResponse -> {
                 response.setStatusCode(HttpStatus.SC_NO_CONTENT).end();
             }).onFailure(aContext::fail);
         } catch (final NumberFormatException details) {
             response.setStatusCode(HttpStatus.SC_BAD_REQUEST).end(details.getMessage());
         }
+    }
+
+    /**
+     * Removes the institution doc, and all item record docs that were harvested by jobs associated with the
+     * institution.
+     *
+     * @param aData A Tuple of the institution as JSON
+     */
+    @Override
+    Future<UpdateResponse> updateSolr(final Tuple aData) {
+        final Institution institution = new Institution(aData.getJsonObject(0));
+
+        final String itemRecordDocsQuery = StringUtils.format("institutionName:\"{}\"", institution.getName());
+        final String institutionDocQuery =
+                StringUtils.format("id:\"{}\"", institution.toSolrDoc().getFieldValue(Institution.ID));
+        final String query = StringUtils.format("{} OR {}", itemRecordDocsQuery, institutionDocQuery);
+        final CompletionStage<UpdateResponse> removal =
+                mySolrClient.deleteByQuery(query).thenCompose(result -> mySolrClient.commit());
+
+        return Future.fromCompletionStage(removal);
     }
 }

--- a/src/main/java/edu/ucla/library/prl/harvester/handlers/RemoveJobHandler.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/handlers/RemoveJobHandler.java
@@ -1,24 +1,39 @@
 
 package edu.ucla.library.prl.harvester.handlers;
 
-import org.apache.http.HttpStatus;
+import java.net.URL;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletionStage;
 
+import org.apache.http.HttpStatus;
+import org.apache.solr.client.solrj.response.UpdateResponse;
+
+import edu.ucla.library.prl.harvester.Institution;
+import edu.ucla.library.prl.harvester.Job;
+import edu.ucla.library.prl.harvester.OaipmhUtils;
 import edu.ucla.library.prl.harvester.Param;
 
+import info.freelibrary.util.StringUtils;
+
+import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.RoutingContext;
+import io.vertx.sqlclient.Tuple;
 
 /**
  * A handler for removing jobs.
  */
-public final class RemoveJobHandler extends AbstractRequestHandler {
+public final class RemoveJobHandler extends AbstractSolrAwareWriteOperationHandler {
 
     /**
      * @param aVertx A Vert.x instance
+     * @param aConfig A configuration
      */
-    public RemoveJobHandler(final Vertx aVertx) {
-        super(aVertx);
+    public RemoveJobHandler(final Vertx aVertx, final JsonObject aConfig) {
+        super(aVertx, aConfig);
     }
 
     @Override
@@ -28,13 +43,69 @@ public final class RemoveJobHandler extends AbstractRequestHandler {
         try {
             final int id = Integer.parseInt(aContext.request().getParam(Param.id.name()));
 
-            myHarvestScheduleStoreService.removeJob(id).compose(nil -> {
-                return myHarvestJobSchedulerService.removeJob(id);
-            }).onSuccess(nil -> {
+            // Query database first to get job info for removing it
+            myHarvestScheduleStoreService.getJob(id).compose(job -> {
+                return myHarvestScheduleStoreService.getInstitution(job.getInstitutionID()).compose(institution -> {
+                    // Do all the solr updating in this context
+                    return myHarvestScheduleStoreService.removeJob(id).compose(nil -> {
+                        return myHarvestJobSchedulerService.removeJob(id);
+                    }).compose(nil -> {
+                        return updateSolr(Tuple.of(job.toJson(), institution.toJson()));
+                    });
+                });
+            }).onSuccess(solrResponse -> {
                 response.setStatusCode(HttpStatus.SC_NO_CONTENT).end();
             }).onFailure(aContext::fail);
         } catch (final NumberFormatException details) {
             response.setStatusCode(HttpStatus.SC_BAD_REQUEST).end(details.getMessage());
         }
+    }
+
+    /**
+     * Removes all item records that were harvested by the job.
+     *
+     * @param aData A Tuple of the ID of the job to remove, and its JSON representation
+     */
+    @Override
+    Future<UpdateResponse> updateSolr(final Tuple aData) {
+        final Job job = new Job(aData.getJsonObject(0));
+        final Institution institution = new Institution(aData.getJsonObject(1));
+        final Future<String> futureRecordRemovalQuery =
+                getRecordRemovalQuery(myVertx, institution.getName(), job.getRepositoryBaseURL(), job.getSets());
+
+        return futureRecordRemovalQuery.compose(solrQuery -> {
+            final CompletionStage<UpdateResponse> removal =
+                    mySolrClient.deleteByQuery(solrQuery).thenCompose(result -> mySolrClient.commit());
+
+            return Future.fromCompletionStage(removal);
+        });
+    }
+
+    /**
+     * @param aVertx A Vert.x instance
+     * @param anInstitutionName An institution name
+     * @param aBaseURL An OAI-PMH repository base URL
+     * @param aSets A list of sets
+     * @return A Solr query that can be used to remove records from the given sets associated with the given institution
+     */
+    static Future<String> getRecordRemovalQuery(final Vertx aVertx, final String anInstitutionName, final URL aBaseURL,
+            final Optional<List<String>> aSets) {
+        final Future<List<String>> getSetsToRemove;
+
+        if (aSets.isPresent() && !aSets.get().isEmpty()) {
+            getSetsToRemove = Future.succeededFuture(aSets.get());
+        } else {
+            // Missing or empty list means all sets in the repository
+            getSetsToRemove = OaipmhUtils.listSets(aVertx, aBaseURL).map(OaipmhUtils::getSetSpecs);
+        }
+
+        return getSetsToRemove.map(sets -> {
+            final String[] collectionQueryClauses = sets.stream() //
+                    .map(set -> StringUtils.format("set_spec:\"{}\"", set)) //
+                    .toArray(x -> new String[sets.size()]);
+
+            return StringUtils.format("institutionName:\"{}\" AND ({})", anInstitutionName,
+                    String.join(" OR ", collectionQueryClauses));
+        });
     }
 }

--- a/src/main/java/edu/ucla/library/prl/harvester/handlers/UpdateInstitutionHandler.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/handlers/UpdateInstitutionHandler.java
@@ -2,28 +2,32 @@
 package edu.ucla.library.prl.harvester.handlers;
 
 import org.apache.http.HttpStatus;
+import org.apache.solr.client.solrj.response.UpdateResponse;
 
 import edu.ucla.library.prl.harvester.Institution;
 import edu.ucla.library.prl.harvester.InvalidInstitutionJsonException;
 import edu.ucla.library.prl.harvester.MediaType;
 import edu.ucla.library.prl.harvester.Param;
 
+import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.RoutingContext;
+import io.vertx.sqlclient.Tuple;
 
 /**
  * A handler for updating institutions.
  */
-public final class UpdateInstitutionHandler extends AbstractRequestHandler {
+public final class UpdateInstitutionHandler extends AbstractSolrAwareWriteOperationHandler {
 
     /**
      * @param aVertx A Vert.x instance
+     * @param aConfig A configuration
      */
-    public UpdateInstitutionHandler(final Vertx aVertx) {
-        super(aVertx);
+    public UpdateInstitutionHandler(final Vertx aVertx, final JsonObject aConfig) {
+        super(aVertx, aConfig);
     }
 
     @Override
@@ -32,9 +36,12 @@ public final class UpdateInstitutionHandler extends AbstractRequestHandler {
 
         try {
             final int id = Integer.parseInt(aContext.request().getParam(Param.id.name()));
-            final Institution institution = new Institution(aContext.body().asJsonObject());
+            final JsonObject institutionJSON = aContext.body().asJsonObject();
+            final Institution institution = new Institution(institutionJSON);
 
-            myHarvestScheduleStoreService.updateInstitution(id, institution).onSuccess(nil -> {
+            myHarvestScheduleStoreService.updateInstitution(id, institution).compose(nil -> {
+                return updateSolr(Tuple.of(id, institutionJSON));
+            }).onSuccess(result -> {
                 final JsonObject responseBody = Institution.withID(institution, id).toJson();
 
                 response.setStatusCode(HttpStatus.SC_OK)
@@ -44,5 +51,18 @@ public final class UpdateInstitutionHandler extends AbstractRequestHandler {
         } catch (final InvalidInstitutionJsonException | NumberFormatException details) {
             response.setStatusCode(HttpStatus.SC_BAD_REQUEST).end(details.getMessage());
         }
+    }
+
+    /**
+     * Updates the institution doc in Solr.
+     *
+     * @param aData A Tuple of the ID of the institution to update, and its JSON representation
+     */
+    @Override
+    Future<UpdateResponse> updateSolr(final Tuple aData) {
+        final Institution institution =
+                Institution.withID(new Institution(aData.getJsonObject(1)), aData.getInteger(0));
+
+        return AddInstitutionHandler.updateInstitutionDoc(mySolrClient, institution);
     }
 }

--- a/src/main/java/edu/ucla/library/prl/harvester/handlers/UpdateJobHandler.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/handlers/UpdateJobHandler.java
@@ -99,7 +99,7 @@ public final class UpdateJobHandler extends AbstractSolrAwareWriteOperationHandl
 
         // If we determined that there are sets to remove, do that now
         return getActualOldJobSets.compose(sets -> {
-            final Optional<List<String>> setsToRemove = Optional.of(getElementsInNewNotInOld(sets, newJobSets.get()));
+            final Optional<List<String>> setsToRemove = Optional.of(getDifference(sets, newJobSets.get()));
             final Future<String> getSolrQuery = RemoveJobHandler.getRecordRemovalQuery(myVertx, institutionName,
                     oldJob.getRepositoryBaseURL(), setsToRemove);
 
@@ -117,7 +117,7 @@ public final class UpdateJobHandler extends AbstractSolrAwareWriteOperationHandl
      * @param aNewList A list representing a new, updated state
      * @return The list of elements that are in {@code aNewList} but not in {@code anOldList}
      */
-    private static List<String> getElementsInNewNotInOld(final List<String> anOldList, final List<String> aNewList) {
+    private static List<String> getDifference(final List<String> anOldList, final List<String> aNewList) {
         return anOldList.stream().filter(setSpec -> !aNewList.contains(setSpec)).toList();
     }
 }

--- a/src/main/java/edu/ucla/library/prl/harvester/handlers/UpdateJobHandler.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/handlers/UpdateJobHandler.java
@@ -1,29 +1,38 @@
 
 package edu.ucla.library.prl.harvester.handlers;
 
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletionStage;
+
 import org.apache.http.HttpStatus;
+import org.apache.solr.client.solrj.response.UpdateResponse;
 
 import edu.ucla.library.prl.harvester.InvalidJobJsonException;
 import edu.ucla.library.prl.harvester.Job;
 import edu.ucla.library.prl.harvester.MediaType;
+import edu.ucla.library.prl.harvester.OaipmhUtils;
 import edu.ucla.library.prl.harvester.Param;
 
+import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.RoutingContext;
+import io.vertx.sqlclient.Tuple;
 
 /**
  * A handler for updating jobs.
  */
-public final class UpdateJobHandler extends AbstractRequestHandler {
+public final class UpdateJobHandler extends AbstractSolrAwareWriteOperationHandler {
 
     /**
      * @param aVertx A Vert.x instance
+     * @param aConfig A configuration
      */
-    public UpdateJobHandler(final Vertx aVertx) {
-        super(aVertx);
+    public UpdateJobHandler(final Vertx aVertx, final JsonObject aConfig) {
+        super(aVertx, aConfig);
     }
 
     @Override
@@ -32,10 +41,17 @@ public final class UpdateJobHandler extends AbstractRequestHandler {
 
         try {
             final int id = Integer.parseInt(aContext.request().getParam(Param.id.name()));
-            final Job job = new Job(aContext.body().asJsonObject());
+            final JsonObject jobJSON = aContext.body().asJsonObject();
+            final Job job = new Job(jobJSON);
 
-            myHarvestScheduleStoreService.updateJob(id, job).compose(nil -> {
-                return myHarvestJobSchedulerService.updateJob(id, job);
+            myHarvestScheduleStoreService.getJob(id).compose(oldJob -> {
+                return myHarvestScheduleStoreService.getInstitution(oldJob.getInstitutionID()).compose(institution -> {
+                    return myHarvestScheduleStoreService.updateJob(id, job).compose(nil -> {
+                        return myHarvestJobSchedulerService.updateJob(id, job);
+                    }).compose(nil -> {
+                        return updateSolr(Tuple.of(oldJob.toJson(), jobJSON, institution.getName()));
+                    });
+                });
             }).onSuccess(nil -> {
                 final JsonObject responseBody = Job.withID(job, id).toJson();
 
@@ -46,5 +62,62 @@ public final class UpdateJobHandler extends AbstractRequestHandler {
         } catch (final InvalidJobJsonException | NumberFormatException details) {
             response.setStatusCode(HttpStatus.SC_BAD_REQUEST).end(details.getMessage());
         }
+    }
+
+    /**
+     * Removes all item records that belong to the sets removed from the job (if any).
+     *
+     * @param aData A Tuple of the old JSON representation of the job, its new JSON representation, and the institution
+     *        name
+     */
+    @Override
+    Future<UpdateResponse> updateSolr(final Tuple aData) {
+        final Job oldJob = new Job(aData.getJsonObject(0));
+        final Job newJob = new Job(aData.getJsonObject(1));
+        final String institutionName = aData.getString(2);
+
+        final Optional<List<String>> oldJobSets = oldJob.getSets();
+        final Optional<List<String>> newJobSets = newJob.getSets();
+        final Future<List<String>> getActualOldJobSets;
+
+        if (oldJobSets.isPresent() && newJobSets.isPresent()) {
+            // Still selective harvesting, althought the list of sets may have changed, so determine that
+            getActualOldJobSets = Future.succeededFuture(oldJobSets.get());
+        } else if (oldJobSets.isEmpty() && newJobSets.isPresent()) {
+            // From non-selective harvesting to selective, so it's very likely that there are sets to remove
+            // Must query OAI-PMH repository in order to get the sets belonging to the old job
+            getActualOldJobSets =
+                    OaipmhUtils.listSets(myVertx, oldJob.getRepositoryBaseURL()).map(OaipmhUtils::getSetSpecs);
+            // TODO: make it impossible to change the base URL
+        } else if (oldJobSets.isPresent() && newJobSets.isEmpty()) {
+            // From selective harvesting to non-selective, so nothing to remove
+            return Future.succeededFuture();
+        } else {
+            // Still harvesting entire repository, so nothing to remove
+            return Future.succeededFuture();
+        }
+
+        // If we determined that there are sets to remove, do that now
+        return getActualOldJobSets.compose(sets -> {
+            final Optional<List<String>> setsToRemove = Optional.of(getElementsInNewNotInOld(sets, newJobSets.get()));
+            final Future<String> getSolrQuery = RemoveJobHandler.getRecordRemovalQuery(myVertx, institutionName,
+                    oldJob.getRepositoryBaseURL(), setsToRemove);
+
+            return getSolrQuery.compose(solrQuery -> {
+                final CompletionStage<UpdateResponse> removal =
+                        mySolrClient.deleteByQuery(solrQuery).thenCompose(result -> mySolrClient.commit());
+
+                return Future.fromCompletionStage(removal);
+            });
+        });
+    }
+
+    /**
+     * @param anOldList A list representing an original state
+     * @param aNewList A list representing a new, updated state
+     * @return The list of elements that are in {@code aNewList} but not in {@code anOldList}
+     */
+    private static List<String> getElementsInNewNotInOld(final List<String> anOldList, final List<String> aNewList) {
+        return anOldList.stream().filter(setSpec -> !aNewList.contains(setSpec)).toList();
     }
 }

--- a/src/main/java/edu/ucla/library/prl/harvester/verticles/MainVerticle.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/verticles/MainVerticle.java
@@ -136,18 +136,18 @@ public class MainVerticle extends AbstractVerticle {
             routeBuilder.operation(Op.getStatus.name()).handler(new StatusHandler());
 
             // Institution operations
-            routeBuilder.operation(Op.addInstitution.name()).handler(new AddInstitutionHandler(vertx));
+            routeBuilder.operation(Op.addInstitution.name()).handler(new AddInstitutionHandler(vertx, aConfig));
             routeBuilder.operation(Op.getInstitution.name()).handler(new GetInstitutionHandler(vertx));
             routeBuilder.operation(Op.listInstitutions.name()).handler(new ListInstitutionsHandler(vertx));
-            routeBuilder.operation(Op.removeInstitution.name()).handler(new RemoveInstitutionHandler(vertx));
-            routeBuilder.operation(Op.updateInstitution.name()).handler(new UpdateInstitutionHandler(vertx));
+            routeBuilder.operation(Op.removeInstitution.name()).handler(new RemoveInstitutionHandler(vertx, aConfig));
+            routeBuilder.operation(Op.updateInstitution.name()).handler(new UpdateInstitutionHandler(vertx, aConfig));
 
             // Job operations
             routeBuilder.operation(Op.addJob.name()).handler(new AddJobHandler(vertx));
             routeBuilder.operation(Op.getJob.name()).handler(new GetJobHandler(vertx));
             routeBuilder.operation(Op.listJobs.name()).handler(new ListJobsHandler(vertx));
-            routeBuilder.operation(Op.removeJob.name()).handler(new RemoveJobHandler(vertx));
-            routeBuilder.operation(Op.updateJob.name()).handler(new UpdateJobHandler(vertx));
+            routeBuilder.operation(Op.removeJob.name()).handler(new RemoveJobHandler(vertx, aConfig));
+            routeBuilder.operation(Op.updateJob.name()).handler(new UpdateJobHandler(vertx, aConfig));
 
             // Admin interface
             routeBuilder.operation(Op.getAdmin.name()).handler(StaticHandler.create());

--- a/src/main/resources/prl-harvester_messages.xml
+++ b/src/main/resources/prl-harvester_messages.xml
@@ -37,4 +37,6 @@
   <entry key="PRL_034">At {}, we can be reasonably certain the job has been removed</entry>
   <entry key="PRL_035">JobResult received, but the Job should have been unscheduled</entry>
   <entry key="PRL_036">The static asset {} could not be resolved: HTTP {} {}</entry>
+  <entry key="PRL_037">Contents of Solr after {}: {}</entry>
+
 </properties>

--- a/src/main/resources/prl-harvester_messages.xml
+++ b/src/main/resources/prl-harvester_messages.xml
@@ -28,6 +28,7 @@
   <entry key="PRL_020">Failed to schedule job with ID {}: {}</entry>
   <entry key="PRL_021">Failed to unschedule job with ID {}: {}</entry>
   <entry key="PRL_022">An Institution must be assigned a unique identifier by the database before this operation can be performed</entry>
+  <entry key="PRL_023">A Job must be assigned a unique identifier by the database before this operation can be performed</entry>
 
   <entry key="PRL_030">Database initialized</entry>
   <entry key="PRL_031">Service instantiated</entry>

--- a/src/test/java/edu/ucla/library/prl/harvester/InstitutionRequestsFT.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/InstitutionRequestsFT.java
@@ -161,9 +161,23 @@ public class InstitutionRequestsFT {
                 responseVerified.flag();
             });
 
-            TestUtils.assertExpectedSolrState(aContext, solrVerified, mySolrClient,
-                    Optional.of(Set.of(responseInstitution)));
-            TestUtils.assertExpectedDatabaseInstitutionRow(aContext, dbVerified, myDbConnectionPool, institution, true);
+            TestUtils.getSolrInstitutionAssertions(mySolrClient, Optional.of(Set.of(responseInstitution)))
+                    .onSuccess(assertions -> {
+                        aContext.verify(() -> {
+                            assertions.run();
+
+                            solrVerified.flag();
+                        });
+                    }).onFailure(aContext::failNow);
+
+            TestUtils.getDatabaseInstitutionAssertions(myDbConnectionPool, Optional.of(Set.of(institution)))
+                    .onSuccess(assertions -> {
+                        aContext.verify(() -> {
+                            assertions.run();
+
+                            dbVerified.flag();
+                        });
+                    }).onFailure(aContext::failNow);
 
             // Second request
             listInstitutions = myWebClient.get(INSTITUTIONS).expect(ResponsePredicate.JSON).send();
@@ -220,9 +234,23 @@ public class InstitutionRequestsFT {
                 responseVerified.flag();
             });
 
-            TestUtils.assertExpectedSolrState(aContext, solrVerified, mySolrClient,
-                    Optional.of(Set.of(responseInstitution)));
-            TestUtils.assertExpectedDatabaseInstitutionRow(aContext, dbVerified, myDbConnectionPool, institution, true);
+            TestUtils.getSolrInstitutionAssertions(mySolrClient, Optional.of(Set.of(responseInstitution)))
+                    .onSuccess(assertions -> {
+                        aContext.verify(() -> {
+                            assertions.run();
+
+                            solrVerified.flag();
+                        });
+                    }).onFailure(aContext::failNow);
+
+            TestUtils.getDatabaseInstitutionAssertions(myDbConnectionPool, Optional.of(Set.of(institution)))
+                    .onSuccess(assertions -> {
+                        aContext.verify(() -> {
+                            assertions.run();
+
+                            dbVerified.flag();
+                        });
+                    }).onFailure(aContext::failNow);
 
             // Second request
             institutionID = TestUtils.getUriTemplateVars(responseInstitution.getID().get());
@@ -283,9 +311,23 @@ public class InstitutionRequestsFT {
                 responseVerified.flag();
             });
 
-            TestUtils.assertExpectedSolrState(aContext, solrVerified, mySolrClient,
-                    Optional.of(Set.of(responseInstitution)));
-            TestUtils.assertExpectedDatabaseInstitutionRow(aContext, dbVerified, myDbConnectionPool, institution, true);
+            TestUtils.getSolrInstitutionAssertions(mySolrClient, Optional.of(Set.of(responseInstitution)))
+                    .onSuccess(assertions -> {
+                        aContext.verify(() -> {
+                            assertions.run();
+
+                            solrVerified.flag();
+                        });
+                    }).onFailure(aContext::failNow);
+
+            TestUtils.getDatabaseInstitutionAssertions(myDbConnectionPool, Optional.of(Set.of(institution)))
+                    .onSuccess(assertions -> {
+                        aContext.verify(() -> {
+                            assertions.run();
+
+                            dbVerified.flag();
+                        });
+                    }).onFailure(aContext::failNow);
 
             // Second request
             institutionID = TestUtils.getUriTemplateVars(responseInstitution.getID().get());
@@ -303,10 +345,23 @@ public class InstitutionRequestsFT {
                     responseVerified.flag();
                 });
 
-                TestUtils.assertExpectedSolrState(aContext, solrVerified, mySolrClient,
-                        Optional.of(Set.of(responseInstitution2)));
-                TestUtils.assertExpectedDatabaseInstitutionRow(aContext, dbVerified, myDbConnectionPool,
-                        updatedInstitution, true);
+                TestUtils.getSolrInstitutionAssertions(mySolrClient, Optional.of(Set.of(responseInstitution2)))
+                        .onSuccess(assertions -> {
+                            aContext.verify(() -> {
+                                assertions.run();
+
+                                solrVerified.flag();
+                            });
+                        }).onFailure(aContext::failNow);
+
+                TestUtils.getDatabaseInstitutionAssertions(myDbConnectionPool, Optional.of(Set.of(updatedInstitution)))
+                        .onSuccess(assertions -> {
+                            aContext.verify(() -> {
+                                assertions.run();
+
+                                dbVerified.flag();
+                            });
+                        }).onFailure(aContext::failNow);
 
                 // Third request
                 getInstitution = myWebClient.get(INSTITUTION.expandToString(institutionID))
@@ -365,9 +420,23 @@ public class InstitutionRequestsFT {
                 responseVerified.flag();
             });
 
-            TestUtils.assertExpectedSolrState(aContext, solrVerified, mySolrClient,
-                    Optional.of(Set.of(responseInstitution)));
-            TestUtils.assertExpectedDatabaseInstitutionRow(aContext, dbVerified, myDbConnectionPool, institution, true);
+            TestUtils.getSolrInstitutionAssertions(mySolrClient, Optional.of(Set.of(responseInstitution)))
+                    .onSuccess(assertions -> {
+                        aContext.verify(() -> {
+                            assertions.run();
+
+                            solrVerified.flag();
+                        });
+                    }).onFailure(aContext::failNow);
+
+            TestUtils.getDatabaseInstitutionAssertions(myDbConnectionPool, Optional.of(Set.of(institution)))
+                    .onSuccess(assertions -> {
+                        aContext.verify(() -> {
+                            assertions.run();
+
+                            dbVerified.flag();
+                        });
+                    }).onFailure(aContext::failNow);
 
             // Second request
             institutionID = TestUtils.getUriTemplateVars(responseInstitution.getID().get());
@@ -382,9 +451,22 @@ public class InstitutionRequestsFT {
                     responseVerified.flag();
                 });
 
-                TestUtils.assertExpectedSolrState(aContext, solrVerified, mySolrClient, Optional.empty());
-                TestUtils.assertExpectedDatabaseInstitutionRow(aContext, dbVerified, myDbConnectionPool, institution,
-                        false);
+                TestUtils.getSolrInstitutionAssertions(mySolrClient, Optional.empty()).onSuccess(assertions -> {
+                    aContext.verify(() -> {
+                        assertions.run();
+
+                        solrVerified.flag();
+                    });
+                }).onFailure(aContext::failNow);
+
+                TestUtils.getDatabaseInstitutionAssertions(myDbConnectionPool, Optional.empty())
+                        .onSuccess(assertions -> {
+                            aContext.verify(() -> {
+                                assertions.run();
+
+                                dbVerified.flag();
+                            });
+                        }).onFailure(aContext::failNow);
 
                 // Third request
                 getInstitution = myWebClient.get(INSTITUTION.expandToString(institutionID)).send();
@@ -448,9 +530,21 @@ public class InstitutionRequestsFT {
                 responseVerified.flag();
             });
 
-            TestUtils.assertExpectedSolrState(aContext, solrVerified, mySolrClient, Optional.empty());
-            TestUtils.assertExpectedDatabaseInstitutionRow(aContext, dbVerified, myDbConnectionPool, institution,
-                    false);
+            TestUtils.getSolrInstitutionAssertions(mySolrClient, Optional.empty()).onSuccess(assertions -> {
+                aContext.verify(() -> {
+                    assertions.run();
+
+                    solrVerified.flag();
+                });
+            }).onFailure(aContext::failNow);
+
+            TestUtils.getDatabaseInstitutionAssertions(myDbConnectionPool, Optional.empty()).onSuccess(assertions -> {
+                aContext.verify(() -> {
+                    assertions.run();
+
+                    dbVerified.flag();
+                });
+            }).onFailure(aContext::failNow);
         }).onFailure(aContext::failNow);
     }
 
@@ -499,9 +593,21 @@ public class InstitutionRequestsFT {
                 responseVerified.flag();
             });
 
-            TestUtils.assertExpectedSolrState(aContext, solrVerified, mySolrClient, Optional.empty());
-            TestUtils.assertExpectedDatabaseInstitutionRow(aContext, dbVerified, myDbConnectionPool, validInstitution,
-                    false);
+            TestUtils.getSolrInstitutionAssertions(mySolrClient, Optional.empty()).onSuccess(assertions -> {
+                aContext.verify(() -> {
+                    assertions.run();
+
+                    solrVerified.flag();
+                });
+            }).onFailure(aContext::failNow);
+
+            TestUtils.getDatabaseInstitutionAssertions(myDbConnectionPool, Optional.empty()).onSuccess(assertions -> {
+                aContext.verify(() -> {
+                    assertions.run();
+
+                    dbVerified.flag();
+                });
+            }).onFailure(aContext::failNow);
         }).onFailure(aContext::failNow);
     }
 
@@ -544,10 +650,23 @@ public class InstitutionRequestsFT {
                 responseVerified.flag();
             });
 
-            TestUtils.assertExpectedSolrState(aContext, solrVerified, mySolrClient,
-                    Optional.of(Set.of(responseInstitution)));
-            TestUtils.assertExpectedDatabaseInstitutionRow(aContext, dbVerified, myDbConnectionPool, validInstitution,
-                    true);
+            TestUtils.getSolrInstitutionAssertions(mySolrClient, Optional.of(Set.of(responseInstitution)))
+                    .onSuccess(assertions -> {
+                        aContext.verify(() -> {
+                            assertions.run();
+
+                            solrVerified.flag();
+                        });
+                    }).onFailure(aContext::failNow);
+
+            TestUtils.getDatabaseInstitutionAssertions(myDbConnectionPool, Optional.of(Set.of(validInstitution)))
+                    .onSuccess(assertions -> {
+                        aContext.verify(() -> {
+                            assertions.run();
+
+                            dbVerified.flag();
+                        });
+                    }).onFailure(aContext::failNow);
 
             // Second request
             institutionID = TestUtils.getUriTemplateVars(responseInstitution.getID().get());
@@ -563,10 +682,23 @@ public class InstitutionRequestsFT {
 
                 });
 
-                TestUtils.assertExpectedSolrState(aContext, solrVerified, mySolrClient,
-                        Optional.of(Set.of(responseInstitution)));
-                TestUtils.assertExpectedDatabaseInstitutionRow(aContext, dbVerified, myDbConnectionPool,
-                        validInstitution, true);
+                TestUtils.getSolrInstitutionAssertions(mySolrClient, Optional.of(Set.of(responseInstitution)))
+                        .onSuccess(assertions -> {
+                            aContext.verify(() -> {
+                                assertions.run();
+
+                                solrVerified.flag();
+                            });
+                        }).onFailure(aContext::failNow);
+
+                TestUtils.getDatabaseInstitutionAssertions(myDbConnectionPool, Optional.of(Set.of(validInstitution)))
+                        .onSuccess(assertions -> {
+                            aContext.verify(() -> {
+                                assertions.run();
+
+                                dbVerified.flag();
+                            });
+                        }).onFailure(aContext::failNow);
 
                 return Future.succeededFuture();
             });

--- a/src/test/java/edu/ucla/library/prl/harvester/JobRequestsFT.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/JobRequestsFT.java
@@ -7,6 +7,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.MalformedURLException;
 import java.text.ParseException;
+import java.util.Optional;
+import java.util.Set;
 
 import javax.mail.internet.AddressException;
 
@@ -186,7 +188,13 @@ public class JobRequestsFT {
                 responseVerified.flag();
             });
 
-            TestUtils.assertExpectedDatabaseJobRow(aContext, dbVerified, myDbConnectionPool, job, true);
+            TestUtils.getDatabaseJobAssertions(myDbConnectionPool, Optional.of(Set.of(job))).onSuccess(assertions -> {
+                aContext.verify(() -> {
+                    assertions.run();
+
+                    dbVerified.flag();
+                });
+            }).onFailure(aContext::failNow);
 
             // Second request
             listJobs = myWebClient.get(JOBS).expect(ResponsePredicate.JSON).send();
@@ -241,7 +249,13 @@ public class JobRequestsFT {
                 responseVerified.flag();
             });
 
-            TestUtils.assertExpectedDatabaseJobRow(aContext, dbVerified, myDbConnectionPool, job, true);
+            TestUtils.getDatabaseJobAssertions(myDbConnectionPool, Optional.of(Set.of(job))).onSuccess(assertions -> {
+                aContext.verify(() -> {
+                    assertions.run();
+
+                    dbVerified.flag();
+                });
+            }).onFailure(aContext::failNow);
 
             // Second request
             jobID = TestUtils.getUriTemplateVars(responseJob.getID().get());
@@ -300,7 +314,13 @@ public class JobRequestsFT {
                 responseVerified.flag();
             });
 
-            TestUtils.assertExpectedDatabaseJobRow(aContext, dbVerified, myDbConnectionPool, job, true);
+            TestUtils.getDatabaseJobAssertions(myDbConnectionPool, Optional.of(Set.of(job))).onSuccess(assertions -> {
+                aContext.verify(() -> {
+                    assertions.run();
+
+                    dbVerified.flag();
+                });
+            }).onFailure(aContext::failNow);
 
             // Second request
             jobID = TestUtils.getUriTemplateVars(responseJob.getID().get());
@@ -318,7 +338,14 @@ public class JobRequestsFT {
                     responseVerified.flag();
                 });
 
-                TestUtils.assertExpectedDatabaseJobRow(aContext, dbVerified, myDbConnectionPool, updatedJob, true);
+                TestUtils.getDatabaseJobAssertions(myDbConnectionPool, Optional.of(Set.of(updatedJob)))
+                        .onSuccess(assertions -> {
+                            aContext.verify(() -> {
+                                assertions.run();
+
+                                dbVerified.flag();
+                            });
+                        }).onFailure(aContext::failNow);
 
                 // Third request
                 getJob = myWebClient.get(JOB.expandToString(jobID)).expect(ResponsePredicate.JSON).send();
@@ -374,7 +401,13 @@ public class JobRequestsFT {
                 responseVerified.flag();
             });
 
-            TestUtils.assertExpectedDatabaseJobRow(aContext, dbVerified, myDbConnectionPool, job, true);
+            TestUtils.getDatabaseJobAssertions(myDbConnectionPool, Optional.of(Set.of(job))).onSuccess(assertions -> {
+                aContext.verify(() -> {
+                    assertions.run();
+
+                    dbVerified.flag();
+                });
+            }).onFailure(aContext::failNow);
 
             // Second request
             jobID = TestUtils.getUriTemplateVars(responseJob.getID().get());
@@ -389,7 +422,13 @@ public class JobRequestsFT {
                     responseVerified.flag();
                 });
 
-                TestUtils.assertExpectedDatabaseJobRow(aContext, dbVerified, myDbConnectionPool, job, false);
+                TestUtils.getDatabaseJobAssertions(myDbConnectionPool, Optional.empty()).onSuccess(assertions -> {
+                    aContext.verify(() -> {
+                        assertions.run();
+
+                        dbVerified.flag();
+                    });
+                }).onFailure(aContext::failNow);
 
                 // Third request
                 getJob = myWebClient.get(JOB.expandToString(jobID)).send();
@@ -451,7 +490,13 @@ public class JobRequestsFT {
                 responseVerified.flag();
             });
 
-            TestUtils.assertExpectedDatabaseJobRow(aContext, dbVerified, myDbConnectionPool, job, false);
+            TestUtils.getDatabaseJobAssertions(myDbConnectionPool, Optional.empty()).onSuccess(assertions -> {
+                aContext.verify(() -> {
+                    assertions.run();
+
+                    dbVerified.flag();
+                });
+            }).onFailure(aContext::failNow);
         }).onFailure(aContext::failNow);
     }
 
@@ -500,7 +545,13 @@ public class JobRequestsFT {
 
             });
 
-            TestUtils.assertExpectedDatabaseJobRow(aContext, dbVerified, myDbConnectionPool, validJob, false);
+            TestUtils.getDatabaseJobAssertions(myDbConnectionPool, Optional.empty()).onSuccess(assertions -> {
+                aContext.verify(() -> {
+                    assertions.run();
+
+                    dbVerified.flag();
+                });
+            }).onFailure(aContext::failNow);
         }).onFailure(aContext::failNow);
     }
 
@@ -541,7 +592,14 @@ public class JobRequestsFT {
 
             });
 
-            TestUtils.assertExpectedDatabaseJobRow(aContext, dbVerified, myDbConnectionPool, validJob, true);
+            TestUtils.getDatabaseJobAssertions(myDbConnectionPool, Optional.of(Set.of(validJob)))
+                    .onSuccess(assertions -> {
+                        aContext.verify(() -> {
+                            assertions.run();
+
+                            dbVerified.flag();
+                        });
+                    }).onFailure(aContext::failNow);
 
             // Second request
             jobID = TestUtils.getUriTemplateVars(responseJob.getID().get());
@@ -556,7 +614,14 @@ public class JobRequestsFT {
 
                 });
 
-                TestUtils.assertExpectedDatabaseJobRow(aContext, dbVerified, myDbConnectionPool, validJob, true);
+                TestUtils.getDatabaseJobAssertions(myDbConnectionPool, Optional.of(Set.of(validJob)))
+                        .onSuccess(assertions -> {
+                            aContext.verify(() -> {
+                                assertions.run();
+
+                                dbVerified.flag();
+                            });
+                        }).onFailure(aContext::failNow);
 
                 return Future.succeededFuture();
             });

--- a/src/test/java/edu/ucla/library/prl/harvester/services/HarvestServiceIT.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/services/HarvestServiceIT.java
@@ -121,7 +121,7 @@ public class HarvestServiceIT {
     @AfterEach
     public void afterEach(final Vertx aVertx, final VertxTestContext aContext) {
         myHarvestScheduleStoreServiceProxy.getInstitution(myTestInstitutionID).compose(institution -> {
-            return TestUtils.wipeSolrRecords(mySolrClient, institution.getName());
+            return TestUtils.removeItemRecords(mySolrClient, institution.getName());
         }).onSuccess(result -> aContext.completeNow()).onFailure(aContext::failNow);
     }
 

--- a/src/test/java/edu/ucla/library/prl/harvester/services/HarvestServiceIT.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/services/HarvestServiceIT.java
@@ -119,8 +119,10 @@ public class HarvestServiceIT {
      * @param aContext A test context
      */
     @AfterEach
-    public void beforeEach(final Vertx aVertx, final VertxTestContext aContext) {
-        TestUtils.wipeSolr(mySolrClient).onSuccess(result -> aContext.completeNow()).onFailure(aContext::failNow);
+    public void afterEach(final Vertx aVertx, final VertxTestContext aContext) {
+        myHarvestScheduleStoreServiceProxy.getInstitution(myTestInstitutionID).compose(institution -> {
+            return TestUtils.wipeSolrRecords(mySolrClient, institution.getName());
+        }).onSuccess(result -> aContext.completeNow()).onFailure(aContext::failNow);
     }
 
     /**
@@ -129,7 +131,9 @@ public class HarvestServiceIT {
      */
     @AfterAll
     public void tearDown(final Vertx aVertx, final VertxTestContext aContext) {
-        myHarvestServiceProxy.close().compose(result -> {
+        TestUtils.wipeSolr(mySolrClient).compose(result -> {
+            return myHarvestServiceProxy.close();
+        }).compose(result -> {
             mySolrClient.shutdown();
 
             return TestUtils.wipeDatabase(myDbConnectionPool).compose(nil -> myDbConnectionPool.close());

--- a/src/test/java/edu/ucla/library/prl/harvester/utils/TestUtils.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/utils/TestUtils.java
@@ -3,27 +3,48 @@ package edu.ucla.library.prl.harvester.utils;
 
 import edu.ucla.library.prl.harvester.Institution;
 import edu.ucla.library.prl.harvester.Job;
+import edu.ucla.library.prl.harvester.MessageCodes;
 import edu.ucla.library.prl.harvester.Param;
+
+import info.freelibrary.util.Logger;
+import info.freelibrary.util.LoggerFactory;
+import info.freelibrary.util.StringUtils;
 
 import io.ino.solrs.JavaAsyncSolrClient;
 
+import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.ext.web.client.predicate.ResponsePredicate;
+import io.vertx.junit5.Checkpoint;
+import io.vertx.junit5.VertxTestContext;
+import io.vertx.junit5.VertxTestContext.ExecutionBlock;
 import io.vertx.sqlclient.Pool;
 import io.vertx.sqlclient.SqlResult;
+import io.vertx.sqlclient.Tuple;
 import io.vertx.sqlclient.templates.SqlTemplate;
+import io.vertx.uritemplate.UriTemplate;
 import io.vertx.uritemplate.Variables;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.text.ParseException;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Random;
+import java.util.Set;
 import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
+import java.util.stream.Stream;
 
 import javax.mail.internet.AddressException;
 import javax.mail.internet.InternetAddress;
@@ -34,7 +55,9 @@ import com.google.i18n.phonenumbers.Phonenumber.PhoneNumber;
 
 import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.client.solrj.response.UpdateResponse;
+import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrDocumentList;
+import org.apache.solr.common.SolrInputDocument;
 import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.common.util.NamedList;
 
@@ -50,6 +73,14 @@ import org.quartz.CronExpression;
  * Utilities related to working with test objects.
  */
 public final class TestUtils {
+
+    public static final UriTemplate INSTITUTION = UriTemplate.of("/institutions/{id}");
+
+    public static final UriTemplate INSTITUTIONS = UriTemplate.of("/institutions");
+
+    public static final UriTemplate JOB = UriTemplate.of("/jobs/{id}");
+
+    public static final UriTemplate JOBS = UriTemplate.of("/jobs");
 
     private static final Random RANDOMIZER = new Random();
 
@@ -73,6 +104,10 @@ public final class TestUtils {
     private static final OffsetDateTimeRandomizer RAND_DATE = new OffsetDateTimeRandomizer();
 
     private static final String SOLR_SELECT_ALL = "*:*";
+
+    private static final String SOLR_SELECT_BY_ID = "id:\"{}\"";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TestUtils.class, MessageCodes.BUNDLE);
 
     private TestUtils() {
     }
@@ -159,15 +194,52 @@ public final class TestUtils {
     }
 
     /**
+     * Clears out the Solr index of item records associated with a single institution.
+     *
+     * @param aSolrClient A Solr client
+     * @param anInstitutionName The name of the institution whose item records should be removed
+     * @return A Future that succeeds if the Solr index was modified successfully, and fails otherwise
+     */
+    public static Future<UpdateResponse> wipeSolrRecords(final JavaAsyncSolrClient aSolrClient,
+            final String anInstitutionName) {
+        final CompletionStage<UpdateResponse> wipeSolrRecords =
+                aSolrClient.deleteByQuery(StringUtils.format("institutionName:\"{}\"", anInstitutionName))
+                        .thenCompose(result -> aSolrClient.commit());
+
+        return Future.fromCompletionStage(wipeSolrRecords);
+    }
+
+    /**
      * @param aSolrClient A Solr client
      * @return A Future that resolves to the list of all documents
      */
     public static Future<SolrDocumentList> getAllDocuments(final JavaAsyncSolrClient aSolrClient) {
-        final SolrParams solrParams = new NamedList<>(Map.of("q", SOLR_SELECT_ALL)).toSolrParams();
         final CompletionStage<SolrDocumentList> results =
-                aSolrClient.query(solrParams).thenApply(QueryResponse::getResults);
+                aSolrClient.query(getSolrParamsFromQuery(SOLR_SELECT_ALL)).thenApply(QueryResponse::getResults);
 
         return Future.fromCompletionStage(results);
+    }
+
+    /**
+     * @param aSolrClient A Solr client
+     * @param anInstitutionName An institution name
+     * @return A Future that resolves to the list of documents that should not exceed a size of 1
+     */
+    public static Future<SolrDocumentList> getInstitutionDoc(final JavaAsyncSolrClient aSolrClient,
+            final String anInstitutionName) {
+        final String query = StringUtils.format(SOLR_SELECT_BY_ID, anInstitutionName);
+        final CompletionStage<SolrDocumentList> results =
+                aSolrClient.query(getSolrParamsFromQuery(query)).thenApply(QueryResponse::getResults);
+
+        return Future.fromCompletionStage(results);
+    }
+
+    /**
+     * @param aQuery A Solr query string
+     * @return The params
+     */
+    private static SolrParams getSolrParamsFromQuery(final String aQuery) {
+        return new NamedList<>(Map.of("q", aQuery)).toSolrParams();
     }
 
     /**
@@ -176,5 +248,218 @@ public final class TestUtils {
      */
     public static Variables getUriTemplateVars(final int anID) {
         return Variables.variables(new JsonObject().put(Param.id.name(), anID));
+    }
+
+    /**
+     * Resets the application.
+     * <p>
+     * Use of the REST API is required because the application maintains the job schedule in-memory.
+     *
+     * @param aWebClient A web client with its default host and port set to point to the application
+     * @return A Future that succeeds if the application was reset successfully, and fails otherwise
+     */
+    public static Future<Void> resetApplication(final WebClient aWebClient) {
+        return aWebClient.get(JOBS).send().compose(response -> {
+            final Stream<Integer> jobIDs = response.bodyAsJsonArray().stream().map(job -> new Job((JsonObject) job)
+                    .getID().orElseThrow(() -> new NoSuchElementException(LOGGER.getMessage(MessageCodes.PRL_023))));
+            @SuppressWarnings("rawtypes")
+            final Function<Integer, Future> deleteJob = id -> {
+                final String uri = JOB.expandToString(getUriTemplateVars(id));
+
+                return aWebClient.delete(uri).expect(ResponsePredicate.SC_NO_CONTENT).send();
+            };
+
+            return CompositeFuture.all(jobIDs.map(deleteJob).toList());
+        }).compose(result -> {
+            return aWebClient.get(INSTITUTIONS).send().compose(response -> {
+                final Stream<Integer> instIDs = response.bodyAsJsonArray().stream()
+                        .map(inst -> new Institution((JsonObject) inst).getID().orElseThrow(
+                                () -> new NoSuchElementException(LOGGER.getMessage(MessageCodes.PRL_022))));
+                @SuppressWarnings("rawtypes")
+                final Function<Integer, Future> deleteInst = id -> {
+                    final String uri = INSTITUTION.expandToString(getUriTemplateVars(id));
+
+                    return aWebClient.delete(uri).expect(ResponsePredicate.SC_NO_CONTENT).send();
+                };
+
+                return CompositeFuture.all(instIDs.map(deleteInst).toList());
+            });
+        }).compose(result -> {
+            return result.mapEmpty();
+        });
+    }
+
+    /**
+     * Runs some assertions on institution rows in a database.
+     *
+     * @param aContext A test context
+     * @param aCheckpoint A checkpoint that will be flagged if the appropriate assertions pass
+     * @param aDbConnectionPool A database connection pool
+     * @param anInstitution An institution that may or not be represented in the database
+     * @param anExpectedExistence Whether or not an institution is expected to be represented in the database
+     */
+    public static void assertExpectedDatabaseInstitutionRow(final VertxTestContext aContext,
+            final Checkpoint aCheckpoint, final Pool aDbConnectionPool, final Institution anInstitution,
+            final boolean anExpectedExistence) {
+        aDbConnectionPool.withConnection(connection -> {
+            final String query = """
+                SELECT id, name, description, location, email, phone, webContact AS "webContact", website
+                FROM public.institutions
+                WHERE name = $1
+                """;
+
+            return connection.preparedQuery(query).execute(Tuple.of(anInstitution.getName()));
+        }).onSuccess(result -> {
+            final ExecutionBlock checksToRun;
+
+            if (anExpectedExistence) {
+                checksToRun = () -> {
+                    final JsonObject expected;
+                    final Institution institution;
+
+                    assertEquals(1, result.rowCount());
+
+                    institution = new Institution(result.iterator().next().toJson());
+                    expected = anInstitution.toJson().put(Institution.ID, institution.getID()
+                            .orElseThrow(() -> new NoSuchElementException(LOGGER.getMessage(MessageCodes.PRL_022))));
+
+                    assertEquals(expected, institution.toJson());
+
+                    aCheckpoint.flag();
+                };
+            } else {
+                checksToRun = () -> {
+                    assertEquals(0, result.rowCount());
+
+                    aCheckpoint.flag();
+                };
+            }
+
+            aContext.verify(checksToRun);
+        }).onFailure(aContext::failNow);
+    }
+
+    /**
+     * Runs some assertions on job rows in a database.
+     *
+     * @param aContext A test context
+     * @param aCheckpoint A checkpoint that will be flagged if the appropriate assertions pass
+     * @param aDbConnectionPool A database connection pool
+     * @param aJob A job that may or not be represented in the database
+     * @param anExpectedExistence Whether or not a job is expected to be represented in the database
+     */
+    public static void assertExpectedDatabaseJobRow(final VertxTestContext aContext, final Checkpoint aCheckpoint,
+            final Pool aDbConnectionPool, final Job aJob, final boolean anExpectedExistence) {
+        aDbConnectionPool.withConnection(connection -> {
+            final String query = """
+                SELECT
+                    id, institutionID AS "institutionID", repositoryBaseURL AS "repositoryBaseURL",
+                    metadataPrefix AS "metadataPrefix", sets, lastSuccessfulRun AS "lastSuccessfulRun",
+                    scheduleCronExpression AS "scheduleCronExpression"
+                FROM public.harvestjobs
+                WHERE repositoryBaseURL = $1
+                """;
+
+            return connection.preparedQuery(query).execute(Tuple.of(aJob.getRepositoryBaseURL().toString()));
+        }).onSuccess(result -> {
+            final ExecutionBlock checksToRun;
+
+            if (anExpectedExistence) {
+                checksToRun = () -> {
+                    final JsonObject expected;
+                    final Job job;
+
+                    assertEquals(1, result.rowCount());
+
+                    job = new Job(result.iterator().next().toJson());
+                    expected = aJob.toJson().put(Job.ID, job.getID()
+                            .orElseThrow(() -> new NoSuchElementException(LOGGER.getMessage(MessageCodes.PRL_023))));
+
+                    assertEquals(expected, job.toJson());
+
+                    aCheckpoint.flag();
+                };
+            } else {
+                checksToRun = () -> {
+                    assertEquals(0, result.rowCount());
+
+                    aCheckpoint.flag();
+                };
+            }
+
+            aContext.verify(checksToRun);
+        }).onFailure(aContext::failNow);
+    }
+
+    /**
+     * Runs some assertions on institution docs in a Solr index.
+     *
+     * @param aContext A test context
+     * @param aCheckpoint A checkpoint
+     * @param aSolrClient A Solr client
+     * @param anInstitutionList The optional exhaustive list of institutions expected to be represented in the index
+     */
+    public static void assertExpectedSolrState(final VertxTestContext aContext, final Checkpoint aCheckpoint,
+            final JavaAsyncSolrClient aSolrClient, final Optional<Set<Institution>> anInstitutionList) {
+        getAllDocuments(aSolrClient).onSuccess(result -> {
+            final ExecutionBlock checksToRun;
+
+            if (anInstitutionList.isPresent()) {
+                checksToRun = () -> {
+                    final Set<Institution> institutions;
+
+                    assertTrue(anInstitutionList.isPresent());
+
+                    institutions = anInstitutionList.get();
+
+                    assertEquals(institutions.size(), result.getNumFound());
+
+                    for (final Institution institution : institutions) {
+                        final SolrInputDocument input = institution.toSolrDoc();
+                        final Optional<SolrDocument> output = result.stream()
+                                .filter(doc -> doc.get(Institution.ID).equals(input.getFieldValue(Institution.ID)))
+                                .findAny();
+
+                        assertTrue(output.isPresent());
+                        assertTrue(documentsAreEffectivelyEqual(input, output.get()));
+                    }
+
+                    aCheckpoint.flag();
+                };
+            } else {
+                checksToRun = () -> {
+                    assertEquals(0, result.getNumFound());
+
+                    aCheckpoint.flag();
+                };
+            }
+
+            aContext.verify(checksToRun);
+        }).onFailure(aContext::failNow);
+    }
+
+    /**
+     * @param anInput A Solr input document
+     * @param anOutput A Solr output document
+     * @return Whether or not the documents are effectively equalent
+     */
+    private static boolean documentsAreEffectivelyEqual(final SolrInputDocument anInput, final SolrDocument anOutput) {
+        final Collection<String> inputFieldNames = anInput.getFieldNames();
+        final Collection<String> outputFieldNames = anOutput.getFieldNames();
+
+        // Consider all fields except _version_, which isn't present for input documents
+        outputFieldNames.remove("_version_");
+
+        if (!inputFieldNames.containsAll(outputFieldNames) || !outputFieldNames.containsAll(inputFieldNames)) {
+            return false;
+        }
+
+        for (final String field : inputFieldNames) {
+            if (!anInput.getFieldValues(field).equals(anOutput.getFieldValues(field))) {
+                return false;
+            }
+        }
+
+        return true;
     }
 }


### PR DESCRIPTION
Builds off of changes introduced in #44 (note the use of `OaipmhUtils`, `Institution#toSolrDoc`, and the `set_spec` Solr index field).

The main change to the application code is that some handlers are now Solr-aware, and they must now implement an abstract method that returns `Future<UpdateResponse>` and call it, of course (and the changes to the tests verify that that is done correctly).

Sorry about the size.