### PR TITLE
Display helpful HTTP 400 error messages to admin user

### DIFF
--- a/src/main/frontend/src/components/HarvesterAdmin.vue
+++ b/src/main/frontend/src/components/HarvesterAdmin.vue
@@ -84,7 +84,7 @@ async function addInstitution(anInstitution) {
     } else {
         actionResultAlert.value = {
             color: "error",
-            message: `Institution add failed: HTTP ${response.status} (${await response.text()})`,
+            message: await getErrorMessage(response, "Institution add failed"),
         }
     }
 
@@ -109,7 +109,7 @@ async function addJob(aJob) {
     } else {
         actionResultAlert.value = {
             color: "error",
-            message: `Job add failed: HTTP ${response.status} (${await response.text()})`,
+            message: await getErrorMessage(response, "Job add failed"),
         }
     }
 
@@ -167,7 +167,7 @@ async function updateInstitution(anInstitution) {
     } else {
         actionResultAlert.value = {
             color: "error",
-            message: `Institution update failed: HTTP ${response.status} (${await response.text()})`,
+            message: await getErrorMessage(response, "Institution update failed"),
         }
     }
 
@@ -192,7 +192,7 @@ async function updateJob(aJob) {
     } else {
         actionResultAlert.value = {
             color: "error",
-            message: `Job update failed: HTTP ${response.status} (${await response.text()})`,
+            message: await getErrorMessage(response, "Job update failed"),
         }
     }
 
@@ -242,7 +242,7 @@ async function removeInstitution(anInstitutionID) {
     } else {
         actionResultAlert.value = {
             color: "error",
-            message: `Institution remove failed: HTTP ${response.status} (${await response.text()})`,
+            message: await getErrorMessage(response, "Institution remove failed"),
         }
     }
 
@@ -266,7 +266,7 @@ async function removeJob(aJobID, anInstitutionID) {
     } else {
         actionResultAlert.value = {
             color: "error",
-            message: `Job remove failed: HTTP ${response.status} (${await response.text()})`,
+            message: await getErrorMessage(response, "Job remove failed"),
         }
     }
 
@@ -287,6 +287,15 @@ function jobWithCsvSerializedSets(aJob) {
  */
 function jobWithDeserializedSets(aJob) {
     return { ...aJob, sets: aJob.sets ? aJob.sets.split(",").map((s) => s.trim()) : [] }
+}
+
+/**
+ * @param {Response} aResponse An HTTP response
+ * @param {String} aPrefix A prefix for the error message
+ * @returns An error message
+ */
+async function getErrorMessage(aResponse, aPrefix) {
+    return `${aPrefix}: HTTP ${aResponse.status} (${await aResponse.text()})`
 }
 </script>
 

--- a/src/main/frontend/src/components/HarvesterAdmin.vue
+++ b/src/main/frontend/src/components/HarvesterAdmin.vue
@@ -84,7 +84,7 @@ async function addInstitution(anInstitution) {
     } else {
         actionResultAlert.value = {
             color: "error",
-            message: await getErrorMessage(response, "Institution add failed"),
+            message: await getErrorMessage(response, "Institution add"),
         }
     }
 
@@ -109,7 +109,7 @@ async function addJob(aJob) {
     } else {
         actionResultAlert.value = {
             color: "error",
-            message: await getErrorMessage(response, "Job add failed"),
+            message: await getErrorMessage(response, "Job add"),
         }
     }
 
@@ -167,7 +167,7 @@ async function updateInstitution(anInstitution) {
     } else {
         actionResultAlert.value = {
             color: "error",
-            message: await getErrorMessage(response, "Institution update failed"),
+            message: await getErrorMessage(response, "Institution update"),
         }
     }
 
@@ -192,7 +192,7 @@ async function updateJob(aJob) {
     } else {
         actionResultAlert.value = {
             color: "error",
-            message: await getErrorMessage(response, "Job update failed"),
+            message: await getErrorMessage(response, "Job update"),
         }
     }
 
@@ -242,7 +242,7 @@ async function removeInstitution(anInstitutionID) {
     } else {
         actionResultAlert.value = {
             color: "error",
-            message: await getErrorMessage(response, "Institution remove failed"),
+            message: await getErrorMessage(response, "Institution remove"),
         }
     }
 
@@ -266,7 +266,7 @@ async function removeJob(aJobID, anInstitutionID) {
     } else {
         actionResultAlert.value = {
             color: "error",
-            message: await getErrorMessage(response, "Job remove failed"),
+            message: await getErrorMessage(response, "Job remove"),
         }
     }
 
@@ -291,11 +291,11 @@ function jobWithDeserializedSets(aJob) {
 
 /**
  * @param {Response} aResponse An HTTP response
- * @param {String} aPrefix A prefix for the error message
+ * @param {String} anOperation The operation that failed
  * @returns An error message
  */
-async function getErrorMessage(aResponse, aPrefix) {
-    return `${aPrefix}: HTTP ${aResponse.status} (${await aResponse.text()})`
+async function getErrorMessage(aResponse, anOperation) {
+    return `${anOperation} failed: HTTP ${aResponse.status} (${await aResponse.text()})`
 }
 </script>
 

--- a/src/main/frontend/src/components/HarvesterAdmin.vue
+++ b/src/main/frontend/src/components/HarvesterAdmin.vue
@@ -84,7 +84,7 @@ async function addInstitution(anInstitution) {
     } else {
         actionResultAlert.value = {
             color: "error",
-            message: `Institution add failed: HTTP ${response.status} (${response.statusText})`,
+            message: `Institution add failed: HTTP ${response.status} (${await response.text()})`,
         }
     }
 
@@ -109,7 +109,7 @@ async function addJob(aJob) {
     } else {
         actionResultAlert.value = {
             color: "error",
-            message: `Job add failed: HTTP ${response.status} (${response.statusText})`,
+            message: `Job add failed: HTTP ${response.status} (${await response.text()})`,
         }
     }
 
@@ -167,7 +167,7 @@ async function updateInstitution(anInstitution) {
     } else {
         actionResultAlert.value = {
             color: "error",
-            message: `Institution update failed: HTTP ${response.status} (${response.statusText})`,
+            message: `Institution update failed: HTTP ${response.status} (${await response.text()})`,
         }
     }
 
@@ -192,7 +192,7 @@ async function updateJob(aJob) {
     } else {
         actionResultAlert.value = {
             color: "error",
-            message: `Job update failed: HTTP ${response.status} (${response.statusText})`,
+            message: `Job update failed: HTTP ${response.status} (${await response.text()})`,
         }
     }
 
@@ -242,7 +242,7 @@ async function removeInstitution(anInstitutionID) {
     } else {
         actionResultAlert.value = {
             color: "error",
-            message: `Institution remove failed: HTTP ${response.status} (${response.statusText})`,
+            message: `Institution remove failed: HTTP ${response.status} (${await response.text()})`,
         }
     }
 
@@ -266,7 +266,7 @@ async function removeJob(aJobID, anInstitutionID) {
     } else {
         actionResultAlert.value = {
             color: "error",
-            message: `Job remove failed: HTTP ${response.status} (${response.statusText})`,
+            message: `Job remove failed: HTTP ${response.status} (${await response.text()})`,
         }
     }
 

--- a/src/main/java/edu/ucla/library/prl/harvester/handlers/InformativeBadRequestHandler.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/handlers/InformativeBadRequestHandler.java
@@ -1,0 +1,25 @@
+
+package edu.ucla.library.prl.harvester.handlers;
+
+import org.apache.http.HttpStatus;
+
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.ErrorHandler;
+import io.vertx.ext.web.validation.BadRequestException;
+
+/**
+ * An error handler for bad requests that puts the error message in the response.
+ */
+public final class InformativeBadRequestHandler implements ErrorHandler {
+
+    @Override
+    public void handle(final RoutingContext aContext) {
+        final Throwable error = aContext.failure();
+
+        if (error instanceof BadRequestException) {
+            aContext.response().setStatusCode(HttpStatus.SC_BAD_REQUEST).end(error.getMessage());
+        } else {
+            aContext.next();
+        }
+    }
+}

--- a/src/main/java/edu/ucla/library/prl/harvester/verticles/MainVerticle.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/verticles/MainVerticle.java
@@ -14,6 +14,7 @@ import edu.ucla.library.prl.harvester.handlers.AddInstitutionHandler;
 import edu.ucla.library.prl.harvester.handlers.AddJobHandler;
 import edu.ucla.library.prl.harvester.handlers.GetInstitutionHandler;
 import edu.ucla.library.prl.harvester.handlers.GetJobHandler;
+import edu.ucla.library.prl.harvester.handlers.InformativeBadRequestHandler;
 import edu.ucla.library.prl.harvester.handlers.ListInstitutionsHandler;
 import edu.ucla.library.prl.harvester.handlers.ListJobsHandler;
 import edu.ucla.library.prl.harvester.handlers.RemoveInstitutionHandler;
@@ -129,7 +130,6 @@ public class MainVerticle extends AbstractVerticle {
     public Future<Router> createRouter(final JsonObject aConfig) {
         // Load the OpenAPI specification
         return RouterBuilder.create(vertx, "openapi.yaml").map(routeBuilder -> {
-            final ServiceExceptionHandler serviceExceptionHandler = new ServiceExceptionHandler();
             final Router router;
 
             // Associate handlers with operation IDs from the OpenAPI spec
@@ -155,7 +155,7 @@ public class MainVerticle extends AbstractVerticle {
             router = routeBuilder.createRouter();
             router.route("/assets/*").handler(StaticHandler.create("webroot/assets"));
             router.route().handler(FaviconHandler.create(vertx, "webroot/favicon.ico"))
-                    .failureHandler(serviceExceptionHandler);
+                    .failureHandler(new InformativeBadRequestHandler()).failureHandler(new ServiceExceptionHandler());
 
             return router;
         });

--- a/src/main/resources/prl-harvester_messages.xml
+++ b/src/main/resources/prl-harvester_messages.xml
@@ -41,5 +41,6 @@
   <entry key="PRL_036">The static asset {} could not be resolved: HTTP {} {}</entry>
   <entry key="PRL_037">Contents of Solr after {}: {}</entry>
   <entry key="PRL_038">Validation succeeded, but it should have failed</entry>
+  <entry key="PRL_039">[Bad Request] Validation error for body application/json: provided object should contain property {}</entry>
 
 </properties>

--- a/src/test/java/edu/ucla/library/prl/harvester/InstitutionRequestsFT.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/InstitutionRequestsFT.java
@@ -61,9 +61,6 @@ public class InstitutionRequestsFT {
 
     private static final UriTemplate INSTITUTIONS = UriTemplate.of("/institutions");
 
-    private static final String MISSING_NAME_VALIDATION_ERROR =
-            "[Bad Request] Validation error for body application/json: provided object should contain property name";
-
     private Pool myDbConnectionPool;
 
     private JavaAsyncSolrClient mySolrClient;
@@ -593,7 +590,7 @@ public class InstitutionRequestsFT {
         myWebClient.post(INSTITUTIONS).sendJson(invalidInstitutionJson).onSuccess(response -> {
             aContext.verify(() -> {
                 assertEquals(HttpStatus.SC_BAD_REQUEST, response.statusCode());
-                assertEquals(MISSING_NAME_VALIDATION_ERROR, response.bodyAsString());
+                assertEquals(LOGGER.getMessage(MessageCodes.PRL_039, Institution.NAME), response.bodyAsString());
 
                 responseVerified.flag();
             });
@@ -685,7 +682,8 @@ public class InstitutionRequestsFT {
             return updateInstitution.compose(updateInstitutionResponse -> {
                 aContext.verify(() -> {
                     assertEquals(HttpStatus.SC_BAD_REQUEST, updateInstitutionResponse.statusCode());
-                    assertEquals(MISSING_NAME_VALIDATION_ERROR, updateInstitutionResponse.bodyAsString());
+                    assertEquals(LOGGER.getMessage(MessageCodes.PRL_039, Institution.NAME),
+                            updateInstitutionResponse.bodyAsString());
 
                     responseVerified.flag();
 

--- a/src/test/java/edu/ucla/library/prl/harvester/JobRequestsFT.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/JobRequestsFT.java
@@ -67,10 +67,6 @@ public class JobRequestsFT {
 
     private static final UriTemplate JOBS = UriTemplate.of("/jobs");
 
-    private static final String MISSING_INSTITUTIONID_VALIDATION_ERROR =
-            "[Bad Request] Validation error for body application/json: " +
-                    "provided object should contain property institutionID";
-
     private Pool myDbConnectionPool;
 
     private JavaAsyncSolrClient mySolrClient;
@@ -557,7 +553,7 @@ public class JobRequestsFT {
         myWebClient.post(JOBS).sendJson(invalidJobJson).onSuccess(response -> {
             aContext.verify(() -> {
                 assertEquals(HttpStatus.SC_BAD_REQUEST, response.statusCode());
-                assertEquals(MISSING_INSTITUTIONID_VALIDATION_ERROR, response.bodyAsString());
+                assertEquals(LOGGER.getMessage(MessageCodes.PRL_039, Job.INSTITUTION_ID), response.bodyAsString());
 
                 responseVerified.flag();
 
@@ -631,7 +627,8 @@ public class JobRequestsFT {
             return updateJob.compose(updateJobResponse -> {
                 aContext.verify(() -> {
                     assertEquals(HttpStatus.SC_BAD_REQUEST, updateJobResponse.statusCode());
-                    assertEquals(MISSING_INSTITUTIONID_VALIDATION_ERROR, updateJobResponse.bodyAsString());
+                    assertEquals(LOGGER.getMessage(MessageCodes.PRL_039, Job.INSTITUTION_ID),
+                            updateJobResponse.bodyAsString());
 
                     responseVerified.flag();
 


### PR DESCRIPTION
Summary:
- the default response handler for OpenAPI validation errors that result in HTTP 400 does not include a detailed description of the cause in the response body, so I created a custom error handler to do that
- in order to use the value of the response body in the admin UI, [Response.text()](https://developer.mozilla.org/en-US/docs/Web/API/Response/text) (a Promise-returning method, hence `await`) must be used, not Response.statusText