### PR TITLE
[SERV-740] Implement UI for job write operations

### DIFF
--- a/src/main/frontend/src/App.vue
+++ b/src/main/frontend/src/App.vue
@@ -80,10 +80,10 @@ fetch("/jobs")
     .then((jobs) => {
         jobs.forEach((job) => {
             if (state.jobs[job.institutionID] === undefined) {
-                state.jobs[job.institutionID] = []
+                state.jobs[job.institutionID] = {}
             }
 
-            state.jobs[job.institutionID].push(job)
+            state.jobs[job.institutionID][job.id] = job
         })
     })
 </script>

--- a/src/main/frontend/src/App.vue
+++ b/src/main/frontend/src/App.vue
@@ -68,6 +68,71 @@ async function sendRemoveInstitutionRequest(anInstitutionID) {
     return response
 }
 
+/**
+ * Sends an addJob request and, if successful, updates the state with the result.
+ *
+ * @param {Object} aJob The job
+ * @returns The HTTP response
+ */
+async function sendAddJobRequest(aJob) {
+    const response = await fetch("/jobs", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(aJob),
+    })
+
+    if (response.status === StatusCodes.CREATED) {
+        const responseBody = await response.json()
+
+        if (state.jobs[responseBody.institutionID] === undefined) {
+            state.jobs[responseBody.institutionID] = {}
+        }
+
+        state.jobs[responseBody.institutionID][responseBody.id] = responseBody
+    }
+
+    return response
+}
+
+/**
+ * Sends an updateJob request and, if successful, updates the state with the result.
+ *
+ * @param {Object} aJob The job
+ * @returns The HTTP response
+ */
+async function sendUpdateJobRequest(aJob) {
+    const response = await fetch(`/jobs/${aJob.id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(aJob),
+    })
+
+    if (response.status === StatusCodes.OK) {
+        const responseBody = await response.json()
+
+        state.jobs[responseBody.institutionID][responseBody.id] = responseBody
+    }
+
+    return response
+}
+
+/**
+ * Sends an removeJob request and, if successful, updates the state with the result.
+ *
+ * @param {Number} aJobID The ID of the job
+ * @param {Number} anInstitutionID The ID of the associated institution
+ * @returns The HTTP response
+ */
+async function sendRemoveJobRequest(aJobID, anInstitutionID) {
+    const response = await fetch(`/jobs/${aJobID}`, { method: "DELETE" })
+
+    if (response.status === StatusCodes.NO_CONTENT) {
+        delete state.jobs[anInstitutionID][aJobID]
+    }
+
+    return response
+}
+
 // Fetch data from back-end
 fetch("/institutions")
     .then((response) => response.json())
@@ -98,7 +163,10 @@ fetch("/jobs")
             v-bind="state"
             :sendAddInstitutionRequest="sendAddInstitutionRequest"
             :sendUpdateInstitutionRequest="sendUpdateInstitutionRequest"
-            :sendRemoveInstitutionRequest="sendRemoveInstitutionRequest" />
+            :sendRemoveInstitutionRequest="sendRemoveInstitutionRequest"
+            :sendAddJobRequest="sendAddJobRequest"
+            :sendUpdateJobRequest="sendUpdateJobRequest"
+            :sendRemoveJobRequest="sendRemoveJobRequest" />
     </main>
 
     <footer>PRL Harvester Admin v{{ version }}</footer>

--- a/src/main/frontend/src/App.vue
+++ b/src/main/frontend/src/App.vue
@@ -80,14 +80,14 @@ async function sendRemoveInstitutionRequest(anInstitutionID) {
 /**
  * Sends an addJob request and, if successful, updates the state with the result.
  *
- * @param {Object} aJob A job with its sets represented as a CSV string
+ * @param {Object} aJob A job
  * @returns The HTTP response
  */
 async function sendAddJobRequest(aJob) {
     const response = await fetch("/jobs", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(jobWithDeserializedSets(aJob)),
+        body: JSON.stringify(aJob),
     })
 
     if (response.status === StatusCodes.CREATED) {
@@ -97,7 +97,7 @@ async function sendAddJobRequest(aJob) {
             state.jobs[responseBody.institutionID] = {}
         }
 
-        state.jobs[responseBody.institutionID][responseBody.id] = jobWithCsvSerializedSets(responseBody)
+        state.jobs[responseBody.institutionID][responseBody.id] = responseBody
     }
 
     return response
@@ -106,20 +106,20 @@ async function sendAddJobRequest(aJob) {
 /**
  * Sends an updateJob request and, if successful, updates the state with the result.
  *
- * @param {Object} aJob A job with its sets represented as a CSV string
+ * @param {Object} aJob A job
  * @returns The HTTP response
  */
 async function sendUpdateJobRequest(aJob) {
     const response = await fetch(`/jobs/${aJob.id}`, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(jobWithDeserializedSets(aJob)),
+        body: JSON.stringify(aJob),
     })
 
     if (response.status === StatusCodes.OK) {
         const responseBody = await response.json()
 
-        state.jobs[responseBody.institutionID][responseBody.id] = jobWithCsvSerializedSets(responseBody)
+        state.jobs[responseBody.institutionID][responseBody.id] = responseBody
     }
 
     return response
@@ -142,22 +142,6 @@ async function sendRemoveJobRequest(aJobID, anInstitutionID) {
     return response
 }
 
-/**
- * @param {Object} aJob A job with its sets represented as an array
- * @returns The job with its sets represented as a CSV string
- */
-function jobWithCsvSerializedSets(aJob) {
-    return { ...aJob, sets: aJob.sets.join() }
-}
-
-/**
- * @param {Object} aJob A job with its sets represented as a CSV string
- * @returns The job with its sets represented as an array
- */
-function jobWithDeserializedSets(aJob) {
-    return { ...aJob, sets: aJob.sets ? aJob.sets.split(',').map(s => s.trim()) : [] }
-}
-
 // Fetch data from back-end
 fetch("/institutions")
     .then((response) => response.json())
@@ -173,7 +157,7 @@ fetch("/jobs")
                 state.jobs[job.institutionID] = {}
             }
 
-            state.jobs[job.institutionID][job.id] = jobWithCsvSerializedSets(job)
+            state.jobs[job.institutionID][job.id] = job
         })
     })
 </script>

--- a/src/main/frontend/src/App.vue
+++ b/src/main/frontend/src/App.vue
@@ -80,14 +80,14 @@ async function sendRemoveInstitutionRequest(anInstitutionID) {
 /**
  * Sends an addJob request and, if successful, updates the state with the result.
  *
- * @param {Object} aJob The job
+ * @param {Object} aJob A job with its sets represented as a CSV string
  * @returns The HTTP response
  */
 async function sendAddJobRequest(aJob) {
     const response = await fetch("/jobs", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(aJob),
+        body: JSON.stringify(jobWithDeserializedSets(aJob)),
     })
 
     if (response.status === StatusCodes.CREATED) {
@@ -97,7 +97,7 @@ async function sendAddJobRequest(aJob) {
             state.jobs[responseBody.institutionID] = {}
         }
 
-        state.jobs[responseBody.institutionID][responseBody.id] = responseBody
+        state.jobs[responseBody.institutionID][responseBody.id] = jobWithCsvSerializedSets(responseBody)
     }
 
     return response
@@ -106,20 +106,20 @@ async function sendAddJobRequest(aJob) {
 /**
  * Sends an updateJob request and, if successful, updates the state with the result.
  *
- * @param {Object} aJob The job
+ * @param {Object} aJob A job with its sets represented as a CSV string
  * @returns The HTTP response
  */
 async function sendUpdateJobRequest(aJob) {
     const response = await fetch(`/jobs/${aJob.id}`, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(aJob),
+        body: JSON.stringify(jobWithDeserializedSets(aJob)),
     })
 
     if (response.status === StatusCodes.OK) {
         const responseBody = await response.json()
 
-        state.jobs[responseBody.institutionID][responseBody.id] = responseBody
+        state.jobs[responseBody.institutionID][responseBody.id] = jobWithCsvSerializedSets(responseBody)
     }
 
     return response
@@ -142,6 +142,22 @@ async function sendRemoveJobRequest(aJobID, anInstitutionID) {
     return response
 }
 
+/**
+ * @param {Object} aJob A job with its sets represented as an array
+ * @returns The job with its sets represented as a CSV string
+ */
+function jobWithCsvSerializedSets(aJob) {
+    return { ...aJob, sets: aJob.sets.join() }
+}
+
+/**
+ * @param {Object} aJob A job with its sets represented as a CSV string
+ * @returns The job with its sets represented as an array
+ */
+function jobWithDeserializedSets(aJob) {
+    return { ...aJob, sets: aJob.sets ? aJob.sets.split(',').map(s => s.trim()) : [] }
+}
+
 // Fetch data from back-end
 fetch("/institutions")
     .then((response) => response.json())
@@ -157,7 +173,7 @@ fetch("/jobs")
                 state.jobs[job.institutionID] = {}
             }
 
-            state.jobs[job.institutionID][job.id] = job
+            state.jobs[job.institutionID][job.id] = jobWithCsvSerializedSets(job)
         })
     })
 </script>

--- a/src/main/frontend/src/App.vue
+++ b/src/main/frontend/src/App.vue
@@ -5,6 +5,15 @@ import { StatusCodes } from "http-status-codes"
 import { version } from "../package.json"
 import HarvesterAdmin from "./components/HarvesterAdmin.vue"
 
+/**
+ * The state object that should be kept in sync with the back-end state.
+ *
+ * The institutions map is from institution IDs to institutions. So for example, `state.institutions[1]` retrieves the
+ * institution with ID 1.
+ *
+ * The jobs map is from institutionIDs to a map from job IDs to jobs. So for example, `state.jobs[2][3]` retrieves the
+ * job with ID 3 and institutionID 2.
+ */
 const state = reactive({ institutions: {}, jobs: {} })
 
 /**

--- a/src/main/frontend/src/components/HarvesterAdmin.vue
+++ b/src/main/frontend/src/components/HarvesterAdmin.vue
@@ -9,6 +9,9 @@ const props = defineProps({
     sendAddInstitutionRequest: { type: Function },
     sendUpdateInstitutionRequest: { type: Function },
     sendRemoveInstitutionRequest: { type: Function },
+    sendAddJobRequest: { type: Function },
+    sendUpdateJobRequest: { type: Function },
+    sendRemoveJobRequest: { type: Function },
 })
 const hasInstitutions = computed(() => Object.keys(props.institutions).length > 0)
 const sortedInstitutions = computed(() => Object.values(props.institutions).sort((a, b) => (a.name < b.name ? -1 : 1)))
@@ -16,6 +19,9 @@ const sortedInstitutions = computed(() => Object.values(props.institutions).sort
 const displayInstitutionForm = ref(false)
 const institutionToAddOrUpdate = ref({})
 const institutionToRemove = ref()
+const institutionIdForJob = ref()
+const jobToAddOrUpdate = ref({})
+const jobToRemove = ref()
 const actionResultAlert = ref()
 
 /**
@@ -31,12 +37,35 @@ function toggleDisplayInstitutionForm() {
 }
 
 /**
+ * Sets the component state that shows or hides the dialog with a form for the user to add or update an job.
+ *
+ * @param {Number} anInstitutionID The ID of the institution to associate the new job with
+ */
+function toggleDisplayJobForm(anInstitutionID) {
+    // If the form was rendered in update mode and is being hidden, clear it out
+    if (institutionIdForJob.value && jobToAddOrUpdate.value.id !== undefined) {
+        setJobToAddOrUpdate({})
+    }
+
+    institutionIdForJob.value = anInstitutionID
+}
+
+/**
  * Sets the component state that is used to populate the institution form.
  *
  * @param {Object} anInstitution The institution to add
  */
 function setInstitutionToAddOrUpdate(anInstitution) {
     institutionToAddOrUpdate.value = anInstitution
+}
+
+/**
+ * Sets the component state that is used to populate the job form.
+ *
+ * @param {Object} aJob The job to add
+ */
+function setJobToAddOrUpdate(aJob) {
+    jobToAddOrUpdate.value = aJob
 }
 
 /**
@@ -65,6 +94,31 @@ async function addInstitution(anInstitution) {
 }
 
 /**
+ * Adds a job.
+ *
+ * @param {Object} aJob The job to add
+ */
+async function addJob(aJob) {
+    const response = await props.sendAddJobRequest(aJob)
+
+    if (response.status === StatusCodes.CREATED) {
+        actionResultAlert.value = {
+            color: "success",
+            message: "Job added successfully",
+        }
+    } else {
+        actionResultAlert.value = {
+            color: "error",
+            message: `Job add failed: HTTP ${response.status} (${response.statusText})`,
+        }
+    }
+
+    // Clear the form and hide it
+    setJobToAddOrUpdate({})
+    toggleDisplayJobForm(undefined)
+}
+
+/**
  * Shows or hides the dialog with a form for the user to update the institution.
  *
  * @param {Number} anInstitutionID The ID of the institution to update
@@ -77,6 +131,23 @@ function selectInstitutionToUpdate(anInstitutionID) {
 
     // Since the institution form is being reused for add and update, need to toggle its display manually
     toggleDisplayInstitutionForm()
+}
+
+/**
+ * Shows or hides the dialog with a form for the user to update the job.
+ *
+ * @param {Number[]} anIDs A tuple of the ID of the job to update, and the ID of the associated institution
+ */
+function selectJobToUpdate(anIDs) {
+    const jobID = anIDs[0]
+    const institutionID = anIDs[1]
+    // Since the form is bound to `jobToAddOrUpdate`, and we don't want to modify `state`: copy the object
+    const copyOfJob = Object.assign({}, props.jobs[institutionID][jobID])
+
+    setJobToAddOrUpdate(copyOfJob)
+
+    // Since the job form is being reused for add and update, need to toggle its display manually
+    toggleDisplayJobForm(institutionID)
 }
 
 /**
@@ -105,12 +176,53 @@ async function updateInstitution(anInstitution) {
 }
 
 /**
+ * Updates a aJob.
+ *
+ * @param {Object} aJob The job to update
+ */
+async function updateJob(aJob) {
+    const response = await props.sendUpdateJobRequest(aJob)
+
+    if (response.status === StatusCodes.OK) {
+        actionResultAlert.value = {
+            color: "success",
+            message: "Job updated successfully",
+        }
+    } else {
+        actionResultAlert.value = {
+            color: "error",
+            message: `Job update failed: HTTP ${response.status} (${response.statusText})`,
+        }
+    }
+
+    // Clear the form and hide it
+    setJobToAddOrUpdate({})
+    toggleDisplayJobForm(undefined)
+}
+
+/**
  * Sets the component state that shows or hides the dialog for the user to confirm institution removal.
  *
  * @param {Number} anInstitutionID The ID of the institution to remove
  */
 function selectInstitutionToRemove(anInstitutionID) {
     institutionToRemove.value = anInstitutionID
+}
+
+/**
+ * Sets the component state that shows or hides the dialog for the user to confirm job removal.
+ *
+ * @param {Number[]} anIDs A tuple of the ID of the job to remove, and the ID of the associated institution
+ */
+function selectJobToRemove(anIDs) {
+    if (anIDs !== undefined) {
+        const jobID = anIDs[0]
+        const institutionID = anIDs[1]
+
+        jobToRemove.value = [jobID, institutionID]
+    } else {
+        jobToRemove.value = undefined
+    }
 }
 
 /**
@@ -135,6 +247,30 @@ async function removeInstitution(anInstitutionID) {
 
     selectInstitutionToRemove(undefined)
 }
+
+/**
+ * Removes a job.
+ *
+ * @param {Number} aJobID The ID of the job to remove
+ * @param {Number} anInstitutionID The ID of the associated institution
+ */
+async function removeJob(aJobID, anInstitutionID) {
+    const response = await props.sendRemoveJobRequest(aJobID, anInstitutionID)
+
+    if (response.status === StatusCodes.NO_CONTENT) {
+        actionResultAlert.value = {
+            color: "success",
+            message: "Job removed successfully",
+        }
+    } else {
+        actionResultAlert.value = {
+            color: "error",
+            message: `Job remove failed: HTTP ${response.status} (${response.statusText})`,
+        }
+    }
+
+    selectJobToRemove(undefined)
+}
 </script>
 
 <template>
@@ -152,7 +288,10 @@ async function removeInstitution(anInstitutionID) {
                 v-bind="institution"
                 :jobs="props.jobs[institution.id] || {}"
                 :selectInstitutionToUpdate="selectInstitutionToUpdate"
-                :selectInstitutionToRemove="selectInstitutionToRemove" />
+                :selectInstitutionToRemove="selectInstitutionToRemove"
+                :toggleDisplayJobForm="toggleDisplayJobForm"
+                :selectJobToUpdate="selectJobToUpdate"
+                :selectJobToRemove="selectJobToRemove" />
         </v-list-item>
     </v-list>
     <v-card v-else variant="plain" width="auto">
@@ -244,6 +383,110 @@ async function removeInstitution(anInstitutionID) {
                     width="auto"
                     @click="selectInstitutionToRemove(undefined)"
                     class="cancel-remove-institution">
+                    Cancel
+                </v-btn>
+            </v-card-actions>
+        </v-card>
+    </v-dialog>
+
+    <!-- A conditionally-rendered form for adding or updating a job -->
+    <v-dialog v-model="institutionIdForJob" width="768">
+        <v-card>
+            <v-form>
+                <v-text-field
+                    v-if="jobToAddOrUpdate.id"
+                    label="ID"
+                    v-model="jobToAddOrUpdate.id"
+                    disabled></v-text-field>
+                <v-text-field
+                    label="Repository Base URL"
+                    v-model="jobToAddOrUpdate.repositoryBaseURL"
+                    required></v-text-field>
+                <v-text-field label="Metadata Format" model-value="oai_dc" disabled></v-text-field>
+                <!-- <v-text-field label="Sets" v-model="jobToAddOrUpdate.sets"></v-text-field> -->
+                <v-text-field
+                    label="Schedule Cron Expression"
+                    v-model="jobToAddOrUpdate.scheduleCronExpression"
+                    required></v-text-field>
+                <v-card-text>
+                    See
+                    <a
+                        href="http://www.quartz-scheduler.org/documentation/quartz-2.3.0/tutorials/crontrigger.html"
+                        target="_blank">
+                        the Quartz docs
+                    </a>
+                    for the Cron expression syntax.
+                </v-card-text>
+                <v-text-field
+                    v-if="jobToAddOrUpdate.id"
+                    label="Last Successful Run"
+                    v-model="jobToAddOrUpdate.lastSuccessfulRun"
+                    disabled></v-text-field>
+            </v-form>
+            <v-card-actions class="d-flex justify-center align-baseline">
+                <v-btn
+                    v-if="jobToAddOrUpdate.id === undefined"
+                    color="primary"
+                    variant="outlined"
+                    width="auto"
+                    class="confirm-add-job"
+                    @click="
+                        addJob({
+                            institutionID: institutionIdForJob,
+                            ...jobToAddOrUpdate,
+                            sets: [],
+                            metadataPrefix: `oai_dc`,
+                        })
+                    ">
+                    Save
+                </v-btn>
+                <v-btn
+                    v-else
+                    color="primary"
+                    variant="outlined"
+                    width="auto"
+                    class="confirm-update-job"
+                    @click="
+                        updateJob({
+                            institutionID: institutionIdForJob,
+                            ...jobToAddOrUpdate,
+                            sets: [],
+                            metadataPrefix: `oai_dc`,
+                        })
+                    ">
+                    Save
+                </v-btn>
+                <v-btn
+                    variant="outlined"
+                    width="auto"
+                    @click="toggleDisplayJobForm(undefined)"
+                    class="cancel-add-or-update-job">
+                    Cancel
+                </v-btn>
+            </v-card-actions>
+        </v-card>
+    </v-dialog>
+
+    <!-- A conditionally-rendered confirmation prompt for removing a job -->
+    <v-dialog v-if="jobToRemove" v-model="jobToRemove" width="auto">
+        <v-card>
+            <v-card-text>
+                <p>
+                    This action will remove this job (associated with
+                    <strong>{{ props.institutions[jobToRemove[1]].name }}</strong
+                    >) and all harvested items.
+                </p>
+            </v-card-text>
+            <v-card-actions class="d-flex justify-center align-baseline">
+                <v-btn
+                    color="red"
+                    variant="outlined"
+                    @click="removeJob(jobToRemove[0], jobToRemove[1])"
+                    width="auto"
+                    class="confirm-remove-job">
+                    Remove
+                </v-btn>
+                <v-btn variant="outlined" width="auto" @click="selectJobToRemove(undefined)" class="cancel-remove-job">
                     Cancel
                 </v-btn>
             </v-card-actions>

--- a/src/main/frontend/src/components/HarvesterAdmin.vue
+++ b/src/main/frontend/src/components/HarvesterAdmin.vue
@@ -449,9 +449,8 @@ function jobWithDeserializedSets(aJob) {
                     class="confirm-add-job"
                     @click="
                         addJob({
-                            institutionID: institutionIdForJob,
                             ...jobToAddOrUpdate,
-                            sets: jobToAddOrUpdate.sets,
+                            institutionID: institutionIdForJob,
                             metadataPrefix: `oai_dc`,
                         })
                     ">
@@ -465,9 +464,8 @@ function jobWithDeserializedSets(aJob) {
                     class="confirm-update-job"
                     @click="
                         updateJob({
-                            institutionID: institutionIdForJob,
                             ...jobToAddOrUpdate,
-                            sets: jobToAddOrUpdate.sets,
+                            institutionID: institutionIdForJob,
                             metadataPrefix: `oai_dc`,
                         })
                     ">

--- a/src/main/frontend/src/components/HarvesterAdmin.vue
+++ b/src/main/frontend/src/components/HarvesterAdmin.vue
@@ -403,7 +403,7 @@ async function removeJob(aJobID, anInstitutionID) {
                     v-model="jobToAddOrUpdate.repositoryBaseURL"
                     required></v-text-field>
                 <v-text-field label="Metadata Format" model-value="oai_dc" disabled></v-text-field>
-                <!-- <v-text-field label="Sets" v-model="jobToAddOrUpdate.sets"></v-text-field> -->
+                <v-text-field label="Sets" v-model="jobToAddOrUpdate.sets"></v-text-field>
                 <v-text-field
                     label="Schedule Cron Expression"
                     v-model="jobToAddOrUpdate.scheduleCronExpression"
@@ -434,7 +434,7 @@ async function removeJob(aJobID, anInstitutionID) {
                         addJob({
                             institutionID: institutionIdForJob,
                             ...jobToAddOrUpdate,
-                            sets: [],
+                            sets: jobToAddOrUpdate.sets,
                             metadataPrefix: `oai_dc`,
                         })
                     ">
@@ -450,7 +450,7 @@ async function removeJob(aJobID, anInstitutionID) {
                         updateJob({
                             institutionID: institutionIdForJob,
                             ...jobToAddOrUpdate,
-                            sets: [],
+                            sets: jobToAddOrUpdate.sets,
                             metadataPrefix: `oai_dc`,
                         })
                     ">

--- a/src/main/frontend/src/components/HarvesterAdmin.vue
+++ b/src/main/frontend/src/components/HarvesterAdmin.vue
@@ -150,7 +150,7 @@ async function removeInstitution(anInstitutionID) {
         <v-list-item v-for="institution in sortedInstitutions" :key="institution.id">
             <InstitutionItem
                 v-bind="institution"
-                :jobs="props.jobs[institution.id] || []"
+                :jobs="props.jobs[institution.id] || {}"
                 :selectInstitutionToUpdate="selectInstitutionToUpdate"
                 :selectInstitutionToRemove="selectInstitutionToRemove" />
         </v-list-item>

--- a/src/main/frontend/src/components/HarvesterAdmin.vue
+++ b/src/main/frontend/src/components/HarvesterAdmin.vue
@@ -96,10 +96,10 @@ async function addInstitution(anInstitution) {
 /**
  * Adds a job.
  *
- * @param {Object} aJob The job to add
+ * @param {Object} aJob A job with its sets represented as a CSV string
  */
 async function addJob(aJob) {
-    const response = await props.sendAddJobRequest(aJob)
+    const response = await props.sendAddJobRequest(jobWithDeserializedSets(aJob))
 
     if (response.status === StatusCodes.CREATED) {
         actionResultAlert.value = {
@@ -144,7 +144,8 @@ function selectJobToUpdate(anIDs) {
     // Since the form is bound to `jobToAddOrUpdate`, and we don't want to modify `state`: copy the object
     const copyOfJob = Object.assign({}, props.jobs[institutionID][jobID])
 
-    setJobToAddOrUpdate(copyOfJob)
+    // The form needs to work with a stringified version of the sets array
+    setJobToAddOrUpdate(jobWithCsvSerializedSets(copyOfJob))
 
     // Since the job form is being reused for add and update, need to toggle its display manually
     toggleDisplayJobForm(institutionID)
@@ -178,10 +179,10 @@ async function updateInstitution(anInstitution) {
 /**
  * Updates a aJob.
  *
- * @param {Object} aJob The job to update
+ * @param {Object} aJob A job with its sets represented as a CSV string
  */
 async function updateJob(aJob) {
-    const response = await props.sendUpdateJobRequest(aJob)
+    const response = await props.sendUpdateJobRequest(jobWithDeserializedSets(aJob))
 
     if (response.status === StatusCodes.OK) {
         actionResultAlert.value = {
@@ -270,6 +271,22 @@ async function removeJob(aJobID, anInstitutionID) {
     }
 
     selectJobToRemove(undefined)
+}
+
+/**
+ * @param {Object} aJob A job with its sets represented as an array
+ * @returns The job with its sets represented as a CSV string
+ */
+function jobWithCsvSerializedSets(aJob) {
+    return { ...aJob, sets: aJob.sets.join() }
+}
+
+/**
+ * @param {Object} aJob A job with its sets represented as a CSV string
+ * @returns The job with its sets represented as an array
+ */
+function jobWithDeserializedSets(aJob) {
+    return { ...aJob, sets: aJob.sets ? aJob.sets.split(",").map((s) => s.trim()) : [] }
 }
 </script>
 

--- a/src/main/frontend/src/components/InstitutionItem.vue
+++ b/src/main/frontend/src/components/InstitutionItem.vue
@@ -11,12 +11,12 @@ const props = defineProps({
     phone: { type: String },
     webContact: { type: String },
     website: { type: String, required: true },
-    jobs: { type: Array, required: true },
+    jobs: { type: Object, required: true },
     selectInstitutionToUpdate: { type: Function },
     selectInstitutionToRemove: { type: Function },
 })
 const sortedJobs = computed(() => {
-    return props.jobs.slice().sort((a, b) => {
+    return Object.values(props.jobs).sort((a, b) => {
         const hostnameA = new URL(a.repositoryBaseURL).hostname
         const hostnameB = new URL(b.repositoryBaseURL).hostname
 
@@ -93,7 +93,7 @@ const headingIdentifier = computed(() => props.name.toLowerCase().replaceAll(" "
         <!-- Next, a rendering of the associated jobs (if any) -->
         <v-card-subtitle class="ma-2 pa-2 text-subtitle-1">Jobs</v-card-subtitle>
         <v-card-text>
-            <v-table v-if="jobs.length > 0" class="harvest-jobs">
+            <v-table v-if="sortedJobs.length > 0" class="harvest-jobs">
                 <thead>
                     <tr>
                         <th>Repository Base URL</th>

--- a/src/main/frontend/src/components/InstitutionItem.vue
+++ b/src/main/frontend/src/components/InstitutionItem.vue
@@ -14,6 +14,9 @@ const props = defineProps({
     jobs: { type: Object, required: true },
     selectInstitutionToUpdate: { type: Function },
     selectInstitutionToRemove: { type: Function },
+    toggleDisplayJobForm: { type: Function },
+    selectJobToUpdate: { type: Function },
+    selectJobToRemove: { type: Function },
 })
 const sortedJobs = computed(() => {
     return Object.values(props.jobs).sort((a, b) => {
@@ -92,21 +95,22 @@ const headingIdentifier = computed(() => props.name.toLowerCase().replaceAll(" "
 
         <!-- Next, a rendering of the associated jobs (if any) -->
         <v-card-subtitle class="ma-2 pa-2 text-subtitle-1">Jobs</v-card-subtitle>
+        <v-card-actions>
+            <v-btn color="primary" variant="outlined" @click="toggleDisplayJobForm(id)" class="propose-add-job ma-2">
+                Add Job
+            </v-btn>
+        </v-card-actions>
         <v-card-text>
-            <v-table v-if="sortedJobs.length > 0" class="harvest-jobs">
-                <thead>
-                    <tr>
-                        <th>Repository Base URL</th>
-                        <th>Sets</th>
-                        <th>Metadata Format</th>
-                        <th>Schedule</th>
-                        <th>Last Successful Run</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <JobItem v-for="job in sortedJobs" v-bind="job" :key="job.id" />
-                </tbody>
-            </v-table>
+            <v-container v-if="sortedJobs.length > 0" class="harvest-jobs">
+                <v-row justify="left">
+                    <v-col v-for="job in sortedJobs" :key="job.id" cols="auto">
+                        <JobItem
+                            v-bind="job"
+                            :selectJobToUpdate="selectJobToUpdate"
+                            :selectJobToRemove="selectJobToRemove" />
+                    </v-col>
+                </v-row>
+            </v-container>
             <p v-else>No jobs yet!</p>
         </v-card-text>
         <v-card-actions class="ma-2 pa-2">

--- a/src/main/frontend/src/components/JobItem.vue
+++ b/src/main/frontend/src/components/JobItem.vue
@@ -9,33 +9,62 @@ const props = defineProps({
     metadataPrefix: { type: String, required: true },
     scheduleCronExpression: { type: String, required: true },
     lastSuccessfulRun: { type: Date },
+    selectJobToUpdate: { type: Function },
+    selectJobToRemove: { type: Function },
 })
-const sortedSets = computed(() => props.sets.slice().sort())
-const isSelectiveHarvest = computed(() => props.sets.length > 0)
+const isSelectiveHarvest = computed(() => (props.sets ? props.sets.length > 0 : false))
+const sortedSets = computed(() => (props.sets ? props.sets.slice().sort() : []))
 </script>
 
 <template>
-    <tr>
-        <td>
-            <a :href="`${repositoryBaseURL}?verb=Identify`">{{ repositoryBaseURL }}</a>
-        </td>
-        <td>
-            <v-list v-if="isSelectiveHarvest">
-                <v-list-item v-for="set in sortedSets" :key="set" density="compact">
-                    <a :href="`${repositoryBaseURL}?verb=ListRecords&set=${set}&metadataPrefix=${metadataPrefix}`">
-                        {{ set }}
-                    </a>
+    <v-card variant="outlined" height="auto" width="auto">
+        <v-card-text>
+            <v-list>
+                <v-list-item density="compact" prepend-icon="mdi-town-hall">
+                    <v-list-item-subtitle>
+                        <a :href="`${repositoryBaseURL}?verb=Identify`">{{ repositoryBaseURL }}</a>
+                    </v-list-item-subtitle>
+                </v-list-item>
+                <v-list-item density="compact" prepend-icon="mdi-archive">
+                    <v-list v-if="isSelectiveHarvest">
+                        <span v-for="set in sortedSets" :key="set" density="compact">
+                            <a
+                                :href="`${repositoryBaseURL}?verb=ListRecords&set=${set}&metadataPrefix=${metadataPrefix}`">
+                                {{ set }} </a
+                            >,
+                        </span>
+                    </v-list>
+                    <span v-else class="optional-field-placeholder">(entire repository)</span>
+                </v-list-item>
+                <v-list-item density="compact" prepend-icon="mdi-file-code">{{ metadataPrefix }}</v-list-item>
+                <v-list-item density="compact" prepend-icon="mdi-calendar-clock">
+                    <v-list-item-subtitle>{{ scheduleCronExpression }}</v-list-item-subtitle>
+                </v-list-item>
+                <v-list-item density="compact" prepend-icon="mdi-timeline-check">
+                    <v-list-item-subtitle>
+                        <span v-if="lastSuccessfulRun">{{ lastSuccessfulRun }}</span>
+                        <span v-else class="optional-field-placeholder">(no successful runs yet)</span>
+                    </v-list-item-subtitle>
                 </v-list-item>
             </v-list>
-            <span v-else class="optional-field-placeholder">(entire repository)</span>
-        </td>
-        <td>{{ metadataPrefix }}</td>
-        <td>{{ scheduleCronExpression }}</td>
-        <td>
-            <span v-if="lastSuccessfulRun">{{ lastSuccessfulRun }}</span>
-            <span v-else class="optional-field-placeholder">(no successful runs yet)</span>
-        </td>
-    </tr>
+        </v-card-text>
+        <v-card-actions class="ma-2 pa-2">
+            <v-btn
+                color="primary"
+                variant="outlined"
+                @click="selectJobToUpdate([id, institutionID])"
+                class="propose-edit-job">
+                Edit
+            </v-btn>
+            <v-btn
+                color="red"
+                variant="outlined"
+                @click="selectJobToRemove([id, institutionID])"
+                class="propose-remove-job">
+                Remove
+            </v-btn>
+        </v-card-actions>
+    </v-card>
 </template>
 
 <style scoped></style>

--- a/src/main/frontend/src/components/JobItem.vue
+++ b/src/main/frontend/src/components/JobItem.vue
@@ -5,15 +5,15 @@ const props = defineProps({
     id: { type: Number, required: true },
     institutionID: { type: Number, required: true },
     repositoryBaseURL: { type: String, required: true },
-    sets: { type: Array, required: true },
+    sets: { type: String, required: true }, // Represented as a CSV-ified array throughout the front-end app, except when making HTTP requests to the back-end
     metadataPrefix: { type: String, required: true },
     scheduleCronExpression: { type: String, required: true },
     lastSuccessfulRun: { type: Date },
     selectJobToUpdate: { type: Function },
     selectJobToRemove: { type: Function },
 })
-const isSelectiveHarvest = computed(() => (props.sets ? props.sets.length > 0 : false))
-const sortedSets = computed(() => (props.sets ? props.sets.slice().sort() : []))
+const isSelectiveHarvest = computed(() => (props.sets ? props.sets.split(',').length > 0 : false))
+const sortedSets = computed(() => (props.sets ? props.sets.split(',') : []))
 </script>
 
 <template>

--- a/src/main/frontend/src/components/JobItem.vue
+++ b/src/main/frontend/src/components/JobItem.vue
@@ -5,15 +5,15 @@ const props = defineProps({
     id: { type: Number, required: true },
     institutionID: { type: Number, required: true },
     repositoryBaseURL: { type: String, required: true },
-    sets: { type: String, required: true }, // Represented as a CSV-ified array throughout the front-end app, except when making HTTP requests to the back-end
+    sets: { type: Array, required: true },
     metadataPrefix: { type: String, required: true },
     scheduleCronExpression: { type: String, required: true },
     lastSuccessfulRun: { type: Date },
     selectJobToUpdate: { type: Function },
     selectJobToRemove: { type: Function },
 })
-const isSelectiveHarvest = computed(() => (props.sets ? props.sets.split(',').length > 0 : false))
-const sortedSets = computed(() => (props.sets ? props.sets.split(',') : []))
+const isSelectiveHarvest = computed(() => (props.sets ? props.sets.length > 0 : false))
+const sortedSets = computed(() => (props.sets ? props.sets.slice().sort() : []))
 </script>
 
 <template>

--- a/src/main/frontend/src/components/__tests__/HarvesterAdmin.spec.js
+++ b/src/main/frontend/src/components/__tests__/HarvesterAdmin.spec.js
@@ -165,7 +165,9 @@ describe("HarvesterAdmin", () => {
         })
 
         describe("with jobs", () => {
-            const jobs = { [testInstitution.id]: { [testJob.id]: testJob, [testJobSelectiveHarvest.id]: testJobSelectiveHarvest } }
+            const jobs = {
+                [testInstitution.id]: { [testJob.id]: testJob, [testJobSelectiveHarvest.id]: testJobSelectiveHarvest },
+            }
             const data = { institutions, jobs }
 
             beforeEach(() => {

--- a/src/main/frontend/src/components/__tests__/InstitutionItem.spec.js
+++ b/src/main/frontend/src/components/__tests__/InstitutionItem.spec.js
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest"
+import { describe, it, expect, beforeEach, afterEach } from "vitest"
 
 import { createVuetify } from "vuetify"
 import * as components from "vuetify/components"
@@ -6,6 +6,7 @@ import * as directives from "vuetify/directives"
 import { mount } from "@vue/test-utils"
 
 import InstitutionItem from "../InstitutionItem.vue"
+import JobItem from "../JobItem.vue"
 import { testJob, testJobSelectiveHarvest, testInstitution } from "./TestData.js"
 
 describe("InstitutionItem", () => {
@@ -32,13 +33,13 @@ describe("InstitutionItem", () => {
      * @param {object[]} jobs The data that should be rendered
      */
     function checkJobs(wrapper, jobs) {
-        const jobsTable = wrapper.find(".harvest-jobs")
+        const jobsList = wrapper.find(".harvest-jobs")
 
         if (jobs.length > 0) {
-            expect(jobsTable.exists()).toBeTruthy()
-            expect(jobsTable.findAll("tbody").at(0).findAll("tr").length).toStrictEqual(jobs.length)
+            expect(jobsList.exists()).toBeTruthy()
+            expect(jobsList.findAllComponents(JobItem).length).toStrictEqual(jobs.length)
         } else {
-            expect(jobsTable.exists()).toBeFalsy()
+            expect(jobsList.exists()).toBeFalsy()
             expect(wrapper.text()).toContain("No jobs yet!")
         }
     }
@@ -47,35 +48,66 @@ describe("InstitutionItem", () => {
      * Checks that the HTML button elements are rendered as expected.
      *
      * @param {VueWrapper} wrapper The result of mounting a {@link InstitutionItem}
+     * @param {object[]} jobs The data that should be rendered
      */
-    function checkButtons(wrapper) {
-        const buttons = wrapper.findAll("button")
-        expect(buttons.length).toStrictEqual(2)
-        expect(buttons.at(0).text()).toContain("Edit")
-        expect(buttons.at(1).text()).toContain("Remove")
+    function checkButtons(wrapper, jobs) {
+        expect(wrapper.findAll("button").length).toStrictEqual(3 + (2 * jobs.length))
+
+        expect(wrapper.find(".propose-add-job").exists()).toBeTruthy()
+        expect(wrapper.find(".propose-edit-institution").exists()).toBeTruthy()
+        expect(wrapper.find(".propose-remove-institution").exists()).toBeTruthy()
+
+        for (const selector of [".propose-edit-job", ".propose-remove-job"]) {
+            expect(wrapper.findAll(selector).length).toStrictEqual(jobs.length)
+        }
     }
 
-    it("renders properly without jobs", () => {
+    describe("without jobs", () => {
         const jobs = []
-        const wrapper = mount(InstitutionItem, {
-            props: { ...testInstitution, jobs },
-            global: { plugins: [vuetify] },
+        const data = { ...testInstitution, jobs }
+
+        let wrapper
+
+        beforeEach(() => {
+            wrapper = mount(InstitutionItem, {
+                props: data,
+                global: { plugins: [vuetify] },
+            })
         })
 
-        checkInstitution(wrapper, testInstitution)
-        checkJobs(wrapper, jobs)
-        checkButtons(wrapper)
+        it("renders properly", () => {
+            checkInstitution(wrapper, testInstitution)
+            checkJobs(wrapper, jobs)
+            checkButtons(wrapper, jobs)
+        })
+
+        afterEach(() => {
+            wrapper.unmount()
+        })
     })
 
-    it("renders properly with jobs", () => {
+    describe("with jobs", () => {
         const jobs = [testJob, testJobSelectiveHarvest]
-        const wrapper = mount(InstitutionItem, {
-            props: { ...testInstitution, jobs },
-            global: { plugins: [vuetify] },
+        const data = { ...testInstitution, jobs }
+
+        let wrapper
+
+        beforeEach(() => {
+            wrapper = mount(InstitutionItem, {
+                props: data,
+                global: { plugins: [vuetify] },
+            })
         })
 
-        checkInstitution(wrapper, testInstitution)
-        checkJobs(wrapper, jobs)
-        checkButtons(wrapper)
+        it("renders properly", () => {
+            checkInstitution(wrapper, testInstitution)
+            checkJobs(wrapper, jobs)
+            checkButtons(wrapper, jobs)
+        })
+
+
+        afterEach(() => {
+            wrapper.unmount()
+        })
     })
 })

--- a/src/main/frontend/src/components/__tests__/InstitutionItem.spec.js
+++ b/src/main/frontend/src/components/__tests__/InstitutionItem.spec.js
@@ -51,7 +51,7 @@ describe("InstitutionItem", () => {
      * @param {object[]} jobs The data that should be rendered
      */
     function checkButtons(wrapper, jobs) {
-        expect(wrapper.findAll("button").length).toStrictEqual(3 + (2 * jobs.length))
+        expect(wrapper.findAll("button").length).toStrictEqual(3 + 2 * jobs.length)
 
         expect(wrapper.find(".propose-add-job").exists()).toBeTruthy()
         expect(wrapper.find(".propose-edit-institution").exists()).toBeTruthy()
@@ -62,52 +62,36 @@ describe("InstitutionItem", () => {
         }
     }
 
-    describe("without jobs", () => {
-        const jobs = []
-        const data = { ...testInstitution, jobs }
+    for (const testInfo of [
+        {
+            name: "without jobs",
+            institution: testInstitution,
+            jobs: [],
+        },
+        {
+            name: "with jobs",
+            institution: testInstitution,
+            jobs: [testJob, testJobSelectiveHarvest],
+        },
+    ]) {
+        describe(testInfo.name, () => {
+            const props = { ...testInfo.institution, jobs: testInfo.jobs }
 
-        let wrapper
+            let wrapper
 
-        beforeEach(() => {
-            wrapper = mount(InstitutionItem, {
-                props: data,
-                global: { plugins: [vuetify] },
+            beforeEach(() => {
+                wrapper = mount(InstitutionItem, { props, global: { plugins: [vuetify] } })
+            })
+
+            it("renders properly", () => {
+                checkInstitution(wrapper, testInfo.institution)
+                checkJobs(wrapper, testInfo.jobs)
+                checkButtons(wrapper, testInfo.jobs)
+            })
+
+            afterEach(() => {
+                wrapper.unmount()
             })
         })
-
-        it("renders properly", () => {
-            checkInstitution(wrapper, testInstitution)
-            checkJobs(wrapper, jobs)
-            checkButtons(wrapper, jobs)
-        })
-
-        afterEach(() => {
-            wrapper.unmount()
-        })
-    })
-
-    describe("with jobs", () => {
-        const jobs = [testJob, testJobSelectiveHarvest]
-        const data = { ...testInstitution, jobs }
-
-        let wrapper
-
-        beforeEach(() => {
-            wrapper = mount(InstitutionItem, {
-                props: data,
-                global: { plugins: [vuetify] },
-            })
-        })
-
-        it("renders properly", () => {
-            checkInstitution(wrapper, testInstitution)
-            checkJobs(wrapper, jobs)
-            checkButtons(wrapper, jobs)
-        })
-
-
-        afterEach(() => {
-            wrapper.unmount()
-        })
-    })
+    }
 })

--- a/src/main/frontend/src/components/__tests__/JobItem.spec.js
+++ b/src/main/frontend/src/components/__tests__/JobItem.spec.js
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest"
+import { describe, it, expect, beforeEach, afterEach } from "vitest"
 
 import { createVuetify } from "vuetify"
 import * as components from "vuetify/components"
@@ -37,23 +37,32 @@ describe("JobItem", () => {
             })
     }
 
-    it("renders properly without sets specified", () => {
-        const wrapper = mount(JobItem, {
-            props: testJob,
-            global: { plugins: [vuetify] },
+    for (const testInfo of [
+        {
+            name: "without sets",
+            job: testJob,
+        },
+        {
+            name: "with sets",
+            job: testJobSelectiveHarvest,
+        },
+    ]) {
+        describe(testInfo.name, () => {
+            const props = testInfo.job
+
+            let wrapper
+
+            beforeEach(() => {
+                wrapper = mount(JobItem, { props, global: { plugins: [vuetify] } })
+            })
+
+            it("renders properly", () => {
+                checkJob(wrapper, testInfo.job)
+            })
+
+            afterEach(() => {
+                wrapper.unmount()
+            })
         })
-
-        checkJob(wrapper, testJob)
-    })
-
-    it("renders properly with sets specified", () => {
-        const wrapper = mount(JobItem, {
-            props: testJobSelectiveHarvest,
-            global: { plugins: [vuetify] },
-        })
-
-        checkJob(wrapper, testJobSelectiveHarvest)
-    })
+    }
 })
-
-export { testJob, testJobSelectiveHarvest }

--- a/src/main/frontend/src/components/__tests__/JobItem.spec.js
+++ b/src/main/frontend/src/components/__tests__/JobItem.spec.js
@@ -37,6 +37,18 @@ describe("JobItem", () => {
             })
     }
 
+    /**
+     * Checks that the HTML button elements are rendered as expected.
+     *
+     * @param {VueWrapper} wrapper The result of mounting a {@link JobItem}
+     */
+    function checkButtons(wrapper) {
+        expect(wrapper.findAll("button").length).toStrictEqual(2)
+
+        expect(wrapper.find(".propose-edit-job").exists()).toBeTruthy()
+        expect(wrapper.find(".propose-remove-job").exists()).toBeTruthy()
+    }
+
     for (const testInfo of [
         {
             name: "without sets",
@@ -58,6 +70,7 @@ describe("JobItem", () => {
 
             it("renders properly", () => {
                 checkJob(wrapper, testInfo.job)
+                checkButtons(wrapper)
             })
 
             afterEach(() => {

--- a/src/main/frontend/src/components/__tests__/TestData.js
+++ b/src/main/frontend/src/components/__tests__/TestData.js
@@ -1,5 +1,4 @@
-const testJob = {
-    id: 1,
+const testJobSeed = {
     institutionID: 1,
     repositoryBaseURL: "http://example.edu/provider",
     sets: [],
@@ -8,9 +7,15 @@ const testJob = {
     lastSuccessfulRun: null,
 }
 
+const testJob = {
+    id: 1,
+    ...testJobSeed,
+}
+
 const testJobSelectiveHarvest = {
-    ...testJob,
+    id: 2,
     sets: ["set1", "set2"],
+    ...testJobSeed,
 }
 
 const testInstitution = {


### PR DESCRIPTION
Largely analogous to #46.

Major notes:
- changed state representation of jobs so that it's indexed by job ID and institution ID
- OAI-PMH sets (an array) are represented as a CSV string while the add/update form is active