### PR TITLE
[SERV-774] Make POST endpoints accept arrays

### DIFF
--- a/src/main/frontend/src/App.vue
+++ b/src/main/frontend/src/App.vue
@@ -17,22 +17,23 @@ import HarvesterAdmin from "./components/HarvesterAdmin.vue"
 const state = reactive({ institutions: {}, jobs: {} })
 
 /**
- * Sends an addInstitution request and, if successful, updates the state with the result.
+ * Sends an addInstitutions request with a single institution and, if successful, updates the state with the result.
  *
  * @param {Object} anInstitution The institution
  * @returns The HTTP response
  */
-async function sendAddInstitutionRequest(anInstitution) {
+async function sendAddInstitutionsRequest(anInstitution) {
     const response = await fetch("/institutions", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(anInstitution),
+        body: JSON.stringify([anInstitution]),
     })
 
     if (response.status === StatusCodes.CREATED) {
         const responseBody = await response.json()
+        const institution = responseBody[0]
 
-        state.institutions[responseBody.id] = responseBody
+        state.institutions[institution.id] = institution
     }
 
     return response
@@ -78,26 +79,27 @@ async function sendRemoveInstitutionRequest(anInstitutionID) {
 }
 
 /**
- * Sends an addJob request and, if successful, updates the state with the result.
+ * Sends an addJobs request with a single job and, if successful, updates the state with the result.
  *
  * @param {Object} aJob A job
  * @returns The HTTP response
  */
-async function sendAddJobRequest(aJob) {
+async function sendAddJobsRequest(aJob) {
     const response = await fetch("/jobs", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(aJob),
+        body: JSON.stringify([aJob]),
     })
 
     if (response.status === StatusCodes.CREATED) {
         const responseBody = await response.json()
+        const job = responseBody[0]
 
-        if (state.jobs[responseBody.institutionID] === undefined) {
-            state.jobs[responseBody.institutionID] = {}
+        if (state.jobs[job.institutionID] === undefined) {
+            state.jobs[job.institutionID] = {}
         }
 
-        state.jobs[responseBody.institutionID][responseBody.id] = responseBody
+        state.jobs[job.institutionID][job.id] = job
     }
 
     return response
@@ -181,10 +183,10 @@ fetch("/jobs")
     <main>
         <HarvesterAdmin
             v-bind="state"
-            :sendAddInstitutionRequest="sendAddInstitutionRequest"
+            :sendAddInstitutionsRequest="sendAddInstitutionsRequest"
             :sendUpdateInstitutionRequest="sendUpdateInstitutionRequest"
             :sendRemoveInstitutionRequest="sendRemoveInstitutionRequest"
-            :sendAddJobRequest="sendAddJobRequest"
+            :sendAddJobsRequest="sendAddJobsRequest"
             :sendUpdateJobRequest="sendUpdateJobRequest"
             :sendRemoveJobRequest="sendRemoveJobRequest" />
     </main>

--- a/src/main/frontend/src/components/HarvesterAdmin.vue
+++ b/src/main/frontend/src/components/HarvesterAdmin.vue
@@ -6,10 +6,10 @@ import InstitutionItem from "./InstitutionItem.vue"
 const props = defineProps({
     institutions: { type: Object, required: true },
     jobs: { type: Object, required: true },
-    sendAddInstitutionRequest: { type: Function },
+    sendAddInstitutionsRequest: { type: Function },
     sendUpdateInstitutionRequest: { type: Function },
     sendRemoveInstitutionRequest: { type: Function },
-    sendAddJobRequest: { type: Function },
+    sendAddJobsRequest: { type: Function },
     sendUpdateJobRequest: { type: Function },
     sendRemoveJobRequest: { type: Function },
 })
@@ -74,7 +74,7 @@ function setJobToAddOrUpdate(aJob) {
  * @param {Object} anInstitution The institution to add
  */
 async function addInstitution(anInstitution) {
-    const response = await props.sendAddInstitutionRequest(anInstitution)
+    const response = await props.sendAddInstitutionsRequest(anInstitution)
 
     if (response.status === StatusCodes.CREATED) {
         actionResultAlert.value = {
@@ -99,7 +99,7 @@ async function addInstitution(anInstitution) {
  * @param {Object} aJob A job with its sets represented as a CSV string
  */
 async function addJob(aJob) {
-    const response = await props.sendAddJobRequest(jobWithDeserializedSets(aJob))
+    const response = await props.sendAddJobsRequest(jobWithDeserializedSets(aJob))
 
     if (response.status === StatusCodes.CREATED) {
         actionResultAlert.value = {

--- a/src/main/java/edu/ucla/library/prl/harvester/Institution.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/Institution.java
@@ -352,4 +352,43 @@ public final class Institution {
     public static Institution withID(final Institution anInstitution, final Integer anInstitutionID) {
         return new Institution(anInstitution.toJson().put(ID, anInstitutionID));
     }
+
+    @Override
+    @SuppressWarnings("PMD.CyclomaticComplexity")
+    public boolean equals(final Object anOther) {
+        if (anOther instanceof Institution) {
+            final Institution other = (Institution) anOther;
+
+            if (getID().equals(other.getID()) && getName().equals(other.getName()) &&
+                    getDescription().equals(other.getDescription()) && getLocation().equals(other.getLocation()) &&
+                    getEmail().equals(other.getEmail()) && getPhone().equals(other.getPhone()) &&
+                    getWebContact().equals(other.getWebContact()) && getWebsite().equals(other.getWebsite())) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+
+        result = prime * result + myID.map(id -> id.hashCode()).orElse(0);
+        result = prime * result + myName.hashCode();
+        result = prime * result + myDescription.hashCode();
+        result = prime * result + myLocation.hashCode();
+        result = prime * result + myEmail.map(email -> email.hashCode()).orElse(0);
+        result = prime * result + myPhone.map(phone -> phone.hashCode()).orElse(0);
+        result = prime * result + myWebContact.map(webContact -> webContact.hashCode()).orElse(0);
+        result = prime * result + myWebsite.hashCode();
+
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return toJson().encode();
+    }
 }

--- a/src/main/java/edu/ucla/library/prl/harvester/Job.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/Job.java
@@ -258,4 +258,41 @@ public final class Job {
     public static Job withID(final Job aJob, final Integer aJobID) {
         return new Job(aJob.toJson().put(ID, aJobID));
     }
+
+    @Override
+    public boolean equals(final Object anOther) {
+        if (anOther instanceof Job) {
+            final Job other = (Job) anOther;
+            if (getID().equals(other.getID()) && getInstitutionID() == other.getInstitutionID() &&
+                    getRepositoryBaseURL().equals(other.getRepositoryBaseURL()) &&
+                    getMetadataPrefix().equals(other.getMetadataPrefix()) && getSets().equals(other.getSets()) &&
+                    getScheduleCronExpression().getCronExpression()
+                            .equals(other.getScheduleCronExpression().getCronExpression()) &&
+                    getLastSuccessfulRun().equals(other.getLastSuccessfulRun())) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+
+        result = prime * result + myID.map(id -> id.hashCode()).orElse(0);
+        result = prime * result + myInstitutionID;
+        result = prime * result + myRepositoryBaseURL.hashCode();
+        result = prime * result + mySets.map(sets -> sets.hashCode()).orElse(0);
+        result = prime * result + myScheduleCronExpression.getCronExpression().hashCode();
+        result = prime * result + myLastSuccessfulRun.map(timestamp -> timestamp.hashCode()).orElse(0);
+
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return toJson().encode();
+    }
 }

--- a/src/main/java/edu/ucla/library/prl/harvester/JobResult.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/JobResult.java
@@ -133,4 +133,35 @@ public class JobResult {
     public int getRecordCount() {
         return myRecordCount;
     }
+
+    @Override
+    public boolean equals(final Object anOther) {
+        if (anOther instanceof JobResult) {
+            final JobResult other = (JobResult) anOther;
+
+            if (getJobID() == other.getJobID() && getStartTime().equals(other.getStartTime()) &&
+                    getRecordCount() == other.getRecordCount()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+
+        result = prime * result + myJobID;
+        result = prime * result + myStartTime.hashCode();
+        result = prime * result + myRecordCount;
+
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return toJson().encode();
+    }
 }

--- a/src/main/java/edu/ucla/library/prl/harvester/Op.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/Op.java
@@ -24,10 +24,10 @@ public enum Op {
     /**
      * Institution operations.
      */
-    addInstitution, getInstitution, listInstitutions, removeInstitution, updateInstitution,
+    addInstitutions, getInstitution, listInstitutions, removeInstitution, updateInstitution,
 
     /**
      * Job operations.
      */
-    addJob, getJob, listJobs, removeJob, updateJob
+    addJobs, getJob, listJobs, removeJob, updateJob
 }

--- a/src/main/java/edu/ucla/library/prl/harvester/handlers/AddInstitutionHandler.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/handlers/AddInstitutionHandler.java
@@ -1,7 +1,10 @@
 
 package edu.ucla.library.prl.harvester.handlers;
 
+import java.util.List;
 import java.util.concurrent.CompletionStage;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.http.HttpStatus;
 import org.apache.solr.client.solrj.response.UpdateResponse;
@@ -12,10 +15,12 @@ import edu.ucla.library.prl.harvester.MediaType;
 
 import io.ino.solrs.JavaAsyncSolrClient;
 
+import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.sqlclient.Tuple;
@@ -36,50 +41,63 @@ public final class AddInstitutionHandler extends AbstractSolrAwareWriteOperation
     @Override
     public void handle(final RoutingContext aContext) {
         final HttpServerResponse response = aContext.response();
+        final Stream<Future<Institution>> semanticValidations =
+                aContext.body().asJsonArray().stream().map(this::validateJob);
 
-        try {
-            final JsonObject institutionJSON = aContext.body().asJsonObject();
-            final Institution institution = new Institution(institutionJSON);
+        CompositeFuture.all(semanticValidations.collect(Collectors.toList())).onSuccess(result -> {
+            final List<Institution> institutions = result.list();
 
-            myHarvestScheduleStoreService.addInstitution(institution).compose(institutionID -> {
-                return updateSolr(Tuple.of(institutionID, institutionJSON)).map(institutionID);
-            }).onSuccess(institutionID -> {
-                final JsonObject responseBody = Institution.withID(institution, institutionID).toJson();
+            myHarvestScheduleStoreService.addInstitutions(institutions).compose(institutionsWithIDs -> {
+                return updateSolr(Tuple.of(institutionsWithIDs)).map(institutionsWithIDs);
+            }).onSuccess(institutionsWithIDs -> {
+                final JsonArray responseBody =
+                        new JsonArray(institutionsWithIDs.stream().map(Institution::toJson).toList());
 
                 response.setStatusCode(HttpStatus.SC_CREATED)
                         .putHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON.toString())
                         .end(responseBody.encode());
             }).onFailure(aContext::fail);
-        } catch (final InvalidInstitutionJsonException details) {
+        }).onFailure(details -> {
             response.setStatusCode(HttpStatus.SC_BAD_REQUEST).end(details.getMessage());
-        }
+        });
     }
 
     /**
-     * Adds an institution doc to Solr.
+     * Adds institution docs to Solr.
      *
-     * @param aData A Tuple of the ID of the institution to update, and its JSON representation
+     * @param aData A 1-tuple of the list of institutions (each bearing a unique local ID) to update
      */
     @Override
+    @SuppressWarnings("unchecked")
     Future<UpdateResponse> updateSolr(final Tuple aData) {
-        final Institution institution =
-                Institution.withID(new Institution(aData.getJsonObject(1)), aData.getInteger(0));
-
-        return updateInstitutionDoc(mySolrClient, institution);
+        return updateInstitutionDoc(mySolrClient, (List<Institution>) aData.get(List.class, 0));
     }
 
     /**
-     * Adds or updates an institution doc in Solr.
+     * Adds or updates institution docs in Solr.
      *
      * @param aSolrClient A Solr client
-     * @param anInstitution The institution
+     * @param anInstitutions The list of institutions
      * @return The result of performing the Solr update
      */
     static Future<UpdateResponse> updateInstitutionDoc(final JavaAsyncSolrClient aSolrClient,
-            final Institution anInstitution) {
+            final List<Institution> anInstitutions) {
         final CompletionStage<UpdateResponse> addInstitution =
-                aSolrClient.addDoc(anInstitution.toSolrDoc()).thenCompose(result -> aSolrClient.commit());
+                aSolrClient.addDocs(anInstitutions.stream().map(Institution::toSolrDoc).toList())
+                        .thenCompose(result -> aSolrClient.commit());
 
         return Future.fromCompletionStage(addInstitution);
+    }
+
+    /**
+     * @param anInstitution An entry in the request body array
+     * @return A Future that succeeds if the entry is a valid {@link Institution}
+     */
+    private Future<Institution> validateJob(final Object anInstitution) {
+        try {
+            return Future.succeededFuture(new Institution(JsonObject.mapFrom(anInstitution)));
+        } catch (final IllegalArgumentException | InvalidInstitutionJsonException details) {
+            return Future.failedFuture(details);
+        }
     }
 }

--- a/src/main/java/edu/ucla/library/prl/harvester/handlers/AddInstitutionsHandler.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/handlers/AddInstitutionsHandler.java
@@ -28,13 +28,13 @@ import io.vertx.sqlclient.Tuple;
 /**
  * A handler for adding institutions.
  */
-public final class AddInstitutionHandler extends AbstractSolrAwareWriteOperationHandler {
+public final class AddInstitutionsHandler extends AbstractSolrAwareWriteOperationHandler {
 
     /**
      * @param aVertx A Vert.x instance
      * @param aConfig A configuration
      */
-    public AddInstitutionHandler(final Vertx aVertx, final JsonObject aConfig) {
+    public AddInstitutionsHandler(final Vertx aVertx, final JsonObject aConfig) {
         super(aVertx, aConfig);
     }
 

--- a/src/main/java/edu/ucla/library/prl/harvester/handlers/AddInstitutionsHandler.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/handlers/AddInstitutionsHandler.java
@@ -42,7 +42,7 @@ public final class AddInstitutionsHandler extends AbstractSolrAwareWriteOperatio
     public void handle(final RoutingContext aContext) {
         final HttpServerResponse response = aContext.response();
         final Stream<Future<Institution>> semanticValidations =
-                aContext.body().asJsonArray().stream().map(this::validateJob);
+                aContext.body().asJsonArray().stream().map(AddInstitutionsHandler::validateJob);
 
         CompositeFuture.all(semanticValidations.collect(Collectors.toList())).onSuccess(result -> {
             final List<Institution> institutions = result.list();
@@ -93,7 +93,7 @@ public final class AddInstitutionsHandler extends AbstractSolrAwareWriteOperatio
      * @param anInstitution An entry in the request body array
      * @return A Future that succeeds if the entry is a valid {@link Institution}
      */
-    private Future<Institution> validateJob(final Object anInstitution) {
+    private static Future<Institution> validateJob(final Object anInstitution) {
         try {
             return Future.succeededFuture(new Institution(JsonObject.mapFrom(anInstitution)));
         } catch (final IllegalArgumentException | InvalidInstitutionJsonException details) {

--- a/src/main/java/edu/ucla/library/prl/harvester/handlers/AddJobHandler.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/handlers/AddJobHandler.java
@@ -2,6 +2,8 @@
 package edu.ucla.library.prl.harvester.handlers;
 
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.http.HttpStatus;
 
@@ -10,10 +12,12 @@ import edu.ucla.library.prl.harvester.InvalidJobJsonException;
 import edu.ucla.library.prl.harvester.MediaType;
 import edu.ucla.library.prl.harvester.OaipmhUtils;
 
+import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.RoutingContext;
 
@@ -32,27 +36,44 @@ public final class AddJobHandler extends AbstractRequestHandler {
     @Override
     public void handle(final RoutingContext aContext) {
         final HttpServerResponse response = aContext.response();
+        final Stream<Future<Job>> semanticValidations =
+                aContext.body().asJsonArray().stream().map(this::validateInstitution);
+
+        CompositeFuture.all(semanticValidations.collect(Collectors.toList())).onSuccess(result -> {
+            final List<Job> jobs = result.list();
+
+            myHarvestScheduleStoreService.addJobs(jobs).compose(jobsWithIDs -> {
+                return myHarvestJobSchedulerService.addJobs(jobsWithIDs).map(jobsWithIDs);
+            }).onSuccess(jobsWithIDs -> {
+                final JsonArray responseBody = new JsonArray(jobsWithIDs.stream().map(Job::toJson).toList());
+
+                response.setStatusCode(HttpStatus.SC_CREATED)
+                        .putHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON.toString())
+                        .end(responseBody.encode());
+            }).onFailure(aContext::fail);
+        }).onFailure(details -> {
+            response.setStatusCode(HttpStatus.SC_BAD_REQUEST).end(details.getMessage());
+        });
+    }
+
+    /**
+     * @param aJob An entry in the request body array
+     * @return A Future that succeeds if the entry is a valid {@link Job}
+     */
+    private Future<Job> validateInstitution(final Object aJob) {
+        Future<Job> deserializationResult;
 
         try {
-            final Job job = new Job(aContext.body().asJsonObject());
-            final Future<Void> validateOaipmhIdentifiers = OaipmhUtils.validateIdentifiers(myVertx,
+            deserializationResult = Future.succeededFuture(new Job(JsonObject.mapFrom(aJob)));
+        } catch (final IllegalArgumentException | InvalidJobJsonException details) {
+            deserializationResult = Future.failedFuture(details);
+        }
+
+        return deserializationResult.compose(job -> {
+            final Future<Void> oaipmhIdentifierValidationResult = OaipmhUtils.validateIdentifiers(myVertx,
                     job.getRepositoryBaseURL(), job.getSets().orElse(List.of()));
 
-            validateOaipmhIdentifiers.onSuccess(nil -> {
-                myHarvestScheduleStoreService.addJob(job).compose(jobID -> {
-                    return myHarvestJobSchedulerService.addJob(jobID, job).map(jobID);
-                }).onSuccess(jobID -> {
-                    final JsonObject responseBody = Job.withID(job, jobID).toJson();
-
-                    response.setStatusCode(HttpStatus.SC_CREATED)
-                            .putHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON.toString())
-                            .end(responseBody.encode());
-                }).onFailure(aContext::fail);
-            }).onFailure(details -> {
-                response.setStatusCode(HttpStatus.SC_BAD_REQUEST).end(details.getMessage());
-            });
-        } catch (final InvalidJobJsonException details) {
-            response.setStatusCode(HttpStatus.SC_BAD_REQUEST).end(details.getMessage());
-        }
+            return oaipmhIdentifierValidationResult.map(job);
+        });
     }
 }

--- a/src/main/java/edu/ucla/library/prl/harvester/handlers/AddJobsHandler.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/handlers/AddJobsHandler.java
@@ -24,12 +24,12 @@ import io.vertx.ext.web.RoutingContext;
 /**
  * A handler for adding jobs.
  */
-public final class AddJobHandler extends AbstractRequestHandler {
+public final class AddJobsHandler extends AbstractRequestHandler {
 
     /**
      * @param aVertx A Vert.x instance
      */
-    public AddJobHandler(final Vertx aVertx) {
+    public AddJobsHandler(final Vertx aVertx) {
         super(aVertx);
     }
 

--- a/src/main/java/edu/ucla/library/prl/harvester/handlers/RemoveInstitutionHandler.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/handlers/RemoveInstitutionHandler.java
@@ -76,7 +76,7 @@ public final class RemoveInstitutionHandler extends AbstractSolrAwareWriteOperat
      * Removes the institution doc, and all item record docs that were harvested by jobs associated with the
      * institution.
      *
-     * @param aData A Tuple of the institution as JSON
+     * @param aData A 1-tuple of the institution as JSON
      */
     @Override
     Future<UpdateResponse> updateSolr(final Tuple aData) {

--- a/src/main/java/edu/ucla/library/prl/harvester/handlers/RemoveJobHandler.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/handlers/RemoveJobHandler.java
@@ -64,7 +64,7 @@ public final class RemoveJobHandler extends AbstractSolrAwareWriteOperationHandl
     /**
      * Removes all item records that were harvested by the job.
      *
-     * @param aData A Tuple of the ID of the job to remove, and its JSON representation
+     * @param aData A 2-tuple of the ID of the job to remove, and its JSON representation
      */
     @Override
     Future<UpdateResponse> updateSolr(final Tuple aData) {

--- a/src/main/java/edu/ucla/library/prl/harvester/handlers/ServiceExceptionHandler.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/handlers/ServiceExceptionHandler.java
@@ -34,6 +34,7 @@ public final class ServiceExceptionHandler implements ErrorHandler {
             final HarvestScheduleStoreServiceException serviceException = (HarvestScheduleStoreServiceException) error;
 
             statusCode = switch (Error.values()[serviceException.failureCode()]) {
+                case BAD_REQUEST -> HttpStatus.SC_BAD_REQUEST;
                 case NOT_FOUND -> HttpStatus.SC_NOT_FOUND;
                 case INTERNAL_ERROR -> HttpStatus.SC_INTERNAL_SERVER_ERROR;
             };

--- a/src/main/java/edu/ucla/library/prl/harvester/handlers/UpdateInstitutionHandler.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/handlers/UpdateInstitutionHandler.java
@@ -1,6 +1,8 @@
 
 package edu.ucla.library.prl.harvester.handlers;
 
+import java.util.List;
+
 import org.apache.http.HttpStatus;
 import org.apache.solr.client.solrj.response.UpdateResponse;
 
@@ -56,13 +58,13 @@ public final class UpdateInstitutionHandler extends AbstractSolrAwareWriteOperat
     /**
      * Updates the institution doc in Solr.
      *
-     * @param aData A Tuple of the ID of the institution to update, and its JSON representation
+     * @param aData A 2-tuple of the ID of the institution to update, and its JSON representation
      */
     @Override
     Future<UpdateResponse> updateSolr(final Tuple aData) {
         final Institution institution =
                 Institution.withID(new Institution(aData.getJsonObject(1)), aData.getInteger(0));
 
-        return AddInstitutionHandler.updateInstitutionDoc(mySolrClient, institution);
+        return AddInstitutionHandler.updateInstitutionDoc(mySolrClient, List.of(institution));
     }
 }

--- a/src/main/java/edu/ucla/library/prl/harvester/handlers/UpdateInstitutionHandler.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/handlers/UpdateInstitutionHandler.java
@@ -65,6 +65,6 @@ public final class UpdateInstitutionHandler extends AbstractSolrAwareWriteOperat
         final Institution institution =
                 Institution.withID(new Institution(aData.getJsonObject(1)), aData.getInteger(0));
 
-        return AddInstitutionHandler.updateInstitutionDoc(mySolrClient, List.of(institution));
+        return AddInstitutionsHandler.updateInstitutionDoc(mySolrClient, List.of(institution));
     }
 }

--- a/src/main/java/edu/ucla/library/prl/harvester/handlers/UpdateJobHandler.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/handlers/UpdateJobHandler.java
@@ -74,8 +74,8 @@ public final class UpdateJobHandler extends AbstractSolrAwareWriteOperationHandl
     /**
      * Removes all item records that belong to the sets removed from the job (if any).
      *
-     * @param aData A Tuple of the old JSON representation of the job, its new JSON representation, and the institution
-     *        name
+     * @param aData A 3-tuple of the old JSON representation of the job, its new JSON representation, and the
+     *        institution name
      */
     @Override
     Future<UpdateResponse> updateSolr(final Tuple aData) {

--- a/src/main/java/edu/ucla/library/prl/harvester/services/HarvestJobSchedulerService.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/services/HarvestJobSchedulerService.java
@@ -1,6 +1,8 @@
 
 package edu.ucla.library.prl.harvester.services;
 
+import java.util.List;
+
 import org.quartz.SchedulerException;
 
 import edu.ucla.library.prl.harvester.Job;
@@ -69,13 +71,12 @@ public interface HarvestJobSchedulerService {
     }
 
     /**
-     * Adds a harvest job.
+     * Adds a list of harvest jobs.
      *
-     * @param aJobId The unique local ID for the harvest job
-     * @param aJob The harvest job to add
-     * @return A Future that succeeds if the harvest job was added
+     * @param aJobs The list of harvest jobs to add, each bearing a unique local ID assigned by the database
+     * @return A Future that succeeds if all the harvest jobs were added
      */
-    Future<Void> addJob(int aJobId, Job aJob);
+    Future<Void> addJobs(List<Job> aJobs);
 
     /**
      * Updates a harvest job.

--- a/src/main/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreService.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreService.java
@@ -71,12 +71,12 @@ public interface HarvestScheduleStoreService {
     Future<List<Institution>> listInstitutions();
 
     /**
-     * Adds an institution.
+     * Adds a list of institutions.
      *
-     * @param anInstitution The institution to add
-     * @return A Future that succeeds, with a unique local ID for the institution, if it was added
+     * @param anInstitutions The list of institutions to add
+     * @return A Future that succeeds, with a list of institutions bearing unique local IDs, if all were added
      */
-    Future<Integer> addInstitution(Institution anInstitution);
+    Future<List<Institution>> addInstitutions(List<Institution> anInstitutions);
 
     /**
      * Updates an institution.
@@ -112,12 +112,12 @@ public interface HarvestScheduleStoreService {
     Future<List<Job>> listJobs();
 
     /**
-     * Adds a harvest job.
+     * Adds a list of harvest jobs.
      *
-     * @param aJob The harvest job to add
-     * @return A Future that succeeds, with a unique local ID for the harvest job, if it was added
+     * @param aJobs The list of harvest jobs to add
+     * @return A Future that succeeds, with a list of harvest jobs bearing unique local IDs, if all were added
      */
-    Future<Integer> addJob(Job aJob);
+    Future<List<Job>> addJobs(List<Job> aJobs);
 
     /**
      * Updates a harvest job.

--- a/src/main/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreService.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreService.java
@@ -169,6 +169,11 @@ public interface HarvestScheduleStoreService {
     enum Error {
 
         /**
+         * Indicates that there was a problem with the provided query parameters.
+         */
+        BAD_REQUEST,
+
+        /**
          * Indicates that the requested item was not found in the store.
          */
         NOT_FOUND,

--- a/src/main/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreServiceImpl.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreServiceImpl.java
@@ -235,6 +235,12 @@ public class HarvestScheduleStoreServiceImpl implements HarvestScheduleStoreServ
 
     @Override
     public Future<List<Institution>> addInstitutions(final List<Institution> anInstitutions) {
+        if (anInstitutions.isEmpty()) {
+            final String errorMsg = LOGGER.getMessage(MessageCodes.PRL_046);
+
+            return Future.failedFuture(new HarvestScheduleStoreServiceException(Error.BAD_REQUEST, errorMsg));
+        }
+
         return myDbConnectionPool.withConnection(connection -> {
             return SqlTemplate.forQuery(connection, ADD_INSTS).mapFrom(INST_TO_TUPLE).mapTo(INST_FROM_ROW)
                     .executeBatch(anInstitutions);
@@ -308,6 +314,12 @@ public class HarvestScheduleStoreServiceImpl implements HarvestScheduleStoreServ
 
     @Override
     public Future<List<Job>> addJobs(final List<Job> aJobs) {
+        if (aJobs.isEmpty()) {
+            final String errorMsg = LOGGER.getMessage(MessageCodes.PRL_046);
+
+            return Future.failedFuture(new HarvestScheduleStoreServiceException(Error.BAD_REQUEST, errorMsg));
+        }
+
         return myDbConnectionPool.withConnection(connection -> {
             return SqlTemplate.forQuery(connection, ADD_JOBS).mapFrom(JOB_TO_TUPLE).mapTo(JOB_FROM_ROW)
                     .executeBatch(aJobs);

--- a/src/main/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreServiceImpl.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreServiceImpl.java
@@ -226,7 +226,7 @@ public class HarvestScheduleStoreServiceImpl implements HarvestScheduleStoreServ
     @Override
     public Future<List<Institution>> listInstitutions() {
         return myDbConnectionPool.withConnection(connection -> {
-            return SqlTemplate.forQuery(connection, LIST_INSTS).mapTo(INST_FROM_ROW).execute(null);
+            return SqlTemplate.forQuery(connection, LIST_INSTS).mapTo(INST_FROM_ROW).execute(Map.of());
         }).recover(error -> {
             return Future
                     .failedFuture(new HarvestScheduleStoreServiceException(Error.INTERNAL_ERROR, error.getMessage()));
@@ -299,7 +299,7 @@ public class HarvestScheduleStoreServiceImpl implements HarvestScheduleStoreServ
     @Override
     public Future<List<Job>> listJobs() {
         return myDbConnectionPool.withConnection(connection -> {
-            return SqlTemplate.forQuery(connection, LIST_JOBS).mapTo(JOB_FROM_ROW).execute(null);
+            return SqlTemplate.forQuery(connection, LIST_JOBS).mapTo(JOB_FROM_ROW).execute(Map.of());
         }).recover(error -> {
             return Future
                     .failedFuture(new HarvestScheduleStoreServiceException(Error.INTERNAL_ERROR, error.getMessage()));

--- a/src/main/java/edu/ucla/library/prl/harvester/services/HarvestServiceUtils.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/services/HarvestServiceUtils.java
@@ -109,6 +109,7 @@ final class HarvestServiceUtils {
         final List<String> setNames = new LinkedList<>();
 
         final String recordIdentifier = aRecord.getHeader().getIdentifier();
+        // PRL requires data providers to define sets in order to participate, so at least one setSpec must be present
         final List<String> setSpecs = aRecord.getHeader().getSetSpecs();
 
         // Get an iterator over the elements inside the top-level "dc" element

--- a/src/main/java/edu/ucla/library/prl/harvester/verticles/MainVerticle.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/verticles/MainVerticle.java
@@ -15,8 +15,8 @@ import edu.ucla.library.prl.harvester.Config;
 import edu.ucla.library.prl.harvester.MessageCodes;
 import edu.ucla.library.prl.harvester.Op;
 import edu.ucla.library.prl.harvester.Paths;
-import edu.ucla.library.prl.harvester.handlers.AddInstitutionHandler;
-import edu.ucla.library.prl.harvester.handlers.AddJobHandler;
+import edu.ucla.library.prl.harvester.handlers.AddInstitutionsHandler;
+import edu.ucla.library.prl.harvester.handlers.AddJobsHandler;
 import edu.ucla.library.prl.harvester.handlers.AuthHandler;
 import edu.ucla.library.prl.harvester.handlers.GetInstitutionHandler;
 import edu.ucla.library.prl.harvester.handlers.GetJobHandler;
@@ -147,14 +147,14 @@ public class MainVerticle extends AbstractVerticle {
             routeBuilder.operation(Op.getStatus.name()).handler(new StatusHandler());
 
             // Institution operations
-            routeBuilder.operation(Op.addInstitutions.name()).handler(new AddInstitutionHandler(vertx, aConfig));
+            routeBuilder.operation(Op.addInstitutions.name()).handler(new AddInstitutionsHandler(vertx, aConfig));
             routeBuilder.operation(Op.getInstitution.name()).handler(new GetInstitutionHandler(vertx));
             routeBuilder.operation(Op.listInstitutions.name()).handler(new ListInstitutionsHandler(vertx));
             routeBuilder.operation(Op.removeInstitution.name()).handler(new RemoveInstitutionHandler(vertx, aConfig));
             routeBuilder.operation(Op.updateInstitution.name()).handler(new UpdateInstitutionHandler(vertx, aConfig));
 
             // Job operations
-            routeBuilder.operation(Op.addJobs.name()).handler(new AddJobHandler(vertx));
+            routeBuilder.operation(Op.addJobs.name()).handler(new AddJobsHandler(vertx));
             routeBuilder.operation(Op.getJob.name()).handler(new GetJobHandler(vertx));
             routeBuilder.operation(Op.listJobs.name()).handler(new ListJobsHandler(vertx));
             routeBuilder.operation(Op.removeJob.name()).handler(new RemoveJobHandler(vertx, aConfig));

--- a/src/main/java/edu/ucla/library/prl/harvester/verticles/MainVerticle.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/verticles/MainVerticle.java
@@ -147,14 +147,14 @@ public class MainVerticle extends AbstractVerticle {
             routeBuilder.operation(Op.getStatus.name()).handler(new StatusHandler());
 
             // Institution operations
-            routeBuilder.operation(Op.addInstitution.name()).handler(new AddInstitutionHandler(vertx, aConfig));
+            routeBuilder.operation(Op.addInstitutions.name()).handler(new AddInstitutionHandler(vertx, aConfig));
             routeBuilder.operation(Op.getInstitution.name()).handler(new GetInstitutionHandler(vertx));
             routeBuilder.operation(Op.listInstitutions.name()).handler(new ListInstitutionsHandler(vertx));
             routeBuilder.operation(Op.removeInstitution.name()).handler(new RemoveInstitutionHandler(vertx, aConfig));
             routeBuilder.operation(Op.updateInstitution.name()).handler(new UpdateInstitutionHandler(vertx, aConfig));
 
             // Job operations
-            routeBuilder.operation(Op.addJob.name()).handler(new AddJobHandler(vertx));
+            routeBuilder.operation(Op.addJobs.name()).handler(new AddJobHandler(vertx));
             routeBuilder.operation(Op.getJob.name()).handler(new GetJobHandler(vertx));
             routeBuilder.operation(Op.listJobs.name()).handler(new ListJobsHandler(vertx));
             routeBuilder.operation(Op.removeJob.name()).handler(new RemoveJobHandler(vertx, aConfig));

--- a/src/main/resources/openapi.yaml
+++ b/src/main/resources/openapi.yaml
@@ -89,12 +89,28 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/Institution"
+    InstitutionList:
+      description: A list of institutions
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/Institution"
     Job:
       description: A job
       content:
         application/json:
           schema:
             $ref: "#/components/schemas/Job"
+    JobList:
+      description: A list of jobs
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/Job"
   requestBodies:
     Institution:
       description: An institution
@@ -102,12 +118,28 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/Institution"
+    InstitutionList:
+      description: A list of institutions
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/Institution"
     Job:
       description: A job
       content:
         application/json:
           schema:
             $ref: "#/components/schemas/Job"
+    JobList:
+      description: A list of jobs
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/Job"
 paths:
   /:
     get:
@@ -153,21 +185,15 @@ paths:
       operationId: listInstitutions
       responses:
         '200':
-          description: A list of all institutions
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/Institution"
+          $ref: "#/components/responses/InstitutionList"
     post:
-      description: The endpoint for adding a new institution
-      operationId: addInstitution
+      description: The endpoint for adding new institutions
+      operationId: addInstitutions
       requestBody:
-        $ref: "#/components/requestBodies/Institution"
+        $ref: "#/components/requestBodies/InstitutionList"
       responses:
         '201':
-          $ref: "#/components/responses/Institution"
+          $ref: "#/components/responses/InstitutionList"
   /institutions/{id}:
     parameters:
     - name: id
@@ -200,21 +226,15 @@ paths:
       operationId: listJobs
       responses:
         '200':
-          description: A list of all jobs
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/Job"
+          $ref: "#/components/responses/JobList"
     post:
-      description: The endpoint for adding a new job
-      operationId: addJob
+      description: The endpoint for adding new jobs
+      operationId: addJobs
       requestBody:
-        $ref: "#/components/requestBodies/Job"
+        $ref: "#/components/requestBodies/JobList"
       responses:
         '201':
-          $ref: "#/components/responses/Job"
+          $ref: "#/components/responses/JobList"
   /jobs/{id}:
     parameters:
     - name: id

--- a/src/main/resources/openapi.yaml
+++ b/src/main/resources/openapi.yaml
@@ -126,6 +126,7 @@ components:
             type: array
             items:
               $ref: "#/components/schemas/Institution"
+            minItems: 1
     Job:
       description: A job
       content:
@@ -140,6 +141,7 @@ components:
             type: array
             items:
               $ref: "#/components/schemas/Job"
+            minItems: 1
 paths:
   /:
     get:

--- a/src/main/resources/prl-harvester_messages.xml
+++ b/src/main/resources/prl-harvester_messages.xml
@@ -51,6 +51,7 @@
   <entry key="PRL_043">Failed to authorize test WebClient</entry>
   <entry key="PRL_044">{} instances {} and {} are not equal but have the same hash code</entry>
   <entry key="PRL_045">Operation succeeded, but it should have failed</entry>
+  <entry key="PRL_046">Must provide non-empty list</entry>
   <entry key="PRL_047">[Bad Request] Validation error for body application/json: provided array should have size &gt;= 1</entry>
 
 </properties>

--- a/src/main/resources/prl-harvester_messages.xml
+++ b/src/main/resources/prl-harvester_messages.xml
@@ -50,5 +50,7 @@
   <entry key="PRL_042">User successfully authorized: {}</entry>
   <entry key="PRL_043">Failed to authorize test WebClient</entry>
   <entry key="PRL_044">{} instances {} and {} are not equal but have the same hash code</entry>
+  <entry key="PRL_045">Operation succeeded, but it should have failed</entry>
+  <entry key="PRL_047">[Bad Request] Validation error for body application/json: provided array should have size &gt;= 1</entry>
 
 </properties>

--- a/src/main/resources/prl-harvester_messages.xml
+++ b/src/main/resources/prl-harvester_messages.xml
@@ -49,5 +49,6 @@
   <entry key="PRL_041">User is trying to login: {}</entry>
   <entry key="PRL_042">User successfully authorized: {}</entry>
   <entry key="PRL_043">Failed to authorize test WebClient</entry>
+  <entry key="PRL_044">{} instances {} and {} are not equal but have the same hash code</entry>
 
 </properties>

--- a/src/test/java/edu/ucla/library/prl/harvester/InstitutionRequestsFT.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/InstitutionRequestsFT.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.net.MalformedURLException;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.mail.internet.AddressException;
 
@@ -156,7 +157,7 @@ public class InstitutionRequestsFT extends AuthorizedFIT {
 
         addInstitutions.compose(addInstitutionsResponse -> {
             final Set<Institution> firstResponseInstitutions =
-                    TestUtils.institutionsFromJsonArray(addInstitutionsResponse.bodyAsJsonArray());
+                    institutionsFromJsonArray(addInstitutionsResponse.bodyAsJsonArray());
             final Future<HttpResponse<Buffer>> listInstitutions;
 
             aContext.verify(() -> {
@@ -191,7 +192,7 @@ public class InstitutionRequestsFT extends AuthorizedFIT {
 
             return listInstitutions.compose(listInstitutionsResponse -> {
                 final Set<Institution> secondResponseInstitutions =
-                        TestUtils.institutionsFromJsonArray(listInstitutionsResponse.bodyAsJsonArray());
+                        institutionsFromJsonArray(listInstitutionsResponse.bodyAsJsonArray());
 
                 aContext.verify(() -> {
                     assertEquals(HttpStatus.SC_OK, listInstitutionsResponse.statusCode());
@@ -727,5 +728,13 @@ public class InstitutionRequestsFT extends AuthorizedFIT {
                 return Future.succeededFuture();
             });
         }).onFailure(aContext::failNow);
+    }
+
+    /**
+     * @param anArray A JSON array
+     * @return The set of {@link Institution}s represented by the array
+     */
+    private static Set<Institution> institutionsFromJsonArray(final JsonArray anArray) {
+        return anArray.stream().map(entry -> new Institution(JsonObject.mapFrom(entry))).collect(Collectors.toSet());
     }
 }

--- a/src/test/java/edu/ucla/library/prl/harvester/InstitutionTest.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/InstitutionTest.java
@@ -90,6 +90,9 @@ public class InstitutionTest {
         assertEquals(institution.getPhone(), institutionFromJson.getPhone());
         assertEquals(institution.getWebContact(), institutionFromJson.getWebContact());
         assertEquals(institution.getWebsite(), institutionFromJson.getWebsite());
+
+        assertEquals(institution, institutionFromJson);
+        assertEquals(institution.hashCode(), institutionFromJson.hashCode());
     }
 
     /**
@@ -145,9 +148,20 @@ public class InstitutionTest {
                 new Institution(aName, aDescription, aLocation, anEmail, aPhone, aWebContact, aWebsite);
         final int institutionID = 1;
         final Institution institutionWithID = Institution.withID(institution, institutionID);
+        final Institution institutionFromJsonWithID =
+                new Institution(institution.toJson().put(Institution.ID, institutionID));
 
+        assertNotEquals(institution, institutionWithID);
         assertNotEquals(institution.toJson(), institutionWithID.toJson());
-        assertEquals(institution.toJson().put("id", institutionID), institutionWithID.toJson());
+
+        if (institution.hashCode() == institutionWithID.hashCode()) {
+            LOGGER.warn(MessageCodes.PRL_044, Job.class.getName(), institution, institutionWithID);
+        }
+
+        // Adding id makes them equal
+        assertEquals(institutionWithID, institutionFromJsonWithID);
+        assertEquals(institutionWithID.toJson(), institutionFromJsonWithID.toJson());
+        assertEquals(institutionWithID.hashCode(), institutionFromJsonWithID.hashCode());
     }
 
     /**

--- a/src/test/java/edu/ucla/library/prl/harvester/InstitutionTest.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/InstitutionTest.java
@@ -206,7 +206,7 @@ public class InstitutionTest {
             assertEquals(anErrorClass, error.getCause().getClass());
         }
 
-        LOGGER.debug(LOGGER.getMessage(MessageCodes.PRL_000, error));
+        LOGGER.debug(MessageCodes.PRL_000, error);
     }
 
     /**

--- a/src/test/java/edu/ucla/library/prl/harvester/JobRequestsFT.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/JobRequestsFT.java
@@ -11,6 +11,7 @@ import java.text.ParseException;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.mail.internet.AddressException;
 
@@ -192,7 +193,7 @@ public class JobRequestsFT extends AuthorizedFIT {
         addJobs = myWebClient.post(JOBS).sendJson(new JsonArray().add(job1.toJson()).add(job2.toJson()));
 
         addJobs.compose(addJobsResponse -> {
-            final Set<Job> firstResponseJobs = TestUtils.jobsFromJsonArray(addJobsResponse.bodyAsJsonArray());
+            final Set<Job> firstResponseJobs = jobsFromJsonArray(addJobsResponse.bodyAsJsonArray());
             final Future<HttpResponse<Buffer>> listJobs;
 
             aContext.verify(() -> {
@@ -217,7 +218,7 @@ public class JobRequestsFT extends AuthorizedFIT {
             listJobs = myWebClient.get(JOBS).expect(ResponsePredicate.JSON).send();
 
             return listJobs.compose(listJobsResponse -> {
-                final Set<Job> secondResponseJobs = TestUtils.jobsFromJsonArray(listJobsResponse.bodyAsJsonArray());
+                final Set<Job> secondResponseJobs = jobsFromJsonArray(listJobsResponse.bodyAsJsonArray());
 
                 aContext.verify(() -> {
                     assertEquals(HttpStatus.SC_OK, listJobsResponse.statusCode());
@@ -727,5 +728,13 @@ public class JobRequestsFT extends AuthorizedFIT {
                 });
             }).onFailure(aContext::failNow);
         }).onFailure(aContext::failNow);
+    }
+
+    /**
+     * @param anArray A JSON array
+     * @return The set of {@link Job}s represented by the array
+     */
+    private static Set<Job> jobsFromJsonArray(final JsonArray anArray) {
+        return anArray.stream().map(entry -> new Job(JsonObject.mapFrom(entry))).collect(Collectors.toSet());
     }
 }

--- a/src/test/java/edu/ucla/library/prl/harvester/JobResultTest.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/JobResultTest.java
@@ -82,7 +82,7 @@ public class JobResultTest {
             assertEquals(anErrorClass, error.getCause().getClass());
         }
 
-        LOGGER.debug(LOGGER.getMessage(MessageCodes.PRL_000, error));
+        LOGGER.debug(MessageCodes.PRL_000, error);
     }
 
     /**

--- a/src/test/java/edu/ucla/library/prl/harvester/JobResultTest.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/JobResultTest.java
@@ -55,6 +55,9 @@ public class JobResultTest {
         // If the objects are equal, then deserialization works
         assertEquals(jobResult.getStartTime(), jobResultFromJson.getStartTime());
         assertEquals(jobResult.getRecordCount(), jobResultFromJson.getRecordCount());
+
+        assertEquals(jobResult, jobResultFromJson);
+        assertEquals(jobResult.hashCode(), jobResultFromJson.hashCode());
     }
 
     /**

--- a/src/test/java/edu/ucla/library/prl/harvester/JobTest.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/JobTest.java
@@ -166,7 +166,7 @@ public class JobTest {
             assertEquals(anErrorClass, error.getCause().getClass());
         }
 
-        LOGGER.debug(LOGGER.getMessage(MessageCodes.PRL_000, error));
+        LOGGER.debug(MessageCodes.PRL_000, error);
     }
 
     /**

--- a/src/test/java/edu/ucla/library/prl/harvester/JobTest.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/JobTest.java
@@ -74,6 +74,9 @@ public class JobTest {
         assertEquals(job.getMetadataPrefix(), jobFromJson.getMetadataPrefix());
         assertEquals(job.getScheduleCronExpression().toString(), jobFromJson.getScheduleCronExpression().toString());
         assertEquals(job.getLastSuccessfulRun(), jobFromJson.getLastSuccessfulRun());
+
+        assertEquals(job, jobFromJson);
+        assertEquals(job.hashCode(), jobFromJson.hashCode());
     }
 
     /**
@@ -112,9 +115,19 @@ public class JobTest {
                 new Job(anInstitutionID, aRepositoryBaseURL, aSets, aScheduleCronExpression, aLastSuccessfulRun);
         final int jobID = 1;
         final Job jobWithID = Job.withID(job, jobID);
+        final Job jobFromJsonWithID = new Job(job.toJson().put(Job.ID, jobID));
 
+        assertNotEquals(job, jobWithID);
         assertNotEquals(job.toJson(), jobWithID.toJson());
-        assertEquals(job.toJson().put("id", jobID), jobWithID.toJson());
+
+        if (job.hashCode() == jobWithID.hashCode()) {
+            LOGGER.warn(MessageCodes.PRL_044, Job.class.getName(), job, jobWithID);
+        }
+
+        // Adding id makes them equal
+        assertEquals(jobWithID, jobFromJsonWithID);
+        assertEquals(jobWithID.toJson(), jobFromJsonWithID.toJson());
+        assertEquals(jobWithID.hashCode(), jobFromJsonWithID.hashCode());
     }
 
     /**

--- a/src/test/java/edu/ucla/library/prl/harvester/services/HarvestJobSchedulerServiceIT.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/services/HarvestJobSchedulerServiceIT.java
@@ -224,7 +224,7 @@ public class HarvestJobSchedulerServiceIT {
      */
     @Test
     @Timeout(value = 10, timeUnit = TimeUnit.SECONDS)
-    public void testAddJobAfterInstantiation(final Vertx aVertx, final VertxTestContext aContext) {
+    public void testAddJobsAfterInstantiation(final Vertx aVertx, final VertxTestContext aContext) {
         final Checkpoint serviceSavedAndDbInitialized = aContext.checkpoint();
 
         HarvestJobSchedulerService.create(aVertx, myConfig).compose(service -> {
@@ -274,8 +274,8 @@ public class HarvestJobSchedulerServiceIT {
                     return Future.failedFuture(details);
                 }
 
-                return myHarvestScheduleStoreServiceProxy.addJob(job).compose(jobID -> {
-                    return service.addJob(jobID, job);
+                return myHarvestScheduleStoreServiceProxy.addJobs(List.of(job)).compose(jobsWithIDs -> {
+                    return service.addJobs(jobsWithIDs);
                 });
             });
         }).onSuccess(initialJob -> {
@@ -426,7 +426,8 @@ public class HarvestJobSchedulerServiceIT {
             return Future.failedFuture(details);
         }
 
-        return myHarvestScheduleStoreServiceProxy.addInstitution(institution);
+        return myHarvestScheduleStoreServiceProxy.addInstitutions(List.of(institution))
+                .map(institutions -> institutions.get(0).getID().get());
     }
 
     /**
@@ -443,7 +444,7 @@ public class HarvestJobSchedulerServiceIT {
             return Future.failedFuture(details);
         }
 
-        return myHarvestScheduleStoreServiceProxy.addJob(job);
+        return myHarvestScheduleStoreServiceProxy.addJobs(List.of(job)).map(jobs -> jobs.get(0).getID().get());
     }
 
     /**

--- a/src/test/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreServiceIT.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreServiceIT.java
@@ -289,7 +289,7 @@ public class HarvestScheduleStoreServiceIT {
      * @param aContext A test context
      */
     @Test
-    public final void testListInstitution(final Vertx aVertx, final VertxTestContext aContext)
+    public final void testListInstitutions(final Vertx aVertx, final VertxTestContext aContext)
             throws AddressException, MalformedURLException, NumberParseException {
         myScheduleStoreProxy.listInstitutions().onSuccess(instList -> {
             aContext.verify(() -> {
@@ -404,13 +404,13 @@ public class HarvestScheduleStoreServiceIT {
     }
 
     /**
-     * Tests inserting job record in db.
+     * Tests inserting job records in db.
      *
      * @param aVertx A Vert.x instance
      * @param aContext A test context
      */
     @Test
-    public final void testAddJob(final Vertx aVertx, final VertxTestContext aContext)
+    public final void testAddJobs(final Vertx aVertx, final VertxTestContext aContext)
             throws AddressException, MalformedURLException, NumberParseException, ParseException {
         final Job toAdd = TestUtils.getRandomJob(myTestInstitutionIDs.get(0));
 

--- a/src/test/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreServiceIT.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreServiceIT.java
@@ -238,6 +238,23 @@ public class HarvestScheduleStoreServiceIT {
     }
 
     /**
+     * Tests that an empty list is dealt with appropriately. FIXME
+     *
+     * @param aVertx A Vert.x instance
+     * @param aContext A test context
+     */
+    @Test
+    public final void testAddInstitutionsEmptyList(final Vertx aVertx, final VertxTestContext aContext) {
+        myScheduleStoreProxy.addInstitutions(List.of()).onFailure(details -> {
+            aContext.verify(() -> {
+                assertTrue(details instanceof ServiceException);
+                assertEquals(HarvestScheduleStoreService.Error.BAD_REQUEST.ordinal(),
+                        ((ServiceException) details).failureCode());
+            }).completeNow();
+        }).onSuccess(result -> aContext.failNow(LOGGER.getMessage(MessageCodes.PRL_045)));
+    }
+
+    /**
      * Tests getting institution by ID from db.
      *
      * @param aVertx A Vert.x instance
@@ -419,6 +436,23 @@ public class HarvestScheduleStoreServiceIT {
                 assertTrue(id >= 1);
             }).completeNow();
         }).onFailure(aContext::failNow);
+    }
+
+    /**
+     * Tests that an empty list is dealt with appropriately. FIXME
+     *
+     * @param aVertx A Vert.x instance
+     * @param aContext A test context
+     */
+    @Test
+    public final void testAddJobsEmptyList(final Vertx aVertx, final VertxTestContext aContext) {
+        myScheduleStoreProxy.addJobs(List.of()).onFailure(details -> {
+            aContext.verify(() -> {
+                assertTrue(details instanceof ServiceException);
+                assertEquals(HarvestScheduleStoreService.Error.BAD_REQUEST.ordinal(),
+                        ((ServiceException) details).failureCode());
+            }).completeNow();
+        }).onSuccess(result -> aContext.failNow(LOGGER.getMessage(MessageCodes.PRL_045)));
     }
 
     /**

--- a/src/test/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreServiceIT.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreServiceIT.java
@@ -295,8 +295,6 @@ public class HarvestScheduleStoreServiceIT {
             aContext.verify(() -> {
                 assertTrue(instList != null);
                 assertTrue(instList.size() >= 3);
-                assertTrue(instList.get(0).getName().equals(SAMPLE_NAME));
-                assertTrue(instList.get(0).getID().isPresent());
             }).completeNow();
         }).onFailure(aContext::failNow);
     }
@@ -436,8 +434,6 @@ public class HarvestScheduleStoreServiceIT {
             aContext.verify(() -> {
                 assertTrue(jobList != null);
                 assertTrue(jobList.size() >= 3);
-                assertTrue(jobList.get(0).getScheduleCronExpression().toString().equals(SAMPLE_CRON));
-                assertTrue(jobList.get(0).getID().isPresent());
             }).completeNow();
         }).onFailure(aContext::failNow);
     }

--- a/src/test/java/edu/ucla/library/prl/harvester/services/HarvestServiceIT.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/services/HarvestServiceIT.java
@@ -106,11 +106,12 @@ public class HarvestServiceIT {
                 return Future.failedFuture(details);
             }
 
-            return myHarvestScheduleStoreServiceProxy.addInstitution(testInstitution).compose(institutionID -> {
-                myTestInstitutionID = institutionID;
+            return myHarvestScheduleStoreServiceProxy.addInstitutions(List.of(testInstitution))
+                    .compose(institutions -> {
+                        myTestInstitutionID = TestUtils.unwrapInstitutionID(institutions.get(0));
 
-                return Future.succeededFuture();
-            });
+                        return Future.succeededFuture();
+                    });
         }).onSuccess(nil -> aContext.completeNow()).onFailure(aContext::failNow);
     }
 

--- a/src/test/java/edu/ucla/library/prl/harvester/utils/TestUtils.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/utils/TestUtils.java
@@ -18,7 +18,6 @@ import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import javax.mail.internet.AddressException;
@@ -54,7 +53,6 @@ import edu.ucla.library.prl.harvester.Param;
 import io.ino.solrs.JavaAsyncSolrClient;
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
-import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.client.WebClient;
 import io.vertx.ext.web.client.predicate.ResponsePredicate;
@@ -420,22 +418,6 @@ public final class TestUtils {
         }
 
         return true;
-    }
-
-    /**
-     * @param anArray A JSON array
-     * @return The set of {@link Institution}s represented by the array
-     */
-    public static Set<Institution> institutionsFromJsonArray(final JsonArray anArray) {
-        return anArray.stream().map(entry -> new Institution(JsonObject.mapFrom(entry))).collect(Collectors.toSet());
-    }
-
-    /**
-     * @param anArray A JSON array
-     * @return The set of {@link Job}s represented by the array
-     */
-    public static Set<Job> jobsFromJsonArray(final JsonArray anArray) {
-        return anArray.stream().map(entry -> new Job(JsonObject.mapFrom(entry))).collect(Collectors.toSet());
     }
 
     /**


### PR DESCRIPTION
Since c840f4a56ef30b259aa2ddc8ac1e2daf455b660e renames files, I'd say the clearest picture of the changes can be seen with:

```bash
git diff ad56..0603
```

Summary:
- AddInstitution and AddJob pluralized throughout codebase; some methods now take a List instead of a single object, and handle that change as appropriate in their implementations
- When rewriting the tests, I realized they would be more concise if Institution and Job could be directly compared for equality, rather than comparing their JSON representations (even though equality in either sense implies equality in both)

d0427f2814ef53d7e1a08f8fbc5115a426a8f1a5 and 88c1239fb4898e6921c1ffed84e6223dccb2a95a are unrelated / just polish.