### PR TITLE
[SERV-739] Implement UI for institution write operations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -374,6 +374,7 @@
             </goals>
             <phase>test</phase>
             <configuration>
+              <skip>${skipUTs}</skip>
               <arguments>
                 <argument>run</argument>
                 <argument>test:unit</argument>

--- a/src/main/frontend/.prettierrc.json
+++ b/src/main/frontend/.prettierrc.json
@@ -1,5 +1,6 @@
 {
     "printWidth": 120,
     "tabWidth": 4,
-    "semi": false
+    "semi": false,
+    "bracketSameLine": true
 }

--- a/src/main/frontend/package-lock.json
+++ b/src/main/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "prl-harvester-frontend",
       "version": "0.0.0",
       "dependencies": {
+        "http-status-codes": "^2.2.0",
         "vue": "^3.2.45",
         "vuetify": "^3.1.8"
       },
@@ -1697,6 +1698,11 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/http-status-codes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.2.0.tgz",
+      "integrity": "sha512-feERVo9iWxvnejp3SEfm/+oNG517npqL2/PIA8ORjyOZjGC7TwCRQsZylciLS64i6pJ0wRYz3rkXLRwbtFa8Ng=="
     },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
@@ -4249,6 +4255,11 @@
         "agent-base": "6",
         "debug": "4"
       }
+    },
+    "http-status-codes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.2.0.tgz",
+      "integrity": "sha512-feERVo9iWxvnejp3SEfm/+oNG517npqL2/PIA8ORjyOZjGC7TwCRQsZylciLS64i6pJ0wRYz3rkXLRwbtFa8Ng=="
     },
     "https-proxy-agent": {
       "version": "5.0.1",

--- a/src/main/frontend/package-lock.json
+++ b/src/main/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "vuetify": "^3.1.8"
       },
       "devDependencies": {
+        "@mdi/font": "^7.1.96",
         "@rushstack/eslint-patch": "^1.1.4",
         "@vitejs/plugin-vue": "^4.0.0",
         "@vue/eslint-config-prettier": "^7.0.0",
@@ -442,6 +443,12 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+      "dev": true
+    },
+    "node_modules/@mdi/font": {
+      "version": "7.1.96",
+      "resolved": "https://registry.npmjs.org/@mdi/font/-/font-7.1.96.tgz",
+      "integrity": "sha512-Imag6npmfkBDi2Ze2jiZVAPTDIKLxhz2Sx82xJ2zctyAU5LYJejLI5ChnDwiD9bMkQfVuzEsI98Q8toHyC+HCg==",
       "dev": true
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -3283,6 +3290,12 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+      "dev": true
+    },
+    "@mdi/font": {
+      "version": "7.1.96",
+      "resolved": "https://registry.npmjs.org/@mdi/font/-/font-7.1.96.tgz",
+      "integrity": "sha512-Imag6npmfkBDi2Ze2jiZVAPTDIKLxhz2Sx82xJ2zctyAU5LYJejLI5ChnDwiD9bMkQfVuzEsI98Q8toHyC+HCg==",
       "dev": true
     },
     "@nodelib/fs.scandir": {

--- a/src/main/frontend/package-lock.json
+++ b/src/main/frontend/package-lock.json
@@ -8,7 +8,8 @@
       "name": "prl-harvester-frontend",
       "version": "0.0.0",
       "dependencies": {
-        "vue": "^3.2.45"
+        "vue": "^3.2.45",
+        "vuetify": "^3.1.8"
       },
       "devDependencies": {
         "@rushstack/eslint-patch": "^1.1.4",
@@ -2909,6 +2910,35 @@
         "eslint": ">=6.0.0"
       }
     },
+    "node_modules/vuetify": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.1.8.tgz",
+      "integrity": "sha512-yODCnRxERSvcBwC6qPiySVhmZzNZ2Yme6b2lNLY1G8W/hbipAtbTCFVGB4ZY/qY7D7JNQBxzgVfZme7bDY9ZrQ==",
+      "engines": {
+        "node": "^12.20 || >=14.13"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/johnleider"
+      },
+      "peerDependencies": {
+        "vite-plugin-vuetify": "^1.0.0-alpha.12",
+        "vue": "^3.2.0",
+        "vue-i18n": "^9.0.0",
+        "webpack-plugin-vuetify": "^2.0.0-alpha.11"
+      },
+      "peerDependenciesMeta": {
+        "vite-plugin-vuetify": {
+          "optional": true
+        },
+        "vue-i18n": {
+          "optional": true
+        },
+        "webpack-plugin-vuetify": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/w3c-xmlserializer": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
@@ -5056,6 +5086,12 @@
         "lodash": "^4.17.21",
         "semver": "^7.3.6"
       }
+    },
+    "vuetify": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.1.8.tgz",
+      "integrity": "sha512-yODCnRxERSvcBwC6qPiySVhmZzNZ2Yme6b2lNLY1G8W/hbipAtbTCFVGB4ZY/qY7D7JNQBxzgVfZme7bDY9ZrQ==",
+      "requires": {}
     },
     "w3c-xmlserializer": {
       "version": "4.0.0",

--- a/src/main/frontend/package.json
+++ b/src/main/frontend/package.json
@@ -11,7 +11,8 @@
     "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs --fix --ignore-path .gitignore"
   },
   "dependencies": {
-    "vue": "^3.2.45"
+    "vue": "^3.2.45",
+    "vuetify": "^3.1.8"
   },
   "devDependencies": {
     "@rushstack/eslint-patch": "^1.1.4",

--- a/src/main/frontend/package.json
+++ b/src/main/frontend/package.json
@@ -11,6 +11,7 @@
     "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs --fix --ignore-path .gitignore"
   },
   "dependencies": {
+    "http-status-codes": "^2.2.0",
     "vue": "^3.2.45",
     "vuetify": "^3.1.8"
   },

--- a/src/main/frontend/package.json
+++ b/src/main/frontend/package.json
@@ -16,6 +16,7 @@
     "vuetify": "^3.1.8"
   },
   "devDependencies": {
+    "@mdi/font": "^7.1.96",
     "@rushstack/eslint-patch": "^1.1.4",
     "@vitejs/plugin-vue": "^4.0.0",
     "@vue/eslint-config-prettier": "^7.0.0",

--- a/src/main/frontend/src/App.vue
+++ b/src/main/frontend/src/App.vue
@@ -1,28 +1,71 @@
 <script setup>
-import { reactive, provide } from "vue"
+import { reactive } from "vue"
+import { StatusCodes } from "http-status-codes"
+
 import { version } from "../package.json"
 import HarvesterAdmin from "./components/HarvesterAdmin.vue"
 
 const state = reactive({ institutions: {}, jobs: {} })
 
 /**
- * Sets the state. FIXME
+ * Sends an addInstitution request and updates the front-end state according to the response.
  *
- * @param {Number} anInstitutionID The ID of the institution
  * @param {Object} anInstitution The institution
+ * @returns The HTTP response
  */
-function stateSetInstitution(anInstitutionID, anInstitution) {
-    state.institutions[anInstitutionID] = anInstitution
+async function sendAddInstitutionRequest(anInstitution) {
+    const response = await fetch("/institutions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(anInstitution),
+    })
+
+    if (response.status === StatusCodes.CREATED) {
+        const responseBody = await response.json()
+
+        state.institutions[responseBody.id] = responseBody
+    }
+
+    return response
 }
 
 /**
- * Deletes the state. FIXME
+ * Sends an updateInstitution request and updates the front-end state according to the response.
+ *
+ * @param {Object} anInstitution The institution
+ * @returns The HTTP response
+ */
+async function sendUpdateInstitutionRequest(anInstitution) {
+    const response = await fetch(`/institutions/${anInstitution.id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(anInstitution),
+    })
+
+    if (response.status === StatusCodes.OK) {
+        const responseBody = await response.json()
+
+        state.institutions[responseBody.id] = responseBody
+    }
+
+    return response
+}
+
+/**
+ * Sends an removeInstitution request and updates the front-end state according to the response.
  *
  * @param {Number} anInstitutionID The ID of the institution
+ * @returns The HTTP response
  */
-function stateDeleteInstitution(anInstitutionID) {
-    delete state.jobs[anInstitutionID]
-    delete state.institutions[anInstitutionID]
+async function sendRemoveInstitutionRequest(anInstitutionID) {
+    const response = await fetch(`/institutions/${anInstitutionID}`, { method: "DELETE" })
+
+    if (response.status === StatusCodes.NO_CONTENT) {
+        delete state.jobs[anInstitutionID]
+        delete state.institutions[anInstitutionID]
+    }
+
+    return response
 }
 
 // Fetch data from back-end
@@ -43,9 +86,6 @@ fetch("/jobs")
             state.jobs[job.institutionID].push(job)
         })
     })
-
-provide("stateSetInstitution", stateSetInstitution)
-provide("stateDeleteInstitution", stateDeleteInstitution)
 </script>
 
 <template>
@@ -54,7 +94,12 @@ provide("stateDeleteInstitution", stateDeleteInstitution)
     </header>
 
     <main>
-        <HarvesterAdmin v-bind="state" />
+        <HarvesterAdmin
+            v-bind="state"
+            :sendAddInstitutionRequest="sendAddInstitutionRequest"
+            :sendUpdateInstitutionRequest="sendUpdateInstitutionRequest"
+            :sendRemoveInstitutionRequest="sendRemoveInstitutionRequest"
+        />
     </main>
 
     <footer>PRL Harvester Admin v{{ version }}</footer>

--- a/src/main/frontend/src/App.vue
+++ b/src/main/frontend/src/App.vue
@@ -8,7 +8,7 @@ import HarvesterAdmin from "./components/HarvesterAdmin.vue"
 const state = reactive({ institutions: {}, jobs: {} })
 
 /**
- * Sends an addInstitution request and updates the front-end state according to the response.
+ * Sends an addInstitution request and, if successful, updates the state with the result.
  *
  * @param {Object} anInstitution The institution
  * @returns The HTTP response
@@ -30,7 +30,7 @@ async function sendAddInstitutionRequest(anInstitution) {
 }
 
 /**
- * Sends an updateInstitution request and updates the front-end state according to the response.
+ * Sends an updateInstitution request and, if successful, updates the state with the result.
  *
  * @param {Object} anInstitution The institution
  * @returns The HTTP response
@@ -52,7 +52,7 @@ async function sendUpdateInstitutionRequest(anInstitution) {
 }
 
 /**
- * Sends an removeInstitution request and updates the front-end state according to the response.
+ * Sends an removeInstitution request and, if successful, updates the state with the result.
  *
  * @param {Number} anInstitutionID The ID of the institution
  * @returns The HTTP response

--- a/src/main/frontend/src/App.vue
+++ b/src/main/frontend/src/App.vue
@@ -98,8 +98,7 @@ fetch("/jobs")
             v-bind="state"
             :sendAddInstitutionRequest="sendAddInstitutionRequest"
             :sendUpdateInstitutionRequest="sendUpdateInstitutionRequest"
-            :sendRemoveInstitutionRequest="sendRemoveInstitutionRequest"
-        />
+            :sendRemoveInstitutionRequest="sendRemoveInstitutionRequest" />
     </main>
 
     <footer>PRL Harvester Admin v{{ version }}</footer>

--- a/src/main/frontend/src/App.vue
+++ b/src/main/frontend/src/App.vue
@@ -1,6 +1,51 @@
 <script setup>
+import { reactive, provide } from "vue"
 import { version } from "../package.json"
 import HarvesterAdmin from "./components/HarvesterAdmin.vue"
+
+const state = reactive({ institutions: {}, jobs: {} })
+
+/**
+ * Sets the state. FIXME
+ *
+ * @param {Number} anInstitutionID The ID of the institution
+ * @param {Object} anInstitution The institution
+ */
+function stateSetInstitution(anInstitutionID, anInstitution) {
+    state.institutions[anInstitutionID] = anInstitution
+}
+
+/**
+ * Deletes the state. FIXME
+ *
+ * @param {Number} anInstitutionID The ID of the institution
+ */
+function stateDeleteInstitution(anInstitutionID) {
+    delete state.jobs[anInstitutionID]
+    delete state.institutions[anInstitutionID]
+}
+
+// Fetch data from back-end
+fetch("/institutions")
+    .then((response) => response.json())
+    .then((institutions) => {
+        institutions.forEach((institution) => (state.institutions[institution.id] = institution))
+    })
+
+fetch("/jobs")
+    .then((response) => response.json())
+    .then((jobs) => {
+        jobs.forEach((job) => {
+            if (state.jobs[job.institutionID] === undefined) {
+                state.jobs[job.institutionID] = []
+            }
+
+            state.jobs[job.institutionID].push(job)
+        })
+    })
+
+provide("stateSetInstitution", stateSetInstitution)
+provide("stateDeleteInstitution", stateDeleteInstitution)
 </script>
 
 <template>
@@ -9,7 +54,7 @@ import HarvesterAdmin from "./components/HarvesterAdmin.vue"
     </header>
 
     <main>
-        <HarvesterAdmin />
+        <HarvesterAdmin v-bind="state" />
     </main>
 
     <footer>PRL Harvester Admin v{{ version }}</footer>

--- a/src/main/frontend/src/components/HarvesterAdmin.vue
+++ b/src/main/frontend/src/components/HarvesterAdmin.vue
@@ -1,8 +1,10 @@
 <script setup>
-import { reactive, computed } from "vue"
+import { reactive, ref, computed, provide } from "vue"
 import InstitutionItem from "./InstitutionItem.vue"
 
 const state = reactive({ institutions: {}, jobs: {} })
+const institutionToRemove = ref()
+const actionResultAlert = ref()
 const sortedInstitutions = computed(() => Object.values(state.institutions).sort((a, b) => (a.name < b.name ? -1 : 1)))
 const hasInstitutions = computed(() => Object.keys(state.institutions).length > 0)
 
@@ -25,6 +27,43 @@ fetch("/jobs")
             state.jobs[job.institutionID].push(job)
         })
     })
+
+/**
+ * Sets the component state that renders a dialog for the user to confirm institution removal.
+ *
+ * @param {Number} anInstitutionID The ID of the institution to remove
+ */
+function setInstitutionToRemove(anInstitutionID) {
+    institutionToRemove.value = anInstitutionID
+}
+
+/**
+ * Removes an institution.
+ *
+ * @param {Number} anInstitutionID The ID of the institution to remove
+ */
+async function removeInstitution(anInstitutionID) {
+    const response = await fetch(`/institutions/${anInstitutionID}`, { method: "DELETE" })
+
+    if (response.status === 204) {
+        delete state.jobs[anInstitutionID]
+        delete state.institutions[anInstitutionID]
+
+        actionResultAlert.value = {
+            color: "success",
+            message: "Institution removed successfully",
+        }
+    } else {
+        actionResultAlert.value = {
+            color: "error",
+            message: `Institution remove failed: HTTP ${response.status} (${response.statusText})`,
+        }
+    }
+
+    setInstitutionToRemove(undefined)
+}
+
+provide("setInstitutionToRemove", setInstitutionToRemove)
 </script>
 
 <template>
@@ -34,6 +73,30 @@ fetch("/jobs")
         </li>
     </ol>
     <p v-else>No institutions yet!</p>
+
+    <v-dialog v-if="institutionToRemove" v-model="institutionToRemove" width="auto">
+        <v-card>
+            <v-card-text>
+                <p>
+                    This action will remove <strong>{{ state.institutions[institutionToRemove].name }}</strong
+                    >.
+                </p>
+                <p v-if="state.jobs[institutionToRemove]">
+                    This will also remove its {{ state.jobs[institutionToRemove].length }} jobs and all harvested items.
+                </p>
+            </v-card-text>
+            <v-card-actions class="d-flex justify-center align-baseline">
+                <v-btn color="red" variant="outlined" @click="removeInstitution(institutionToRemove)" width="auto"
+                    >Remove</v-btn
+                >
+                <v-btn variant="outlined" width="auto" @click="setInstitutionToRemove(undefined)">Cancel</v-btn>
+            </v-card-actions>
+        </v-card>
+    </v-dialog>
+
+    <v-snackbar v-if="actionResultAlert" v-model="actionResultAlert" :color="actionResultAlert.color">
+        {{ actionResultAlert.message }}
+    </v-snackbar>
 </template>
 
 <style scoped>

--- a/src/main/frontend/src/components/HarvesterAdmin.vue
+++ b/src/main/frontend/src/components/HarvesterAdmin.vue
@@ -2,13 +2,16 @@
 import { reactive, ref, computed, provide } from "vue"
 import InstitutionItem from "./InstitutionItem.vue"
 
+// State that must be kept in sync with the back-end
 const state = reactive({ institutions: {}, jobs: {} })
+const hasInstitutions = computed(() => Object.keys(state.institutions).length > 0)
+const sortedInstitutions = computed(() => Object.values(state.institutions).sort((a, b) => (a.name < b.name ? -1 : 1)))
+
+// State exclusive to the front-end
 const displayInstitutionForm = ref(false)
 const institutionToAddOrUpdate = ref({})
 const institutionToRemove = ref()
 const actionResultAlert = ref()
-const sortedInstitutions = computed(() => Object.values(state.institutions).sort((a, b) => (a.name < b.name ? -1 : 1)))
-const hasInstitutions = computed(() => Object.keys(state.institutions).length > 0)
 
 // Initialize application state
 

--- a/src/main/frontend/src/components/HarvesterAdmin.vue
+++ b/src/main/frontend/src/components/HarvesterAdmin.vue
@@ -10,6 +10,8 @@ const actionResultAlert = ref()
 const sortedInstitutions = computed(() => Object.values(state.institutions).sort((a, b) => (a.name < b.name ? -1 : 1)))
 const hasInstitutions = computed(() => Object.keys(state.institutions).length > 0)
 
+// Initialize application state
+
 fetch("/institutions")
     .then((response) => response.json())
     .then((institutions) => {
@@ -29,6 +31,9 @@ fetch("/jobs")
             state.jobs[job.institutionID].push(job)
         })
     })
+
+provide("setInstitutionToUpdate", setInstitutionToUpdate)
+provide("setInstitutionToRemove", setInstitutionToRemove)
 
 /**
  * Sets the component state that renders a dialog with a form for the user to add or update an institution.
@@ -166,9 +171,6 @@ async function removeInstitution(anInstitutionID) {
 
     setInstitutionToRemove(undefined)
 }
-
-provide("setInstitutionToUpdate", setInstitutionToUpdate)
-provide("setInstitutionToRemove", setInstitutionToRemove)
 </script>
 
 <template>

--- a/src/main/frontend/src/components/HarvesterAdmin.vue
+++ b/src/main/frontend/src/components/HarvesterAdmin.vue
@@ -2,14 +2,16 @@
 import { reactive, computed } from "vue"
 import InstitutionItem from "./InstitutionItem.vue"
 
-const state = reactive({ institutions: [], jobs: {} })
-const sortedInstitutions = computed(() => state.institutions.slice().sort((a, b) => (a.name < b.name ? -1 : 1)))
-const hasInstitutions = computed(() => state.institutions.length > 0)
+const state = reactive({ institutions: {}, jobs: {} })
+const sortedInstitutions = computed(() => Object.values(state.institutions).sort((a, b) => (a.name < b.name ? -1 : 1)))
+const hasInstitutions = computed(() => Object.keys(state.institutions).length > 0)
 
 fetch("/institutions")
     .then((response) => response.json())
     .then((institutions) => {
-        state.institutions = institutions
+        institutions.forEach((institution) => {
+            state.institutions[institution.id] = institution
+        })
     })
 
 fetch("/jobs")

--- a/src/main/frontend/src/components/HarvesterAdmin.vue
+++ b/src/main/frontend/src/components/HarvesterAdmin.vue
@@ -142,8 +142,7 @@ async function removeInstitution(anInstitutionID) {
         color="primary"
         variant="outlined"
         @click="toggleDisplayInstitutionForm"
-        class="propose-add-institution ma-4"
-    >
+        class="propose-add-institution ma-4">
         Add Institution
     </v-btn>
 
@@ -153,8 +152,7 @@ async function removeInstitution(anInstitutionID) {
                 v-bind="institution"
                 :jobs="props.jobs[institution.id] || []"
                 :selectInstitutionToUpdate="selectInstitutionToUpdate"
-                :selectInstitutionToRemove="selectInstitutionToRemove"
-            />
+                :selectInstitutionToRemove="selectInstitutionToRemove" />
         </v-list-item>
     </v-list>
     <v-card v-else variant="plain" width="auto">
@@ -169,8 +167,7 @@ async function removeInstitution(anInstitutionID) {
                     v-if="institutionToAddOrUpdate.id"
                     label="ID"
                     v-model="institutionToAddOrUpdate.id"
-                    disabled
-                ></v-text-field>
+                    disabled></v-text-field>
                 <v-text-field label="Name" v-model="institutionToAddOrUpdate.name" required></v-text-field>
                 <v-textarea label="Description" v-model="institutionToAddOrUpdate.description" required></v-textarea>
                 <v-text-field label="Location" v-model="institutionToAddOrUpdate.location" required></v-text-field>
@@ -178,15 +175,13 @@ async function removeInstitution(anInstitutionID) {
                     label="Website"
                     type="url"
                     v-model="institutionToAddOrUpdate.website"
-                    required
-                ></v-text-field>
+                    required></v-text-field>
                 <v-text-field label="Email" type="email" v-model="institutionToAddOrUpdate.email"></v-text-field>
                 <v-text-field label="Phone" type="tel" v-model="institutionToAddOrUpdate.phone"></v-text-field>
                 <v-text-field
                     label="Web Contact"
                     type="url"
-                    v-model="institutionToAddOrUpdate.webContact"
-                ></v-text-field>
+                    v-model="institutionToAddOrUpdate.webContact"></v-text-field>
             </v-form>
             <v-card-actions class="d-flex justify-center align-baseline">
                 <v-btn
@@ -195,8 +190,7 @@ async function removeInstitution(anInstitutionID) {
                     variant="outlined"
                     width="auto"
                     class="confirm-add-institution"
-                    @click="addInstitution(institutionToAddOrUpdate)"
-                >
+                    @click="addInstitution(institutionToAddOrUpdate)">
                     Save
                 </v-btn>
                 <v-btn
@@ -205,16 +199,14 @@ async function removeInstitution(anInstitutionID) {
                     variant="outlined"
                     width="auto"
                     class="confirm-update-institution"
-                    @click="updateInstitution(institutionToAddOrUpdate)"
-                >
+                    @click="updateInstitution(institutionToAddOrUpdate)">
                     Save
                 </v-btn>
                 <v-btn
                     variant="outlined"
                     width="auto"
                     @click="toggleDisplayInstitutionForm"
-                    class="cancel-add-or-update-institution"
-                >
+                    class="cancel-add-or-update-institution">
                     Cancel
                 </v-btn>
             </v-card-actions>
@@ -244,16 +236,14 @@ async function removeInstitution(anInstitutionID) {
                     variant="outlined"
                     @click="removeInstitution(institutionToRemove)"
                     width="auto"
-                    class="confirm-remove-institution"
-                >
+                    class="confirm-remove-institution">
                     Remove
                 </v-btn>
                 <v-btn
                     variant="outlined"
                     width="auto"
                     @click="selectInstitutionToRemove(undefined)"
-                    class="cancel-remove-institution"
-                >
+                    class="cancel-remove-institution">
                     Cancel
                 </v-btn>
             </v-card-actions>

--- a/src/main/frontend/src/components/HarvesterAdmin.vue
+++ b/src/main/frontend/src/components/HarvesterAdmin.vue
@@ -138,7 +138,14 @@ async function removeInstitution(anInstitutionID) {
 </script>
 
 <template>
-    <v-btn color="primary" variant="outlined" @click="toggleDisplayInstitutionForm" class="ma-4">Add Institution</v-btn>
+    <v-btn
+        color="primary"
+        variant="outlined"
+        @click="toggleDisplayInstitutionForm"
+        class="propose-add-institution ma-4"
+    >
+        Add Institution
+    </v-btn>
 
     <v-list v-if="hasInstitutions" lines="one">
         <v-list-item v-for="institution in sortedInstitutions" :key="institution.id">
@@ -187,6 +194,7 @@ async function removeInstitution(anInstitutionID) {
                     color="primary"
                     variant="outlined"
                     width="auto"
+                    class="confirm-add-institution"
                     @click="addInstitution(institutionToAddOrUpdate)"
                 >
                     Save
@@ -196,11 +204,19 @@ async function removeInstitution(anInstitutionID) {
                     color="primary"
                     variant="outlined"
                     width="auto"
+                    class="confirm-update-institution"
                     @click="updateInstitution(institutionToAddOrUpdate)"
                 >
                     Save
                 </v-btn>
-                <v-btn variant="outlined" width="auto" @click="toggleDisplayInstitutionForm">Cancel</v-btn>
+                <v-btn
+                    variant="outlined"
+                    width="auto"
+                    @click="toggleDisplayInstitutionForm"
+                    class="cancel-add-or-update-institution"
+                >
+                    Cancel
+                </v-btn>
             </v-card-actions>
         </v-card>
     </v-dialog>
@@ -223,10 +239,23 @@ async function removeInstitution(anInstitutionID) {
                 </p>
             </v-card-text>
             <v-card-actions class="d-flex justify-center align-baseline">
-                <v-btn color="red" variant="outlined" @click="removeInstitution(institutionToRemove)" width="auto">
+                <v-btn
+                    color="red"
+                    variant="outlined"
+                    @click="removeInstitution(institutionToRemove)"
+                    width="auto"
+                    class="confirm-remove-institution"
+                >
                     Remove
                 </v-btn>
-                <v-btn variant="outlined" width="auto" @click="selectInstitutionToRemove(undefined)">Cancel</v-btn>
+                <v-btn
+                    variant="outlined"
+                    width="auto"
+                    @click="selectInstitutionToRemove(undefined)"
+                    class="cancel-remove-institution"
+                >
+                    Cancel
+                </v-btn>
             </v-card-actions>
         </v-card>
     </v-dialog>

--- a/src/main/frontend/src/components/HarvesterAdmin.vue
+++ b/src/main/frontend/src/components/HarvesterAdmin.vue
@@ -154,6 +154,7 @@ async function removeInstitution(anInstitutionID) {
         <v-card-text max-width="auto">No institutions yet!</v-card-text>
     </v-card>
 
+    <!-- A conditionally-rendered form for adding or updating an institution -->
     <v-dialog v-model="displayInstitutionForm" width="768">
         <v-card>
             <v-form>
@@ -204,6 +205,7 @@ async function removeInstitution(anInstitutionID) {
         </v-card>
     </v-dialog>
 
+    <!-- A conditionally-rendered confirmation prompt for removing an institution -->
     <v-dialog v-if="institutionToRemove" v-model="institutionToRemove" width="auto">
         <v-card>
             <v-card-text>
@@ -229,6 +231,7 @@ async function removeInstitution(anInstitutionID) {
         </v-card>
     </v-dialog>
 
+    <!-- Information on the success or failure of the most recent HTTP request to the back-end -->
     <v-snackbar v-if="actionResultAlert" v-model="actionResultAlert" :color="actionResultAlert.color">
         {{ actionResultAlert.message }}
     </v-snackbar>

--- a/src/main/frontend/src/components/HarvesterAdmin.vue
+++ b/src/main/frontend/src/components/HarvesterAdmin.vue
@@ -189,18 +189,48 @@ async function removeInstitution(anInstitutionID) {
     <v-dialog v-model="displayInstitutionForm" width="768">
         <v-card>
             <v-form>
-                <v-text-field v-if="institutionToAddOrUpdate.id" label="ID" v-model="institutionToAddOrUpdate.id" disabled></v-text-field>
+                <v-text-field
+                    v-if="institutionToAddOrUpdate.id"
+                    label="ID"
+                    v-model="institutionToAddOrUpdate.id"
+                    disabled
+                ></v-text-field>
                 <v-text-field label="Name" v-model="institutionToAddOrUpdate.name" required></v-text-field>
                 <v-textarea label="Description" v-model="institutionToAddOrUpdate.description" required></v-textarea>
                 <v-text-field label="Location" v-model="institutionToAddOrUpdate.location" required></v-text-field>
-                <v-text-field label="Website" type="url" v-model="institutionToAddOrUpdate.website" required></v-text-field>
+                <v-text-field
+                    label="Website"
+                    type="url"
+                    v-model="institutionToAddOrUpdate.website"
+                    required
+                ></v-text-field>
                 <v-text-field label="Email" type="email" v-model="institutionToAddOrUpdate.email"></v-text-field>
                 <v-text-field label="Phone" type="tel" v-model="institutionToAddOrUpdate.phone"></v-text-field>
-                <v-text-field label="Web Contact" type="url" v-model="institutionToAddOrUpdate.webContact"></v-text-field>
+                <v-text-field
+                    label="Web Contact"
+                    type="url"
+                    v-model="institutionToAddOrUpdate.webContact"
+                ></v-text-field>
             </v-form>
             <v-card-actions class="d-flex justify-center align-baseline">
-                <v-btn v-if="institutionToAddOrUpdate.id === undefined" color="primary" variant="outlined" width="auto" @click="addInstitution(institutionToAddOrUpdate)">Save</v-btn>
-                <v-btn v-else color="primary" variant="outlined" width="auto" @click="updateInstitution(institutionToAddOrUpdate)">Save</v-btn>
+                <v-btn
+                    v-if="institutionToAddOrUpdate.id === undefined"
+                    color="primary"
+                    variant="outlined"
+                    width="auto"
+                    @click="addInstitution(institutionToAddOrUpdate)"
+                >
+                    Save
+                </v-btn>
+                <v-btn
+                    v-else
+                    color="primary"
+                    variant="outlined"
+                    width="auto"
+                    @click="updateInstitution(institutionToAddOrUpdate)"
+                >
+                    Save
+                </v-btn>
                 <v-btn variant="outlined" width="auto" @click="toggleDisplayInstitutionForm">Cancel</v-btn>
             </v-card-actions>
         </v-card>

--- a/src/main/frontend/src/components/HarvesterAdmin.vue
+++ b/src/main/frontend/src/components/HarvesterAdmin.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { reactive, ref, computed, provide } from "vue"
+import { StatusCodes } from "http-status-codes"
 import InstitutionItem from "./InstitutionItem.vue"
 
 // State that must be kept in sync with the back-end
@@ -71,7 +72,7 @@ async function addInstitution(anInstitution) {
         body: JSON.stringify(anInstitution),
     })
 
-    if (response.status === 201) {
+    if (response.status === StatusCodes.CREATED) {
         const responseBody = await response.json()
 
         state.institutions[responseBody.id] = responseBody
@@ -119,7 +120,7 @@ async function updateInstitution(anInstitution) {
         body: JSON.stringify(anInstitution),
     })
 
-    if (response.status === 200) {
+    if (response.status === StatusCodes.OK) {
         const responseBody = await response.json()
 
         state.institutions[responseBody.id] = responseBody
@@ -157,7 +158,7 @@ function setInstitutionToRemove(anInstitutionID) {
 async function removeInstitution(anInstitutionID) {
     const response = await fetch(`/institutions/${anInstitutionID}`, { method: "DELETE" })
 
-    if (response.status === 204) {
+    if (response.status === StatusCodes.NO_CONTENT) {
         delete state.jobs[anInstitutionID]
         delete state.institutions[anInstitutionID]
 

--- a/src/main/frontend/src/components/HarvesterAdmin.vue
+++ b/src/main/frontend/src/components/HarvesterAdmin.vue
@@ -178,14 +178,16 @@ async function removeInstitution(anInstitutionID) {
 </script>
 
 <template>
-    <v-btn color="primary" variant="outlined" @click="toggleDisplayInstitutionForm">Add Institution</v-btn>
+    <v-btn color="primary" variant="outlined" @click="toggleDisplayInstitutionForm" class="ma-4">Add Institution</v-btn>
 
-    <ol v-if="hasInstitutions">
-        <li v-for="institution in sortedInstitutions" :key="institution.id">
+    <v-list v-if="hasInstitutions" lines="one">
+        <v-list-item v-for="institution in sortedInstitutions" :key="institution.id">
             <InstitutionItem v-bind="institution" :jobs="state.jobs[institution.id] || []" />
-        </li>
-    </ol>
-    <p v-else>No institutions yet!</p>
+        </v-list-item>
+    </v-list>
+    <v-card v-else variant="plain" width="auto">
+        <v-card-text max-width="auto">No institutions yet!</v-card-text>
+    </v-card>
 
     <v-dialog v-model="displayInstitutionForm" width="768">
         <v-card>
@@ -262,13 +264,4 @@ async function removeInstitution(anInstitutionID) {
     </v-snackbar>
 </template>
 
-<style scoped>
-ol {
-    display: grid;
-    gap: 2rem;
-}
-
-li {
-    list-style-type: none;
-}
-</style>
+<style scoped></style>

--- a/src/main/frontend/src/components/HarvesterAdmin.vue
+++ b/src/main/frontend/src/components/HarvesterAdmin.vue
@@ -3,6 +3,8 @@ import { reactive, ref, computed, provide } from "vue"
 import InstitutionItem from "./InstitutionItem.vue"
 
 const state = reactive({ institutions: {}, jobs: {} })
+const displayInstitutionForm = ref(false)
+const institutionToAdd = ref({})
 const institutionToRemove = ref()
 const actionResultAlert = ref()
 const sortedInstitutions = computed(() => Object.values(state.institutions).sort((a, b) => (a.name < b.name ? -1 : 1)))
@@ -27,6 +29,55 @@ fetch("/jobs")
             state.jobs[job.institutionID].push(job)
         })
     })
+
+/**
+ * Sets the component state that renders a dialog with a form for the user to add an institution.
+ */
+function toggleDisplayInstitutionForm() {
+    displayInstitutionForm.value = !displayInstitutionForm.value
+}
+
+/**
+ * Sets the component state that is used to populate the institution form.
+ *
+ * @param {Object} anInstitution The institution to add
+ */
+function setInstitutionToAdd(anInstitution) {
+    institutionToAdd.value = anInstitution
+}
+
+/**
+ * Adds an institution
+ *
+ * @param {Object} anInstitution The institution to add
+ */
+async function addInstitution(anInstitution) {
+    const response = await fetch("/institutions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(anInstitution),
+    })
+
+    if (response.status === 201) {
+        const responseBody = await response.json()
+
+        state.institutions[responseBody.id] = responseBody
+
+        actionResultAlert.value = {
+            color: "success",
+            message: "Institution added successfully",
+        }
+    } else {
+        actionResultAlert.value = {
+            color: "error",
+            message: `Institution add failed: HTTP ${response.status} (${response.statusText})`,
+        }
+    }
+
+    // Clear the form and hide it
+    setInstitutionToAdd({})
+    toggleDisplayInstitutionForm()
+}
 
 /**
  * Sets the component state that renders a dialog for the user to confirm institution removal.
@@ -67,12 +118,32 @@ provide("setInstitutionToRemove", setInstitutionToRemove)
 </script>
 
 <template>
+    <v-btn color="primary" variant="outlined" @click="toggleDisplayInstitutionForm">Add Institution</v-btn>
+
     <ol v-if="hasInstitutions">
         <li v-for="institution in sortedInstitutions" :key="institution.id">
             <InstitutionItem v-bind="institution" :jobs="state.jobs[institution.id] || []" />
         </li>
     </ol>
     <p v-else>No institutions yet!</p>
+
+    <v-dialog v-model="displayInstitutionForm" width="768">
+        <v-card>
+            <v-form>
+                <v-text-field label="Name" v-model="institutionToAdd.name" required></v-text-field>
+                <v-textarea label="Description" v-model="institutionToAdd.description" required></v-textarea>
+                <v-text-field label="Location" v-model="institutionToAdd.location" required></v-text-field>
+                <v-text-field label="Website" type="url" v-model="institutionToAdd.website" required></v-text-field>
+                <v-text-field label="Email" type="email" v-model="institutionToAdd.email"></v-text-field>
+                <v-text-field label="Phone" type="tel" v-model="institutionToAdd.phone"></v-text-field>
+                <v-text-field label="Web Contact" type="url" v-model="institutionToAdd.webContact"></v-text-field>
+            </v-form>
+            <v-card-actions class="d-flex justify-center align-baseline">
+                <v-btn color="primary" variant="outlined" width="auto" @click="addInstitution(institutionToAdd)">Add</v-btn>
+                <v-btn color="error" variant="outlined" width="auto" @click="toggleDisplayInstitutionForm">Cancel</v-btn>
+            </v-card-actions>
+        </v-card>
+    </v-dialog>
 
     <v-dialog v-if="institutionToRemove" v-model="institutionToRemove" width="auto">
         <v-card>

--- a/src/main/frontend/src/components/HarvesterAdmin.vue
+++ b/src/main/frontend/src/components/HarvesterAdmin.vue
@@ -199,8 +199,8 @@ async function removeInstitution(anInstitutionID) {
                 <v-text-field label="Web Contact" type="url" v-model="institutionToAddOrUpdate.webContact"></v-text-field>
             </v-form>
             <v-card-actions class="d-flex justify-center align-baseline">
-                <v-btn v-if="institutionToAddOrUpdate.id === undefined" color="primary" variant="outlined" width="auto" @click="addInstitution(institutionToAddOrUpdate)">Add</v-btn>
-                <v-btn v-else color="primary" variant="outlined" width="auto" @click="updateInstitution(institutionToAddOrUpdate)">Update</v-btn>
+                <v-btn v-if="institutionToAddOrUpdate.id === undefined" color="primary" variant="outlined" width="auto" @click="addInstitution(institutionToAddOrUpdate)">Save</v-btn>
+                <v-btn v-else color="primary" variant="outlined" width="auto" @click="updateInstitution(institutionToAddOrUpdate)">Save</v-btn>
                 <v-btn variant="outlined" width="auto" @click="toggleDisplayInstitutionForm">Cancel</v-btn>
             </v-card-actions>
         </v-card>

--- a/src/main/frontend/src/components/HarvesterAdmin.vue
+++ b/src/main/frontend/src/components/HarvesterAdmin.vue
@@ -36,7 +36,7 @@ provide("setInstitutionToUpdate", setInstitutionToUpdate)
 provide("setInstitutionToRemove", setInstitutionToRemove)
 
 /**
- * Sets the component state that renders a dialog with a form for the user to add or update an institution.
+ * Sets the component state that shows or hides the dialog with a form for the user to add or update an institution.
  */
 function toggleDisplayInstitutionForm() {
     // If the form was rendered in update mode and is being hidden, clear it out
@@ -90,7 +90,7 @@ async function addInstitution(anInstitution) {
 }
 
 /**
- * Renders a dialog with a form for the user to update the institution.
+ * Shows or hides the dialog with a form for the user to update the institution.
  *
  * @param {Number} anInstitutionID The ID of the institution to update
  */
@@ -138,7 +138,7 @@ async function updateInstitution(anInstitution) {
 }
 
 /**
- * Sets the component state that renders a dialog for the user to confirm institution removal.
+ * Sets the component state that shows or hides the dialog for the user to confirm institution removal.
  *
  * @param {Number} anInstitutionID The ID of the institution to remove
  */

--- a/src/main/frontend/src/components/InstitutionItem.vue
+++ b/src/main/frontend/src/components/InstitutionItem.vue
@@ -110,8 +110,20 @@ const headingIdentifier = computed(() => props.name.toLowerCase().replaceAll(" "
             <p v-else>No jobs yet!</p>
         </v-card-text>
         <v-card-actions class="ma-2 pa-2">
-            <v-btn color="primary" variant="outlined" @click="selectInstitutionToUpdate(id)">Edit</v-btn>
-            <v-btn color="red" variant="outlined" @click="selectInstitutionToRemove(id)">
+            <v-btn
+                color="primary"
+                variant="outlined"
+                @click="selectInstitutionToUpdate(id)"
+                class="propose-edit-institution"
+            >
+                Edit
+            </v-btn>
+            <v-btn
+                color="red"
+                variant="outlined"
+                @click="selectInstitutionToRemove(id)"
+                class="propose-remove-institution"
+            >
                 Remove {{ `"${name}"` }}
             </v-btn>
         </v-card-actions>

--- a/src/main/frontend/src/components/InstitutionItem.vue
+++ b/src/main/frontend/src/components/InstitutionItem.vue
@@ -114,16 +114,14 @@ const headingIdentifier = computed(() => props.name.toLowerCase().replaceAll(" "
                 color="primary"
                 variant="outlined"
                 @click="selectInstitutionToUpdate(id)"
-                class="propose-edit-institution"
-            >
+                class="propose-edit-institution">
                 Edit
             </v-btn>
             <v-btn
                 color="red"
                 variant="outlined"
                 @click="selectInstitutionToRemove(id)"
-                class="propose-remove-institution"
-            >
+                class="propose-remove-institution">
                 Remove {{ `"${name}"` }}
             </v-btn>
         </v-card-actions>

--- a/src/main/frontend/src/components/InstitutionItem.vue
+++ b/src/main/frontend/src/components/InstitutionItem.vue
@@ -13,6 +13,7 @@ const props = defineProps({
     website: { type: String, required: true },
     jobs: { type: Array, required: true },
 })
+const setInstitutionToUpdate = inject("setInstitutionToUpdate")
 const setInstitutionToRemove = inject("setInstitutionToRemove")
 const sortedJobs = computed(() => {
     return props.jobs.slice().sort((a, b) => {
@@ -107,6 +108,7 @@ const headingIdentifier = computed(() => props.name.toLowerCase().replaceAll(" "
         </table>
         <p v-else>No jobs yet!</p>
 
+        <v-btn color="primary" variant="outlined" @click="setInstitutionToUpdate(id)">Update</v-btn>
         <v-btn color="red" variant="outlined" @click="setInstitutionToRemove(id)">Remove {{ `"${name}"` }}</v-btn>
     </section>
 </template>

--- a/src/main/frontend/src/components/InstitutionItem.vue
+++ b/src/main/frontend/src/components/InstitutionItem.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, inject } from "vue"
+import { computed } from "vue"
 import JobItem from "./JobItem.vue"
 
 const props = defineProps({
@@ -12,9 +12,9 @@ const props = defineProps({
     webContact: { type: String },
     website: { type: String, required: true },
     jobs: { type: Array, required: true },
+    selectInstitutionToUpdate: { type: Function },
+    selectInstitutionToRemove: { type: Function },
 })
-const setInstitutionToUpdate = inject("setInstitutionToUpdate")
-const setInstitutionToRemove = inject("setInstitutionToRemove")
 const sortedJobs = computed(() => {
     return props.jobs.slice().sort((a, b) => {
         const hostnameA = new URL(a.repositoryBaseURL).hostname
@@ -107,8 +107,10 @@ const headingIdentifier = computed(() => props.name.toLowerCase().replaceAll(" "
             <p v-else>No jobs yet!</p>
         </v-card-text>
         <v-card-actions class="ma-2 pa-2">
-            <v-btn color="primary" variant="outlined" @click="setInstitutionToUpdate(id)">Edit</v-btn>
-            <v-btn color="red" variant="outlined" @click="setInstitutionToRemove(id)">Remove {{ `"${name}"` }}</v-btn>
+            <v-btn color="primary" variant="outlined" @click="selectInstitutionToUpdate(id)">Edit</v-btn>
+            <v-btn color="red" variant="outlined" @click="selectInstitutionToRemove(id)">
+                Remove {{ `"${name}"` }}
+            </v-btn>
         </v-card-actions>
     </v-card>
 </template>

--- a/src/main/frontend/src/components/InstitutionItem.vue
+++ b/src/main/frontend/src/components/InstitutionItem.vue
@@ -91,6 +91,9 @@ const headingIdentifier = computed(() => props.name.toLowerCase().replaceAll(" "
             </tr>
         </table>
 
+        <v-btn color="primary" variant="outlined" @click="setInstitutionToUpdate(id)">Update</v-btn>
+        <v-btn color="red" variant="outlined" @click="setInstitutionToRemove(id)">Remove {{ `"${name}"` }}</v-btn>
+
         <h3>Jobs</h3>
         <table v-if="jobs.length > 0">
             <thead>
@@ -107,9 +110,6 @@ const headingIdentifier = computed(() => props.name.toLowerCase().replaceAll(" "
             </tbody>
         </table>
         <p v-else>No jobs yet!</p>
-
-        <v-btn color="primary" variant="outlined" @click="setInstitutionToUpdate(id)">Update</v-btn>
-        <v-btn color="red" variant="outlined" @click="setInstitutionToRemove(id)">Remove {{ `"${name}"` }}</v-btn>
     </section>
 </template>
 

--- a/src/main/frontend/src/components/InstitutionItem.vue
+++ b/src/main/frontend/src/components/InstitutionItem.vue
@@ -49,6 +49,7 @@ const headingIdentifier = computed(() => props.name.toLowerCase().replaceAll(" "
 
 <template>
     <v-card :id="`${headingIdentifier}`" variant="outlined">
+        <!-- First, a rendering of the institution metadata -->
         <v-card-title class="text-h">{{ name }}</v-card-title>
         <v-row no-gutters>
             <v-col cols="4">
@@ -88,6 +89,8 @@ const headingIdentifier = computed(() => props.name.toLowerCase().replaceAll(" "
             </v-col>
         </v-row>
         <v-divider class="border-opacity-25"></v-divider>
+
+        <!-- Next, a rendering of the associated jobs (if any) -->
         <v-card-subtitle class="ma-2 pa-2 text-subtitle-1">Jobs</v-card-subtitle>
         <v-card-text>
             <v-table v-if="jobs.length > 0" class="harvest-jobs">

--- a/src/main/frontend/src/components/InstitutionItem.vue
+++ b/src/main/frontend/src/components/InstitutionItem.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed } from "vue"
+import { computed, inject } from "vue"
 import JobItem from "./JobItem.vue"
 
 const props = defineProps({
@@ -13,6 +13,7 @@ const props = defineProps({
     website: { type: String, required: true },
     jobs: { type: Array, required: true },
 })
+const setInstitutionToRemove = inject("setInstitutionToRemove")
 const sortedJobs = computed(() => {
     return props.jobs.slice().sort((a, b) => {
         const hostnameA = new URL(a.repositoryBaseURL).hostname
@@ -105,6 +106,8 @@ const headingIdentifier = computed(() => props.name.toLowerCase().replaceAll(" "
             </tbody>
         </table>
         <p v-else>No jobs yet!</p>
+
+        <v-btn color="red" variant="outlined" @click="setInstitutionToRemove(id)">Remove {{ `"${name}"` }}</v-btn>
     </section>
 </template>
 

--- a/src/main/frontend/src/components/InstitutionItem.vue
+++ b/src/main/frontend/src/components/InstitutionItem.vue
@@ -48,7 +48,6 @@ const headingIdentifier = computed(() => props.name.toLowerCase().replaceAll(" "
 </script>
 
 <template>
-    <a class="anchor" aria-hidden="true" :href="`#${headingIdentifier}`">&sect;</a>
     <v-card :id="`${headingIdentifier}`" variant="outlined">
         <v-card-title class="text-h">{{ name }}</v-card-title>
         <v-row no-gutters>

--- a/src/main/frontend/src/components/InstitutionItem.vue
+++ b/src/main/frontend/src/components/InstitutionItem.vue
@@ -49,107 +49,69 @@ const headingIdentifier = computed(() => props.name.toLowerCase().replaceAll(" "
 
 <template>
     <a class="anchor" aria-hidden="true" :href="`#${headingIdentifier}`">&sect;</a>
-    <section :id="`${headingIdentifier}`">
-        <h2>{{ name }}</h2>
-        <table class="institution-metadata">
-            <tr>
-                <th>Description</th>
-                <td>
+    <v-card :id="`${headingIdentifier}`" variant="outlined">
+        <v-card-title class="text-h">{{ name }}</v-card-title>
+        <v-row no-gutters>
+            <v-col cols="4">
+                <v-list>
+                    <v-list-item density="compact" prepend-icon="mdi-map-marker">
+                        <v-list-item-subtitle>{{ location }}</v-list-item-subtitle>
+                    </v-list-item>
+                    <v-list-item density="compact" prepend-icon="mdi-web">
+                        <v-list-item-subtitle>
+                            <a :href="website">{{ website }}</a>
+                        </v-list-item-subtitle>
+                    </v-list-item>
+                    <v-list-item density="compact" prepend-icon="mdi-email">
+                        <v-list-item-subtitle>
+                            <a v-if="email" :href="`mailto:${email}`">{{ email }}</a>
+                            <span v-else class="optional-field-placeholder">(not provided)</span>
+                        </v-list-item-subtitle>
+                    </v-list-item>
+                    <v-list-item density="compact" prepend-icon="mdi-phone">
+                        <v-list-item-subtitle>
+                            <a v-if="phone" :href="`tel:${phone}`">{{ phone }}</a>
+                            <span v-else class="optional-field-placeholder">(not provided)</span>
+                        </v-list-item-subtitle>
+                    </v-list-item>
+                    <v-list-item density="compact" prepend-icon="mdi-link">
+                        <v-list-item-subtitle>
+                            <a v-if="webContact" :href="webContact">{{ webContact }}</a>
+                            <span v-else class="optional-field-placeholder">(not provided)</span>
+                        </v-list-item-subtitle>
+                    </v-list-item>
+                </v-list>
+            </v-col>
+            <v-col>
+                <v-sheet class="ma-2 pa-2">
                     <blockquote>{{ description }}</blockquote>
-                </td>
-            </tr>
-            <tr>
-                <th>Location</th>
-                <td>{{ location }}</td>
-            </tr>
-            <tr>
-                <th>Email</th>
-                <td>
-                    <a v-if="email" :href="`mailto:${email}`">{{ email }}</a>
-                    <span v-else class="optional-field-placeholder">(not provided)</span>
-                </td>
-            </tr>
-            <tr>
-                <th>Phone</th>
-                <td>
-                    <a v-if="phone" :href="`tel:${phone}`">{{ phone }}</a>
-                    <span v-else class="optional-field-placeholder">(not provided)</span>
-                </td>
-            </tr>
-            <tr>
-                <th>Web Contact</th>
-                <td>
-                    <a v-if="webContact" :href="webContact">{{ webContact }}</a>
-                    <span v-else class="optional-field-placeholder">(not provided)</span>
-                </td>
-            </tr>
-            <tr>
-                <th>Website</th>
-                <td>
-                    <a :href="website">{{ website }}</a>
-                </td>
-            </tr>
-        </table>
-
-        <v-btn color="primary" variant="outlined" @click="setInstitutionToUpdate(id)">Edit</v-btn>
-        <v-btn color="red" variant="outlined" @click="setInstitutionToRemove(id)">Remove {{ `"${name}"` }}</v-btn>
-
-        <h3>Jobs</h3>
-        <table v-if="jobs.length > 0">
-            <thead>
-                <tr>
-                    <th>Repository Base URL</th>
-                    <th>Sets</th>
-                    <th>Metadata Format</th>
-                    <th>Schedule</th>
-                    <th>Last Successful Run</th>
-                </tr>
-            </thead>
-            <tbody>
-                <JobItem v-for="job in sortedJobs" v-bind="job" :key="job.id" />
-            </tbody>
-        </table>
-        <p v-else>No jobs yet!</p>
-    </section>
+                </v-sheet>
+            </v-col>
+        </v-row>
+        <v-divider class="border-opacity-25"></v-divider>
+        <v-card-subtitle class="ma-2 pa-2 text-subtitle-1">Jobs</v-card-subtitle>
+        <v-card-text>
+            <v-table v-if="jobs.length > 0" class="harvest-jobs">
+                <thead>
+                    <tr>
+                        <th>Repository Base URL</th>
+                        <th>Sets</th>
+                        <th>Metadata Format</th>
+                        <th>Schedule</th>
+                        <th>Last Successful Run</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <JobItem v-for="job in sortedJobs" v-bind="job" :key="job.id" />
+                </tbody>
+            </v-table>
+            <p v-else>No jobs yet!</p>
+        </v-card-text>
+        <v-card-actions class="ma-2 pa-2">
+            <v-btn color="primary" variant="outlined" @click="setInstitutionToUpdate(id)">Edit</v-btn>
+            <v-btn color="red" variant="outlined" @click="setInstitutionToRemove(id)">Remove {{ `"${name}"` }}</v-btn>
+        </v-card-actions>
+    </v-card>
 </template>
 
-<style scoped>
-h2 {
-    padding-bottom: 1rem;
-}
-
-h3 {
-    padding: 1rem 0;
-}
-
-thead th {
-    padding: 0.5rem;
-}
-
-tbody tr:nth-child(odd) {
-    background-color: #8bb8e8;
-}
-
-tbody tr:nth-child(even) {
-    background-color: #ffd100;
-}
-
-.anchor {
-    float: left;
-    margin-left: -2rem;
-    line-height: 1;
-    padding: 0.5rem;
-}
-
-.institution-metadata {
-    border-collapse: collapse;
-}
-
-.institution-metadata th {
-    padding: 0.5rem;
-}
-
-.institution-metadata tr {
-    border-bottom: thin solid;
-}
-</style>
+<style scoped></style>

--- a/src/main/frontend/src/components/InstitutionItem.vue
+++ b/src/main/frontend/src/components/InstitutionItem.vue
@@ -91,7 +91,7 @@ const headingIdentifier = computed(() => props.name.toLowerCase().replaceAll(" "
             </tr>
         </table>
 
-        <v-btn color="primary" variant="outlined" @click="setInstitutionToUpdate(id)">Update</v-btn>
+        <v-btn color="primary" variant="outlined" @click="setInstitutionToUpdate(id)">Edit</v-btn>
         <v-btn color="red" variant="outlined" @click="setInstitutionToRemove(id)">Remove {{ `"${name}"` }}</v-btn>
 
         <h3>Jobs</h3>

--- a/src/main/frontend/src/components/JobItem.vue
+++ b/src/main/frontend/src/components/JobItem.vue
@@ -20,13 +20,13 @@ const isSelectiveHarvest = computed(() => props.sets.length > 0)
             <a :href="`${repositoryBaseURL}?verb=Identify`">{{ repositoryBaseURL }}</a>
         </td>
         <td>
-            <ul v-if="isSelectiveHarvest">
-                <li v-for="set in sortedSets" :key="set">
+            <v-list v-if="isSelectiveHarvest">
+                <v-list-item v-for="set in sortedSets" :key="set" density="compact">
                     <a :href="`${repositoryBaseURL}?verb=ListRecords&set=${set}&metadataPrefix=${metadataPrefix}`">
-                        <span>{{ set }}</span>
+                        {{ set }}
                     </a>
-                </li>
-            </ul>
+                </v-list-item>
+            </v-list>
             <span v-else class="optional-field-placeholder">(entire repository)</span>
         </td>
         <td>{{ metadataPrefix }}</td>
@@ -38,8 +38,4 @@ const isSelectiveHarvest = computed(() => props.sets.length > 0)
     </tr>
 </template>
 
-<style scoped>
-td {
-    padding: 0.5rem;
-}
-</style>
+<style scoped></style>

--- a/src/main/frontend/src/components/__tests__/HarvesterAdmin.spec.js
+++ b/src/main/frontend/src/components/__tests__/HarvesterAdmin.spec.js
@@ -38,15 +38,23 @@ describe("HarvesterAdmin", () => {
         const nInstitutionButtons = 2 * institutions.length
 
         expect(buttons.length).toStrictEqual(1 + nInstitutionButtons)
-        expect(buttons.at(0).text()).toStrictEqual("Add Institution")
+
+        let button = buttons.at(0)
+
+        expect(button.text()).toStrictEqual("Add Institution")
+        expect(button.classes()).toContain("propose-add-institution")
 
         if (institutions.length > 0) {
             // Each institution should have an Edit and Remove button
             for (let i = 1; i < nInstitutionButtons; i++) {
+                button = buttons.at(i)
+
                 if (i % 2 === 1) {
-                    expect(buttons.at(i).text()).toStrictEqual("Edit")
+                    expect(button.text()).toStrictEqual("Edit")
+                    expect(button.classes()).toContain("propose-edit-institution")
                 } else {
-                    expect(buttons.at(i).text()).toContain("Remove")
+                    expect(button.text()).toContain("Remove")
+                    expect(button.classes()).toContain("propose-remove-institution")
                 }
             }
         }
@@ -72,7 +80,7 @@ describe("HarvesterAdmin", () => {
         })
 
         it("displays a form for adding an institution when the appropriate button is clicked", async () => {
-            const addInstitutionButton = wrapper.findAll("button").at(0)
+            const addInstitutionButton = wrapper.find(".propose-add-institution")
 
             addInstitutionFormFields.forEach((value) => {
                 expect(document.body.innerHTML).not.toContain(value)
@@ -110,7 +118,7 @@ describe("HarvesterAdmin", () => {
         })
 
         it("displays a form for updating an institution when the appropriate button is clicked", async () => {
-            const updateInstitutionButton = wrapper.findAll("button").at(1) // FIXME: use id of the element to find
+            const updateInstitutionButton = wrapper.find(".propose-edit-institution")
 
             updateInstitutionFormFields.forEach((value) => {
                 expect(document.body.innerHTML).not.toContain(value)
@@ -124,7 +132,7 @@ describe("HarvesterAdmin", () => {
         })
 
         it("displays a dialog to confirm removing an institution when the appropriate button is clicked", async () => {
-            const removeInstitutionButton = wrapper.findAll("button").at(2) // FIXME: use id of the element to find
+            const removeInstitutionButton = wrapper.find(".propose-remove-institution")
             const removeInstitutionDialogText = "This action will remove"
 
             expect(document.body.innerHTML).not.toContain(removeInstitutionDialogText)

--- a/src/main/frontend/src/components/__tests__/HarvesterAdmin.spec.js
+++ b/src/main/frontend/src/components/__tests__/HarvesterAdmin.spec.js
@@ -1,0 +1,141 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest"
+
+import { createVuetify } from "vuetify"
+import * as components from "vuetify/components"
+import * as directives from "vuetify/directives"
+import { mount } from "@vue/test-utils"
+
+import HarvesterAdmin from "../HarvesterAdmin.vue"
+import InstitutionItem from "../InstitutionItem.vue"
+import { testInstitution } from "./TestData.js"
+
+describe("HarvesterAdmin", () => {
+    const vuetify = createVuetify({ components, directives })
+
+    const addInstitutionFormFields = ["Name", "Description", "Location", "Website", "Email", "Phone", "Web Contact"]
+    const updateInstitutionFormFields = ["ID"].concat(addInstitutionFormFields)
+
+    /**
+     * Checks that the expected number of institutions are rendered.
+     *
+     * @param {VueWrapper} wrapper The result of mounting a {@link HarvesterAdmin}
+     * @param {object} institutionsMap A map from institution ID to institution (matching the part of the state that stores institutions)
+     */
+    function checkInstitutionsCount(wrapper, institutionsMap) {
+        // The spec for InstitutionItem does a more thorough check of the rendering
+        expect(wrapper.findAllComponents(InstitutionItem).length).toStrictEqual(Object.keys(institutionsMap).length)
+    }
+
+    /**
+     * Checks that the HTML button elements are rendered as expected.
+     *
+     * @param {VueWrapper} wrapper The result of mounting a {@link HarvesterAdmin}
+     * @param {Object} institutionsMap A map from institution ID to institution
+     */
+    function checkButtons(wrapper, institutionsMap) {
+        const institutions = Object.values(institutionsMap)
+        const buttons = wrapper.findAll("button")
+        const nInstitutionButtons = 2 * institutions.length
+
+        expect(buttons.length).toStrictEqual(1 + nInstitutionButtons)
+        expect(buttons.at(0).text()).toStrictEqual("Add Institution")
+
+        if (institutions.length > 0) {
+            // Each institution should have an Edit and Remove button
+            for (let i = 1; i < nInstitutionButtons; i++) {
+                if (i % 2 === 1) {
+                    expect(buttons.at(i).text()).toStrictEqual("Edit")
+                } else {
+                    expect(buttons.at(i).text()).toContain("Remove")
+                }
+            }
+        }
+    }
+
+    describe("without institutions", () => {
+        const institutions = {}
+        const jobs = {}
+        const data = { institutions, jobs }
+
+        let wrapper
+
+        beforeEach(() => {
+            wrapper = mount(HarvesterAdmin, {
+                props: data,
+                global: { plugins: [vuetify] },
+            })
+        })
+
+        it("renders properly", () => {
+            checkInstitutionsCount(wrapper, institutions)
+            checkButtons(wrapper, institutions)
+        })
+
+        it("displays a form for adding an institution when the appropriate button is clicked", async () => {
+            const addInstitutionButton = wrapper.findAll("button").at(0)
+
+            addInstitutionFormFields.forEach((value) => {
+                expect(document.body.innerHTML).not.toContain(value)
+            })
+
+            await addInstitutionButton.trigger("click")
+
+            addInstitutionFormFields.forEach((value) => {
+                expect(document.body.innerHTML).toContain(value)
+            })
+        })
+
+        afterEach(() => {
+            wrapper.unmount()
+        })
+    })
+
+    describe("with institutions", () => {
+        const institutions = { [testInstitution.id]: testInstitution }
+        const jobs = {}
+        const data = { institutions, jobs }
+
+        let wrapper
+
+        beforeEach(() => {
+            wrapper = mount(HarvesterAdmin, {
+                props: data,
+                global: { plugins: [vuetify] },
+            })
+        })
+
+        it("renders properly", () => {
+            checkInstitutionsCount(wrapper, institutions)
+            checkButtons(wrapper, institutions)
+        })
+
+        it("displays a form for updating an institution when the appropriate button is clicked", async () => {
+            const updateInstitutionButton = wrapper.findAll("button").at(1) // FIXME: use id of the element to find
+
+            updateInstitutionFormFields.forEach((value) => {
+                expect(document.body.innerHTML).not.toContain(value)
+            })
+
+            await updateInstitutionButton.trigger("click")
+
+            updateInstitutionFormFields.forEach((value) => {
+                expect(document.body.innerHTML).toContain(value)
+            })
+        })
+
+        it("displays a dialog to confirm removing an institution when the appropriate button is clicked", async () => {
+            const removeInstitutionButton = wrapper.findAll("button").at(2) // FIXME: use id of the element to find
+            const removeInstitutionDialogText = "This action will remove"
+
+            expect(document.body.innerHTML).not.toContain(removeInstitutionDialogText)
+
+            await removeInstitutionButton.trigger("click")
+
+            expect(document.body.innerHTML).toContain(removeInstitutionDialogText)
+        })
+
+        afterEach(() => {
+            wrapper.unmount()
+        })
+    })
+})

--- a/src/main/frontend/src/components/__tests__/InstitutionItem.spec.js
+++ b/src/main/frontend/src/components/__tests__/InstitutionItem.spec.js
@@ -6,44 +6,76 @@ import * as directives from "vuetify/directives"
 import { mount } from "@vue/test-utils"
 
 import InstitutionItem from "../InstitutionItem.vue"
-import { testJob, testJobSelectiveHarvest } from "./JobItem.spec.js"
-
-const testInstitutionNoJobs = {
-    id: 1,
-    name: "Test Institution",
-    description: "A description of the institution.",
-    location: "The location of the institution.",
-    email: "test@example.edu",
-    phone: "+1 800 200 0000",
-    webContact: "http://example.edu/contact",
-    website: "http://example.edu",
-    jobs: [],
-}
-const testInstitution = {
-    ...testInstitutionNoJobs,
-    jobs: [testJob, testJobSelectiveHarvest],
-}
+import { testJob, testJobSelectiveHarvest, testInstitution } from "./TestData.js"
 
 describe("InstitutionItem", () => {
     const vuetify = createVuetify({ components, directives })
 
+    /**
+     * Checks that the institution metadata is rendered as expected.
+     *
+     * @param {VueWrapper} wrapper The result of mounting a {@link InstitutionItem}
+     * @param {object} institution The data that should be rendered
+     */
+    function checkInstitution(wrapper, institution) {
+        Object.entries(institution)
+            .filter(([key, value]) => key !== "id" && value !== null)
+            .forEach((keyValuePair) => {
+                expect(wrapper.text()).toContain(keyValuePair.at(1))
+            })
+    }
+
+    /**
+     * Checks whether the jobs metadata is rendered or not.
+     *
+     * @param {VueWrapper} wrapper The result of mounting a {@link InstitutionItem}
+     * @param {object[]} jobs The data that should be rendered
+     */
+    function checkJobs(wrapper, jobs) {
+        const jobsTable = wrapper.find(".harvest-jobs")
+
+        if (jobs.length > 0) {
+            expect(jobsTable.exists()).toBeTruthy()
+            expect(jobsTable.findAll("tbody").at(0).findAll("tr").length).toStrictEqual(jobs.length)
+        } else {
+            expect(jobsTable.exists()).toBeFalsy()
+            expect(wrapper.text()).toContain("No jobs yet!")
+        }
+    }
+
+    /**
+     * Checks that the HTML button elements are rendered as expected.
+     *
+     * @param {VueWrapper} wrapper The result of mounting a {@link InstitutionItem}
+     */
+    function checkButtons(wrapper) {
+        const buttons = wrapper.findAll("button")
+        expect(buttons.length).toStrictEqual(2)
+        expect(buttons.at(0).text()).toContain("Edit")
+        expect(buttons.at(1).text()).toContain("Remove")
+    }
+
     it("renders properly without jobs", () => {
+        const jobs = []
         const wrapper = mount(InstitutionItem, {
-            props: { ...testInstitutionNoJobs },
+            props: { ...testInstitution, jobs },
             global: { plugins: [vuetify] },
         })
 
-        expect(wrapper.text()).toContain("Test Institution").toContain("No jobs yet!")
+        checkInstitution(wrapper, testInstitution)
+        checkJobs(wrapper, jobs)
+        checkButtons(wrapper)
     })
+
     it("renders properly with jobs", () => {
+        const jobs = [testJob, testJobSelectiveHarvest]
         const wrapper = mount(InstitutionItem, {
-            props: { ...testInstitution },
+            props: { ...testInstitution, jobs },
             global: { plugins: [vuetify] },
         })
 
-        expect(wrapper.text())
-            .toContain("Test Institution")
-            .toContain(testJob.repositoryBaseURL)
-            .toContain(testJobSelectiveHarvest.repositoryBaseURL)
+        checkInstitution(wrapper, testInstitution)
+        checkJobs(wrapper, jobs)
+        checkButtons(wrapper)
     })
 })

--- a/src/main/frontend/src/components/__tests__/InstitutionItem.spec.js
+++ b/src/main/frontend/src/components/__tests__/InstitutionItem.spec.js
@@ -1,6 +1,10 @@
 import { describe, it, expect } from "vitest"
 
+import { createVuetify } from "vuetify"
+import * as components from "vuetify/components"
+import * as directives from "vuetify/directives"
 import { mount } from "@vue/test-utils"
+
 import InstitutionItem from "../InstitutionItem.vue"
 import { testJob, testJobSelectiveHarvest } from "./JobItem.spec.js"
 
@@ -21,13 +25,21 @@ const testInstitution = {
 }
 
 describe("InstitutionItem", () => {
+    const vuetify = createVuetify({ components, directives })
+
     it("renders properly without jobs", () => {
-        const wrapper = mount(InstitutionItem, { props: { ...testInstitutionNoJobs } })
+        const wrapper = mount(InstitutionItem, {
+            props: { ...testInstitutionNoJobs },
+            global: { plugins: [vuetify] },
+        })
 
         expect(wrapper.text()).toContain("Test Institution").toContain("No jobs yet!")
     })
     it("renders properly with jobs", () => {
-        const wrapper = mount(InstitutionItem, { props: { ...testInstitution } })
+        const wrapper = mount(InstitutionItem, {
+            props: { ...testInstitution },
+            global: { plugins: [vuetify] },
+        })
 
         expect(wrapper.text())
             .toContain("Test Institution")

--- a/src/main/frontend/src/components/__tests__/JobItem.spec.js
+++ b/src/main/frontend/src/components/__tests__/JobItem.spec.js
@@ -6,23 +6,36 @@ import * as directives from "vuetify/directives"
 import { mount } from "@vue/test-utils"
 
 import JobItem from "../JobItem.vue"
-
-const testJob = {
-    id: 1,
-    institutionID: 1,
-    repositoryBaseURL: "http://example.edu/provider",
-    sets: [],
-    metadataPrefix: "oai_dc",
-    scheduleCronExpression: "0 0 0 * * ?",
-    lastSuccessfulRun: null,
-}
-const testJobSelectiveHarvest = {
-    ...testJob,
-    sets: ["set1", "set2"],
-}
+import { testJob, testJobSelectiveHarvest } from "./TestData.js"
 
 describe("JobItem", () => {
     const vuetify = createVuetify({ components, directives })
+
+    /**
+     * Checks that the job metadata is rendered as expected.
+     *
+     * @param {VueWrapper} wrapper The result of mounting a {@link JobItem}
+     * @param {object} job The data that should be rendered
+     */
+    function checkJob(wrapper, job) {
+        Object.entries(job)
+            .filter(([key]) => !["id", "institutionID"].includes(key))
+            .forEach(([key, value]) => {
+                if (value !== null) {
+                    if (value instanceof Array) {
+                        value.forEach((element) => {
+                            expect(wrapper.text()).toContain(element)
+                        })
+                    } else {
+                        expect(wrapper.text()).toContain(value)
+                    }
+                } else {
+                    if (key === "sets") {
+                        expect(wrapper.text()).toContain("(entire repository)")
+                    }
+                }
+            })
+    }
 
     it("renders properly without sets specified", () => {
         const wrapper = mount(JobItem, {
@@ -30,17 +43,16 @@ describe("JobItem", () => {
             global: { plugins: [vuetify] },
         })
 
-        expect(wrapper.text()).toContain("(entire repository)")
+        checkJob(wrapper, testJob)
     })
+
     it("renders properly with sets specified", () => {
         const wrapper = mount(JobItem, {
             props: testJobSelectiveHarvest,
             global: { plugins: [vuetify] },
         })
 
-        testJobSelectiveHarvest.sets.forEach((set) => {
-            expect(wrapper.text()).toContain(set)
-        })
+        checkJob(wrapper, testJobSelectiveHarvest)
     })
 })
 

--- a/src/main/frontend/src/components/__tests__/JobItem.spec.js
+++ b/src/main/frontend/src/components/__tests__/JobItem.spec.js
@@ -1,6 +1,10 @@
 import { describe, it, expect } from "vitest"
 
+import { createVuetify } from "vuetify"
+import * as components from "vuetify/components"
+import * as directives from "vuetify/directives"
 import { mount } from "@vue/test-utils"
+
 import JobItem from "../JobItem.vue"
 
 const testJob = {
@@ -18,13 +22,21 @@ const testJobSelectiveHarvest = {
 }
 
 describe("JobItem", () => {
+    const vuetify = createVuetify({ components, directives })
+
     it("renders properly without sets specified", () => {
-        const wrapper = mount(JobItem, { props: { ...testJob } })
+        const wrapper = mount(JobItem, {
+            props: testJob,
+            global: { plugins: [vuetify] },
+        })
 
         expect(wrapper.text()).toContain("(entire repository)")
     })
     it("renders properly with sets specified", () => {
-        const wrapper = mount(JobItem, { props: { ...testJobSelectiveHarvest } })
+        const wrapper = mount(JobItem, {
+            props: testJobSelectiveHarvest,
+            global: { plugins: [vuetify] },
+        })
 
         testJobSelectiveHarvest.sets.forEach((set) => {
             expect(wrapper.text()).toContain(set)

--- a/src/main/frontend/src/components/__tests__/TestData.js
+++ b/src/main/frontend/src/components/__tests__/TestData.js
@@ -1,0 +1,27 @@
+const testJob = {
+    id: 1,
+    institutionID: 1,
+    repositoryBaseURL: "http://example.edu/provider",
+    sets: [],
+    metadataPrefix: "oai_dc",
+    scheduleCronExpression: "0 0 0 * * ?",
+    lastSuccessfulRun: null,
+}
+
+const testJobSelectiveHarvest = {
+    ...testJob,
+    sets: ["set1", "set2"],
+}
+
+const testInstitution = {
+    id: 1,
+    name: "Test Institution",
+    description: "A description of the institution.",
+    location: "The location of the institution.",
+    email: "test@example.edu",
+    phone: "+1 800 200 0000",
+    webContact: "http://example.edu/contact",
+    website: "http://example.edu",
+}
+
+export { testJob, testJobSelectiveHarvest, testInstitution }

--- a/src/main/frontend/src/main.js
+++ b/src/main/frontend/src/main.js
@@ -2,15 +2,18 @@ import { createApp } from "vue"
 import { createVuetify } from "vuetify"
 import * as components from "vuetify/components"
 import * as directives from "vuetify/directives"
+import { aliases, mdi } from "vuetify/iconsets/mdi"
 
 import App from "./App.vue"
 
 import "vuetify/styles"
+import "@mdi/font/css/materialdesignicons.css"
 import "./assets/main.css"
 
 const vuetify = createVuetify({
     components,
     directives,
+    icons: { aliases, sets: { mdi } },
 })
 
 createApp(App).use(vuetify).mount("#app")

--- a/src/main/frontend/src/main.js
+++ b/src/main/frontend/src/main.js
@@ -1,6 +1,16 @@
 import { createApp } from "vue"
+import { createVuetify } from "vuetify"
+import * as components from "vuetify/components"
+import * as directives from "vuetify/directives"
+
 import App from "./App.vue"
 
+import "vuetify/styles"
 import "./assets/main.css"
 
-createApp(App).mount("#app")
+const vuetify = createVuetify({
+    components,
+    directives,
+})
+
+createApp(App).use(vuetify).mount("#app")

--- a/src/main/frontend/vite.config.js
+++ b/src/main/frontend/vite.config.js
@@ -11,4 +11,8 @@ export default defineConfig({
             "@": fileURLToPath(new URL("./src", import.meta.url)),
         },
     },
+    test: {
+        deps: { inline: ["vuetify"] },
+        globals: true,
+    },
 })


### PR DESCRIPTION
Major changes / consequences:
- all uses of the fetch API (and related state management) now live in App.vue; this allows passing test data as props to the admin UI
- all instances of [prop drilling](https://vuejs.org/guide/components/provide-inject.html#prop-drilling) have been removed, which eliminated a bunch of warnings that the tests were emitting
- most of the custom CSS I'd written earlier was able to be removed by adopting Vuetify
- earlier, I was importing the test data from one of the spec files, which was inadvertently causing said spec to be run more than once 😳 so now it lives in its own file