### PR TITLE
[SERV-797] Send configurable User-Agent HTTP header on outgoing requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,17 +22,17 @@ DB_RECONNECT_INTERVAL|The length of the database reconnect interval (in millisec
 HARVEST_TIMEOUT|The max amount of time that a harvest may take to complete (in milliseconds)|No|30000
 HARVESTER_USER_AGENT|The User-Agent HTTP request header to use for outgoing requests|No|PRL Harvester
 HTTP_PORT|The application's port|No|8888
+LDAP_ATTRIBUTE_KEY|The LDAP attribute key used to authorize user|Yes|
+LDAP_ATTRIBUTE_VALUE|The LDAP attribute value used to authorize user|Yes|
+LDAP_AUTH_QUERY|The LDAP query to authenticate user|Yes|
+LDAP_USER_QUERY|The LDAP query to retrieve user info|Yes|
+LDAP_URL|The LDAP server URL|Yes|
 PGDATABASE|The database name|No|db
 PGHOSTADDR|The database host|No|localhost
 PGPASSWORD|The database password|No|pass
 PGPORT|The database port|No|5432
 PGUSER|The database username|No|user
 SOLR_CORE_URL|The Solr core URL|Yes|
-LDAP_URL|The LDAP server URL|Yes|
-LDAP_AUTH_QUERY|The LDAP query to authenticate user|Yes|
-LDAP_USER_QUERY|The LDAP query to retrieve user info|Yes|
-LDAP_ATTRIBUTE_KEY|The LDAP attribute key used to authorize user|Yes|
-LDAP_ATTRIBUTE_VALUE|The LDAP attribute value used to authorize user|Yes|
 
 ## Running
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ DB_CONNECTION_POOL_MAX_SIZE|The max size of the database connection pool|No|5
 DB_RECONNECT_ATTEMPTS|The number of database reconnect attempts|No|2
 DB_RECONNECT_INTERVAL|The length of the database reconnect interval (in milliseconds)|No|1000
 HARVEST_TIMEOUT|The max amount of time that a harvest may take to complete (in milliseconds)|No|30000
+HARVESTER_USER_AGENT|The User-Agent HTTP request header to use for outgoing requests|No|PRL Harvester
 HTTP_PORT|The application's port|No|8888
 PGDATABASE|The database name|No|db
 PGHOSTADDR|The database host|No|localhost

--- a/src/main/java/edu/ucla/library/prl/harvester/Config.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/Config.java
@@ -14,11 +14,6 @@ public final class Config {
     public static final String HTTP_PORT = "HTTP_PORT";
 
     /**
-     * The configuration property for the application's host.
-     */
-    public static final String HTTP_HOST = "HTTP_HOST";
-
-    /**
      * The configuration property for the database username.
      */
     public static final String DB_USERNAME = "PGUSER";

--- a/src/main/java/edu/ucla/library/prl/harvester/Config.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/Config.java
@@ -114,4 +114,14 @@ public final class Config {
     public static String getHarvesterUserAgent(final JsonObject aConfig) {
         return aConfig.getString(Config.HARVESTER_USER_AGENT, Constants.DEFAULT_HARVESTER_USER_AGENT);
     }
+
+    /**
+     * Gets the application's port.
+     *
+     * @param aConfig A configuration
+     * @return The port
+     */
+    public static int getHttpPort(final JsonObject aConfig) {
+        return aConfig.getInteger(Config.HTTP_PORT, Constants.DEFAULT_HTTP_PORT);
+    }
 }

--- a/src/main/java/edu/ucla/library/prl/harvester/Config.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/Config.java
@@ -1,8 +1,10 @@
 
 package edu.ucla.library.prl.harvester;
 
+import io.vertx.core.json.JsonObject;
+
 /**
- * Properties that are used to configure the application.
+ * Properties that are used to configure the application, and helper methods for accessing them.
  */
 public final class Config {
 
@@ -62,6 +64,11 @@ public final class Config {
     public static final String HARVEST_TIMEOUT = "HARVEST_TIMEOUT";
 
     /**
+     * The ENV property for the User-Agent HTTP request header to use for outgoing requests.
+     */
+    public static final String HARVESTER_USER_AGENT = "HARVESTER_USER_AGENT";
+
+    /**
      * The ENV property for the Solr core URL.
      */
     public static final String SOLR_CORE_URL = "SOLR_CORE_URL";
@@ -105,4 +112,13 @@ public final class Config {
         // This is intentionally left empty.
     }
 
+    /**
+     * Gets the User-Agent HTTP request header to use for outgoing requests.
+     *
+     * @param aConfig A configuration
+     * @return The user agent
+     */
+    public static String getHarvesterUserAgent(final JsonObject aConfig) {
+        return aConfig.getString(Config.HARVESTER_USER_AGENT, Constants.DEFAULT_HARVESTER_USER_AGENT);
+    }
 }

--- a/src/main/java/edu/ucla/library/prl/harvester/Config.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/Config.java
@@ -98,13 +98,6 @@ public final class Config {
      */
     public static final String LDAP_ATTRIBUTE_VALUE = "LDAP_ATTRIBUTE_VALUE";
 
-    // Below are additional configuration options required by test classes (i.e., not the application).
-
-    /**
-     * The test configuration property for the data provider's base URL.
-     */
-    public static final String TEST_PROVIDER_BASE_URL = "TEST_PROVIDER_BASE_URL";
-
     /**
      * Constant classes should have private constructors.
      */

--- a/src/main/java/edu/ucla/library/prl/harvester/Config.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/Config.java
@@ -69,14 +69,14 @@ public final class Config {
     public static final String HARVESTER_USER_AGENT = "HARVESTER_USER_AGENT";
 
     /**
-     * The ENV property for the Solr core URL.
+     * The ENV property for the attribute name used to authorize the user.
      */
-    public static final String SOLR_CORE_URL = "SOLR_CORE_URL";
+    public static final String LDAP_ATTRIBUTE_KEY = "LDAP_ATTRIBUTE_KEY";
 
     /**
-     * The ENV property for the LDAP URL.
+     * The ENV property for the attribute value used to authorize the user.
      */
-    public static final String LDAP_URL = "LDAP_URL";
+    public static final String LDAP_ATTRIBUTE_VALUE = "LDAP_ATTRIBUTE_VALUE";
 
     /**
      * The ENV property for the LDAP authentication query.
@@ -89,14 +89,14 @@ public final class Config {
     public static final String LDAP_USER_QUERY = "LDAP_USER_QUERY";
 
     /**
-     * The ENV property for the attribute name used to authorize the user.
+     * The ENV property for the LDAP URL.
      */
-    public static final String LDAP_ATTRIBUTE_KEY = "LDAP_ATTRIBUTE_KEY";
+    public static final String LDAP_URL = "LDAP_URL";
 
     /**
-     * The ENV property for the attribute value used to authorize the user.
+     * The ENV property for the Solr core URL.
      */
-    public static final String LDAP_ATTRIBUTE_VALUE = "LDAP_ATTRIBUTE_VALUE";
+    public static final String SOLR_CORE_URL = "SOLR_CORE_URL";
 
     /**
      * Constant classes should have private constructors.

--- a/src/main/java/edu/ucla/library/prl/harvester/Config.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/Config.java
@@ -14,31 +14,6 @@ public final class Config {
     public static final String HTTP_PORT = "HTTP_PORT";
 
     /**
-     * The configuration property for the database username.
-     */
-    public static final String DB_USERNAME = "PGUSER";
-
-    /**
-     * The configuration property for the database password.
-     */
-    public static final String DB_PASSWORD = "PGPASSWORD";
-
-    /**
-     * The configuration property for the database port.
-     */
-    public static final String DB_PORT = "PGPORT";
-
-    /**
-     * The ENV property for the database host.
-     */
-    public static final String DB_HOST = "PGHOSTADDR";
-
-    /**
-     * The ENV property for the database name.
-     */
-    public static final String DB_NAME = "PGDATABASE";
-
-    /**
      * The ENV property for the max size of the database connection pool.
      */
     public static final String DB_CONNECTION_POOL_MAX_SIZE = "DB_CONNECTION_POOL_MAX_SIZE";

--- a/src/main/java/edu/ucla/library/prl/harvester/Constants.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/Constants.java
@@ -17,6 +17,11 @@ public final class Constants {
     public static final String DEFAULT_HARVESTER_USER_AGENT = "PRL Harvester";
 
     /**
+     * The default value for the HTTP port.
+     */
+    public static final int DEFAULT_HTTP_PORT = 8888;
+
+    /**
      * Constant classes should have private constructors.
      */
     private Constants() {

--- a/src/main/java/edu/ucla/library/prl/harvester/Constants.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/Constants.java
@@ -12,6 +12,11 @@ public final class Constants {
     public static final String OAI_DC = "oai_dc";
 
     /**
+     * The default value for the User-Agent HTTP request header.
+     */
+    public static final String DEFAULT_HARVESTER_USER_AGENT = "PRL Harvester";
+
+    /**
      * Constant classes should have private constructors.
      */
     private Constants() {

--- a/src/main/java/edu/ucla/library/prl/harvester/handlers/AbstractRequestHandler.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/handlers/AbstractRequestHandler.java
@@ -1,11 +1,13 @@
 
 package edu.ucla.library.prl.harvester.handlers;
 
+import edu.ucla.library.prl.harvester.Config;
 import edu.ucla.library.prl.harvester.services.HarvestJobSchedulerService;
 import edu.ucla.library.prl.harvester.services.HarvestScheduleStoreService;
 
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.RoutingContext;
 
 /**
@@ -19,6 +21,11 @@ public abstract class AbstractRequestHandler implements Handler<RoutingContext> 
     protected final Vertx myVertx;
 
     /**
+     * The User-Agent HTTP request header to use for outgoing requests.
+     */
+    protected final String myHarvesterUserAgent;
+
+    /**
      * A proxy to the harvest schedule store service.
      */
     protected final HarvestScheduleStoreService myHarvestScheduleStoreService;
@@ -30,8 +37,10 @@ public abstract class AbstractRequestHandler implements Handler<RoutingContext> 
 
     /**
      * @param aVertx A Vert.x instance
+     * @param aConfig A configuration
      */
-    protected AbstractRequestHandler(final Vertx aVertx) {
+    protected AbstractRequestHandler(final Vertx aVertx, final JsonObject aConfig) {
+        myHarvesterUserAgent = Config.getHarvesterUserAgent(aConfig);
         myHarvestJobSchedulerService = HarvestJobSchedulerService.createProxy(aVertx);
         myHarvestScheduleStoreService = HarvestScheduleStoreService.createProxy(aVertx);
         myVertx = aVertx;

--- a/src/main/java/edu/ucla/library/prl/harvester/handlers/AbstractSolrAwareWriteOperationHandler.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/handlers/AbstractSolrAwareWriteOperationHandler.java
@@ -27,7 +27,7 @@ public abstract class AbstractSolrAwareWriteOperationHandler extends AbstractReq
      * @param aConfig A configuration
      */
     protected AbstractSolrAwareWriteOperationHandler(final Vertx aVertx, final JsonObject aConfig) {
-        super(aVertx);
+        super(aVertx, aConfig);
 
         mySolrClient = JavaAsyncSolrClient.create(aConfig.getString(Config.SOLR_CORE_URL));
     }

--- a/src/main/java/edu/ucla/library/prl/harvester/handlers/AddJobsHandler.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/handlers/AddJobsHandler.java
@@ -28,9 +28,10 @@ public final class AddJobsHandler extends AbstractRequestHandler {
 
     /**
      * @param aVertx A Vert.x instance
+     * @param aConfig A configuration
      */
-    public AddJobsHandler(final Vertx aVertx) {
-        super(aVertx);
+    public AddJobsHandler(final Vertx aVertx, final JsonObject aConfig) {
+        super(aVertx, aConfig);
     }
 
     @Override
@@ -71,7 +72,7 @@ public final class AddJobsHandler extends AbstractRequestHandler {
 
         return deserializationResult.compose(job -> {
             final Future<Void> oaipmhIdentifierValidationResult = OaipmhUtils.validateIdentifiers(myVertx,
-                    job.getRepositoryBaseURL(), job.getSets().orElse(List.of()));
+                    job.getRepositoryBaseURL(), job.getSets().orElse(List.of()), myHarvesterUserAgent);
 
             return oaipmhIdentifierValidationResult.map(job);
         });

--- a/src/main/java/edu/ucla/library/prl/harvester/handlers/AuthHandler.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/handlers/AuthHandler.java
@@ -122,6 +122,8 @@ public class AuthHandler implements Handler<RoutingContext> {
                 promise.fail(LOGGER.getMessage(MessageCodes.PRL_029, user.principal().encode()));
             }
         }).onFailure(promise::fail);
+
+        return promise.future();
     }
 
     /**

--- a/src/main/java/edu/ucla/library/prl/harvester/handlers/GetInstitutionHandler.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/handlers/GetInstitutionHandler.java
@@ -9,6 +9,7 @@ import edu.ucla.library.prl.harvester.Param;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.RoutingContext;
 
 /**
@@ -18,9 +19,10 @@ public final class GetInstitutionHandler extends AbstractRequestHandler {
 
     /**
      * @param aVertx A Vert.x instance
+     * @param aConfig A configuration
      */
-    public GetInstitutionHandler(final Vertx aVertx) {
-        super(aVertx);
+    public GetInstitutionHandler(final Vertx aVertx, final JsonObject aConfig) {
+        super(aVertx, aConfig);
     }
 
     @Override

--- a/src/main/java/edu/ucla/library/prl/harvester/handlers/GetJobHandler.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/handlers/GetJobHandler.java
@@ -9,6 +9,7 @@ import edu.ucla.library.prl.harvester.Param;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.RoutingContext;
 
 /**
@@ -18,9 +19,10 @@ public final class GetJobHandler extends AbstractRequestHandler {
 
     /**
      * @param aVertx A Vert.x instance
+     * @param aConfig A configuration
      */
-    public GetJobHandler(final Vertx aVertx) {
-        super(aVertx);
+    public GetJobHandler(final Vertx aVertx, final JsonObject aConfig) {
+        super(aVertx, aConfig);
     }
 
     @Override

--- a/src/main/java/edu/ucla/library/prl/harvester/handlers/ListInstitutionsHandler.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/handlers/ListInstitutionsHandler.java
@@ -9,6 +9,7 @@ import edu.ucla.library.prl.harvester.MediaType;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.RoutingContext;
 
 /**
@@ -18,9 +19,10 @@ public final class ListInstitutionsHandler extends AbstractRequestHandler {
 
     /**
      * @param aVertx A Vert.x instance
+     * @param aConfig A configuration
      */
-    public ListInstitutionsHandler(final Vertx aVertx) {
-        super(aVertx);
+    public ListInstitutionsHandler(final Vertx aVertx, final JsonObject aConfig) {
+        super(aVertx, aConfig);
     }
 
     @Override

--- a/src/main/java/edu/ucla/library/prl/harvester/handlers/ListJobsHandler.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/handlers/ListJobsHandler.java
@@ -9,6 +9,7 @@ import edu.ucla.library.prl.harvester.MediaType;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.RoutingContext;
 
 /**
@@ -18,9 +19,10 @@ public final class ListJobsHandler extends AbstractRequestHandler {
 
     /**
      * @param aVertx A Vert.x instance
+     * @param aConfig A configuration
      */
-    public ListJobsHandler(final Vertx aVertx) {
-        super(aVertx);
+    public ListJobsHandler(final Vertx aVertx, final JsonObject aConfig) {
+        super(aVertx, aConfig);
     }
 
     @Override

--- a/src/main/java/edu/ucla/library/prl/harvester/verticles/MainVerticle.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/verticles/MainVerticle.java
@@ -201,7 +201,7 @@ public class MainVerticle extends AbstractVerticle {
      * @return A Future that resolves to the HTTP server
      */
     public Future<HttpServer> createHttpServer(final JsonObject aConfig, final Router aRouter) {
-        final int port = aConfig.getInteger(Config.HTTP_PORT, 8888);
+        final int port = Config.getHttpPort(aConfig);
 
         return vertx.createHttpServer(new HttpServerOptions().setPort(port)).requestHandler(aRouter).listen();
     }

--- a/src/main/java/edu/ucla/library/prl/harvester/verticles/MainVerticle.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/verticles/MainVerticle.java
@@ -148,15 +148,15 @@ public class MainVerticle extends AbstractVerticle {
 
             // Institution operations
             routeBuilder.operation(Op.addInstitutions.name()).handler(new AddInstitutionsHandler(vertx, aConfig));
-            routeBuilder.operation(Op.getInstitution.name()).handler(new GetInstitutionHandler(vertx));
-            routeBuilder.operation(Op.listInstitutions.name()).handler(new ListInstitutionsHandler(vertx));
+            routeBuilder.operation(Op.getInstitution.name()).handler(new GetInstitutionHandler(vertx, aConfig));
+            routeBuilder.operation(Op.listInstitutions.name()).handler(new ListInstitutionsHandler(vertx, aConfig));
             routeBuilder.operation(Op.removeInstitution.name()).handler(new RemoveInstitutionHandler(vertx, aConfig));
             routeBuilder.operation(Op.updateInstitution.name()).handler(new UpdateInstitutionHandler(vertx, aConfig));
 
             // Job operations
-            routeBuilder.operation(Op.addJobs.name()).handler(new AddJobsHandler(vertx));
-            routeBuilder.operation(Op.getJob.name()).handler(new GetJobHandler(vertx));
-            routeBuilder.operation(Op.listJobs.name()).handler(new ListJobsHandler(vertx));
+            routeBuilder.operation(Op.addJobs.name()).handler(new AddJobsHandler(vertx, aConfig));
+            routeBuilder.operation(Op.getJob.name()).handler(new GetJobHandler(vertx, aConfig));
+            routeBuilder.operation(Op.listJobs.name()).handler(new ListJobsHandler(vertx, aConfig));
             routeBuilder.operation(Op.removeJob.name()).handler(new RemoveJobHandler(vertx, aConfig));
             routeBuilder.operation(Op.updateJob.name()).handler(new UpdateJobHandler(vertx, aConfig));
 

--- a/src/main/java/edu/ucla/library/prl/harvester/verticles/MainVerticle.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/verticles/MainVerticle.java
@@ -170,9 +170,9 @@ public class MainVerticle extends AbstractVerticle {
             router = routeBuilder.createRouter();
 
             // If LDAP server is configured, configure our router to check for authorized login
-            if (StringUtils.trimToNull(System.getenv(Config.LDAP_URL)) != null) {
+            if (StringUtils.trimToNull(aConfig.getString(Config.LDAP_URL)) != null) {
                 final SessionStore sessionStore = LocalSessionStore.create(vertx);
-                final AuthHandler authHandler = new AuthHandler(vertx);
+                final AuthHandler authHandler = new AuthHandler(vertx, aConfig);
 
                 // Support maintaining state and processing forms
                 router.route().order(0).handler(BodyHandler.create());

--- a/src/test/java/edu/ucla/library/prl/harvester/AuthorizedFIT.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/AuthorizedFIT.java
@@ -16,6 +16,7 @@ import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.client.HttpRequest;
 import io.vertx.ext.web.client.WebClient;
 import io.vertx.ext.web.client.WebClientSession;
@@ -40,12 +41,13 @@ abstract class AuthorizedFIT {
      * {@link WebClientSession}.
      *
      * @param aWebClient An unauthorized Web client
+     * @param aConfig A configuration
      * @return A successful future with an authorized Web client or a failed future if the authorization failed
      */
-    protected static Future<WebClient> authorize(final WebClient aWebClient) {
+    protected static Future<WebClient> authorize(final WebClient aWebClient, final JsonObject aConfig) {
         final Promise<WebClient> promise = Promise.promise();
-        final String username = System.getenv(TestUtils.LDAP_USERNAME);
-        final String password = System.getenv(TestUtils.LDAP_PASSWORD);
+        final String username = aConfig.getString(TestUtils.LDAP_USERNAME);
+        final String password = aConfig.getString(TestUtils.LDAP_PASSWORD);
         final HttpRequest<Buffer> request = aWebClient.post(LOGIN_URL);
 
         // Mimic our login form's user information

--- a/src/test/java/edu/ucla/library/prl/harvester/DatabaseIT.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/DatabaseIT.java
@@ -34,6 +34,21 @@ public class DatabaseIT {
     private static final Logger LOGGER = LoggerFactory.getLogger(DatabaseIT.class, MessageCodes.BUNDLE);
 
     /**
+     * The standard Postgres environment variable for configuring the database username.
+     */
+    private static final String PGUSER = "PGUSER";
+
+    /**
+     * The standard Postgres environment variable for configuring the database password.
+     */
+    private static final String PGPASSWORD = "PGPASSWORD";
+
+    /**
+     * The standard Postgres environment variable for configuring the database port.
+     */
+    private static final String PGPORT = "PGPORT";
+
+    /**
      * Expected column names from the institutions table.
      */
     @SuppressWarnings("PMD.MultipleStringLiterals")
@@ -65,12 +80,10 @@ public class DatabaseIT {
     public static final void setUp() {
         // Note: TRACE level logging should NEVER be used on a public server.
         if (LOGGER.isTraceEnabled()) {
-            LOGGER.trace(MessageCodes.PRL_005, System.getenv(Config.DB_USERNAME), System.getenv(Config.DB_PORT),
-                    System.getenv(Config.DB_PASSWORD));
+            LOGGER.trace(MessageCodes.PRL_005, System.getenv(PGUSER), System.getenv(PGPORT), System.getenv(PGPASSWORD));
         } else {
             // The below still only triggers if DEBUG level requirement is met.
-            LOGGER.debug(MessageCodes.PRL_005, System.getenv(Config.DB_USERNAME), System.getenv(Config.DB_PORT),
-                    "****");
+            LOGGER.debug(MessageCodes.PRL_005, System.getenv(PGUSER), System.getenv(PGPORT), "****");
         }
 
         myDatabase = PgPool.pool();

--- a/src/test/java/edu/ucla/library/prl/harvester/FrontEndIT.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/FrontEndIT.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import edu.ucla.library.prl.harvester.utils.TestUtils;
 import info.freelibrary.util.Logger;
 import info.freelibrary.util.LoggerFactory;
 
@@ -53,7 +54,7 @@ public class FrontEndIT extends AuthorizedFIT {
     @BeforeAll
     public final void setUp(final Vertx aVertx, final VertxTestContext aContext) {
         ConfigRetriever.create(aVertx).getConfig().compose(config -> {
-            final String host = config.getString(Config.HTTP_HOST);
+            final String host = config.getString(TestUtils.HTTP_HOST);
             final int port = Config.getHttpPort(config);
             final WebClientOptions webClientOpts = new WebClientOptions().setDefaultHost(host).setDefaultPort(port);
 

--- a/src/test/java/edu/ucla/library/prl/harvester/FrontEndIT.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/FrontEndIT.java
@@ -54,7 +54,7 @@ public class FrontEndIT extends AuthorizedFIT {
     public final void setUp(final Vertx aVertx, final VertxTestContext aContext) {
         ConfigRetriever.create(aVertx).getConfig().compose(config -> {
             final String host = config.getString(Config.HTTP_HOST);
-            final int port = config.getInteger(Config.HTTP_PORT);
+            final int port = Config.getHttpPort(config);
             final WebClientOptions webClientOpts = new WebClientOptions().setDefaultHost(host).setDefaultPort(port);
 
             myWebClient = WebClientSession.create(WebClient.create(aVertx, webClientOpts));

--- a/src/test/java/edu/ucla/library/prl/harvester/FrontEndIT.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/FrontEndIT.java
@@ -60,7 +60,7 @@ public class FrontEndIT extends AuthorizedFIT {
 
             myWebClient = WebClientSession.create(WebClient.create(aVertx, webClientOpts));
 
-            return authorize(myWebClient);
+            return authorize(myWebClient, config);
         }).onSuccess(result -> aContext.completeNow()).onFailure(aContext::failNow);
     }
 

--- a/src/test/java/edu/ucla/library/prl/harvester/InstitutionRequestsFT.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/InstitutionRequestsFT.java
@@ -76,7 +76,7 @@ public class InstitutionRequestsFT extends AuthorizedFIT {
     public final void setUp(final Vertx aVertx, final VertxTestContext aContext) {
         ConfigRetriever.create(aVertx).getConfig().compose(config -> {
             final String host = config.getString(Config.HTTP_HOST);
-            final int port = config.getInteger(Config.HTTP_PORT);
+            final int port = Config.getHttpPort(config);
             final WebClientOptions webClientOpts = new WebClientOptions().setDefaultHost(host).setDefaultPort(port);
 
             myDbConnectionPool = HarvestScheduleStoreService.getConnectionPool(aVertx, config);

--- a/src/test/java/edu/ucla/library/prl/harvester/InstitutionRequestsFT.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/InstitutionRequestsFT.java
@@ -83,7 +83,7 @@ public class InstitutionRequestsFT extends AuthorizedFIT {
             mySolrClient = JavaAsyncSolrClient.create(config.getString(Config.SOLR_CORE_URL));
             myWebClient = WebClientSession.create(WebClient.create(aVertx, webClientOpts));
 
-            return authorize(myWebClient);
+            return authorize(myWebClient, config);
         }).onSuccess(result -> aContext.completeNow()).onFailure(aContext::failNow);
     }
 

--- a/src/test/java/edu/ucla/library/prl/harvester/InstitutionRequestsFT.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/InstitutionRequestsFT.java
@@ -75,7 +75,7 @@ public class InstitutionRequestsFT extends AuthorizedFIT {
     @BeforeAll
     public final void setUp(final Vertx aVertx, final VertxTestContext aContext) {
         ConfigRetriever.create(aVertx).getConfig().compose(config -> {
-            final String host = config.getString(Config.HTTP_HOST);
+            final String host = config.getString(TestUtils.HTTP_HOST);
             final int port = Config.getHttpPort(config);
             final WebClientOptions webClientOpts = new WebClientOptions().setDefaultHost(host).setDefaultPort(port);
 

--- a/src/test/java/edu/ucla/library/prl/harvester/JobRequestsFT.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/JobRequestsFT.java
@@ -85,7 +85,7 @@ public class JobRequestsFT extends AuthorizedFIT {
     @BeforeAll
     public final void setUp(final Vertx aVertx, final VertxTestContext aContext) {
         ConfigRetriever.create(aVertx).getConfig().compose(config -> {
-            final String host = config.getString(Config.HTTP_HOST);
+            final String host = config.getString(TestUtils.HTTP_HOST);
             final int port = Config.getHttpPort(config);
             final WebClientOptions webClientOpts = new WebClientOptions().setDefaultHost(host).setDefaultPort(port);
 

--- a/src/test/java/edu/ucla/library/prl/harvester/JobRequestsFT.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/JobRequestsFT.java
@@ -100,7 +100,7 @@ public class JobRequestsFT extends AuthorizedFIT {
 
             myWebClient = WebClientSession.create(WebClient.create(aVertx, webClientOpts));
 
-            return authorize(myWebClient);
+            return authorize(myWebClient, config);
         }).onSuccess(result -> aContext.completeNow()).onFailure(aContext::failNow);
     }
 

--- a/src/test/java/edu/ucla/library/prl/harvester/JobRequestsFT.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/JobRequestsFT.java
@@ -86,7 +86,7 @@ public class JobRequestsFT extends AuthorizedFIT {
     public final void setUp(final Vertx aVertx, final VertxTestContext aContext) {
         ConfigRetriever.create(aVertx).getConfig().compose(config -> {
             final String host = config.getString(Config.HTTP_HOST);
-            final int port = config.getInteger(Config.HTTP_PORT);
+            final int port = Config.getHttpPort(config);
             final WebClientOptions webClientOpts = new WebClientOptions().setDefaultHost(host).setDefaultPort(port);
 
             myDbConnectionPool = HarvestScheduleStoreService.getConnectionPool(aVertx, config);

--- a/src/test/java/edu/ucla/library/prl/harvester/JobRequestsFT.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/JobRequestsFT.java
@@ -93,7 +93,7 @@ public class JobRequestsFT extends AuthorizedFIT {
             mySolrClient = JavaAsyncSolrClient.create(config.getString(Config.SOLR_CORE_URL));
 
             try {
-                myTestProviderBaseURL = new URL(config.getString(Config.TEST_PROVIDER_BASE_URL));
+                myTestProviderBaseURL = new URL(config.getString(TestUtils.TEST_PROVIDER_BASE_URL));
             } catch (final MalformedURLException details) {
                 return Future.failedFuture(details);
             }

--- a/src/test/java/edu/ucla/library/prl/harvester/OaipmhUtilsFT.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/OaipmhUtilsFT.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import edu.ucla.library.prl.harvester.utils.TestUtils;
 import info.freelibrary.util.Logger;
 import info.freelibrary.util.LoggerFactory;
 
@@ -62,7 +63,7 @@ public class OaipmhUtilsFT {
             myHarvesterUserAgent = Config.getHarvesterUserAgent(config);
 
             try {
-                myTestDataProviderURL = new URL(config.getString(Config.TEST_PROVIDER_BASE_URL));
+                myTestDataProviderURL = new URL(config.getString(TestUtils.TEST_PROVIDER_BASE_URL));
             } catch (final MalformedURLException details) {
                 aContext.failNow(details);
                 return;

--- a/src/test/java/edu/ucla/library/prl/harvester/OaipmhUtilsFT.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/OaipmhUtilsFT.java
@@ -12,7 +12,10 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -22,7 +25,6 @@ import info.freelibrary.util.Logger;
 import info.freelibrary.util.LoggerFactory;
 
 import io.vertx.config.ConfigRetriever;
-import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
@@ -34,6 +36,7 @@ import io.vertx.junit5.VertxTestContext;
  * OAI-PMH data provider container is running.
  */
 @ExtendWith(VertxExtension.class)
+@TestInstance(Lifecycle.PER_CLASS)
 public class OaipmhUtilsFT {
 
     /**
@@ -45,6 +48,30 @@ public class OaipmhUtilsFT {
 
     private static final String SET2 = "set2";
 
+    private String myHarvesterUserAgent;
+
+    private URL myTestDataProviderURL;
+
+    /**
+     * @param aVertx A Vert.x instance
+     * @param aContext A test context
+     */
+    @BeforeAll
+    public final void setUp(final Vertx aVertx, final VertxTestContext aContext) {
+        ConfigRetriever.create(aVertx).getConfig().onSuccess(config -> {
+            myHarvesterUserAgent = Config.getHarvesterUserAgent(config);
+
+            try {
+                myTestDataProviderURL = new URL(config.getString(Config.TEST_PROVIDER_BASE_URL));
+            } catch (final MalformedURLException details) {
+                aContext.failNow(details);
+                return;
+            }
+
+            aContext.completeNow();
+        });
+    }
+
     /**
      * Tests {@link OaipmhUtils#listSets}.
      *
@@ -53,9 +80,7 @@ public class OaipmhUtilsFT {
      */
     @Test
     public final void testListSets(final Vertx aVertx, final VertxTestContext aContext) {
-        getTestDataProviderURL(aVertx).compose(url -> {
-            return OaipmhUtils.listSets(aVertx, url);
-        }).onSuccess(sets -> {
+        OaipmhUtils.listSets(aVertx, myTestDataProviderURL, myHarvesterUserAgent).onSuccess(sets -> {
             aContext.verify(() -> {
                 assertEquals(2, sets.size());
                 assertTrue(OaipmhUtils.getSetSpecs(sets).containsAll(java.util.Set.of(SET1, SET2)));
@@ -75,13 +100,12 @@ public class OaipmhUtilsFT {
     @MethodSource
     public final void testListRecords(final List<String> aSets, final int anExpectedRecordCount, final Vertx aVertx,
             final VertxTestContext aContext) {
-        getTestDataProviderURL(aVertx).compose(url -> {
-            return OaipmhUtils.listRecords(aVertx, url, aSets, OAI_DC, Optional.empty());
-        }).onSuccess(records -> {
-            aContext.verify(() -> {
-                assertEquals(anExpectedRecordCount, records.size());
-            }).completeNow();
-        });
+        OaipmhUtils.listRecords(aVertx, myTestDataProviderURL, aSets, OAI_DC, Optional.empty(), myHarvesterUserAgent)
+                .onSuccess(records -> {
+                    aContext.verify(() -> {
+                        assertEquals(anExpectedRecordCount, records.size());
+                    }).completeNow();
+                });
     }
 
     /**
@@ -102,9 +126,8 @@ public class OaipmhUtilsFT {
      */
     @Test
     public final void testValidateIdentifiers(final Vertx aVertx, final VertxTestContext aContext) {
-        getTestDataProviderURL(aVertx).compose(url -> {
-            return OaipmhUtils.validateIdentifiers(aVertx, url, List.of(SET1, SET2));
-        }).onSuccess(nil -> aContext.completeNow()).onFailure(aContext::failNow);
+        OaipmhUtils.validateIdentifiers(aVertx, myTestDataProviderURL, List.of(SET1, SET2), myHarvesterUserAgent)
+                .onSuccess(nil -> aContext.completeNow()).onFailure(aContext::failNow);
     }
 
     /**
@@ -124,11 +147,13 @@ public class OaipmhUtilsFT {
             return;
         }
 
-        OaipmhUtils.validateIdentifiers(aVertx, invalidOaipmhBaseURL, List.of(SET1, SET2)).onFailure(details -> {
-            aContext.verify(() -> {
-                assertEquals(LOGGER.getMessage(MessageCodes.PRL_024, invalidOaipmhBaseURL), details.getMessage());
-            }).completeNow();
-        }).onSuccess(nil -> aContext.failNow(LOGGER.getMessage(MessageCodes.PRL_038)));
+        OaipmhUtils.validateIdentifiers(aVertx, invalidOaipmhBaseURL, List.of(SET1, SET2), myHarvesterUserAgent)
+                .onFailure(details -> {
+                    aContext.verify(() -> {
+                        assertEquals(LOGGER.getMessage(MessageCodes.PRL_024, invalidOaipmhBaseURL),
+                                details.getMessage());
+                    }).completeNow();
+                }).onSuccess(nil -> aContext.failNow(LOGGER.getMessage(MessageCodes.PRL_038)));
     }
 
     /**
@@ -141,26 +166,12 @@ public class OaipmhUtilsFT {
     public final void testValidateIdentifiersInvalidSetSpec(final Vertx aVertx, final VertxTestContext aContext) {
         final String undefinedSet = "set3";
 
-        getTestDataProviderURL(aVertx).compose(url -> {
-            return OaipmhUtils.validateIdentifiers(aVertx, url, List.of(undefinedSet)).onFailure(details -> {
-                aContext.verify(() -> {
-                    assertEquals(LOGGER.getMessage(MessageCodes.PRL_025, url, undefinedSet), details.getMessage());
-                }).completeNow();
-            }).onSuccess(nil -> aContext.failNow(LOGGER.getMessage(MessageCodes.PRL_038)));
-        });
-    }
-
-    /**
-     * @param aVertx A Vert.x instance
-     * @return The base URL of the test OAI-PMH data provider
-     */
-    private static Future<URL> getTestDataProviderURL(final Vertx aVertx) {
-        return ConfigRetriever.create(aVertx).getConfig().compose(config -> {
-            try {
-                return Future.succeededFuture(new URL(config.getString(Config.TEST_PROVIDER_BASE_URL)));
-            } catch (final MalformedURLException details) {
-                return Future.failedFuture(details);
-            }
-        });
+        OaipmhUtils.validateIdentifiers(aVertx, myTestDataProviderURL, List.of(undefinedSet), myHarvesterUserAgent)
+                .onFailure(details -> {
+                    aContext.verify(() -> {
+                        assertEquals(LOGGER.getMessage(MessageCodes.PRL_025, myTestDataProviderURL, undefinedSet),
+                                details.getMessage());
+                    }).completeNow();
+                }).onSuccess(nil -> aContext.failNow(LOGGER.getMessage(MessageCodes.PRL_038)));
     }
 }

--- a/src/test/java/edu/ucla/library/prl/harvester/handlers/StatusHandlerIT.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/handlers/StatusHandlerIT.java
@@ -51,7 +51,7 @@ public class StatusHandlerIT {
     public void setUp(final Vertx aVertx, final VertxTestContext aContext) {
         ConfigRetriever.create(aVertx).getConfig().onSuccess(config -> {
             myWebClient = WebClient.create(aVertx);
-            myPort = config.getInteger(Config.HTTP_PORT, 8888);
+            myPort = Config.getHttpPort(config);
 
             aContext.completeNow();
         }).onFailure(aContext::failNow);

--- a/src/test/java/edu/ucla/library/prl/harvester/services/HarvestJobSchedulerServiceIT.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/services/HarvestJobSchedulerServiceIT.java
@@ -115,7 +115,7 @@ public class HarvestJobSchedulerServiceIT {
             myHarvestService = binder.setAddress(HarvestService.ADDRESS).register(HarvestService.class, harvestService);
 
             try {
-                myTestProviderBaseURL = new URL(config.getString(Config.TEST_PROVIDER_BASE_URL));
+                myTestProviderBaseURL = new URL(config.getString(TestUtils.TEST_PROVIDER_BASE_URL));
             } catch (final MalformedURLException details) {
                 return Future.failedFuture(details);
             }

--- a/src/test/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreServiceIT.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreServiceIT.java
@@ -238,7 +238,7 @@ public class HarvestScheduleStoreServiceIT {
     }
 
     /**
-     * Tests that an empty list is dealt with appropriately. FIXME
+     * Tests that providing an empty list of institutions results in an error.
      *
      * @param aVertx A Vert.x instance
      * @param aContext A test context
@@ -439,7 +439,7 @@ public class HarvestScheduleStoreServiceIT {
     }
 
     /**
-     * Tests that an empty list is dealt with appropriately. FIXME
+     * Tests that providing an empty list of jobs results in an error.
      *
      * @param aVertx A Vert.x instance
      * @param aContext A test context

--- a/src/test/java/edu/ucla/library/prl/harvester/services/HarvestServiceIT.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/services/HarvestServiceIT.java
@@ -100,7 +100,7 @@ public class HarvestServiceIT {
             mySolrClient = JavaAsyncSolrClient.create(config.getString(Config.SOLR_CORE_URL));
 
             try {
-                myTestProviderBaseURL = new URL(config.getString(Config.TEST_PROVIDER_BASE_URL));
+                myTestProviderBaseURL = new URL(config.getString(TestUtils.TEST_PROVIDER_BASE_URL));
                 testInstitution = TestUtils.getRandomInstitution();
             } catch (final AddressException | MalformedURLException | NumberParseException details) {
                 return Future.failedFuture(details);

--- a/src/test/java/edu/ucla/library/prl/harvester/utils/TestUtils.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/utils/TestUtils.java
@@ -71,6 +71,11 @@ import io.vertx.uritemplate.Variables;
 public final class TestUtils {
 
     /**
+     * The ENV property for the application's host.
+     */
+    public static final String HTTP_HOST = "HTTP_HOST";
+
+    /**
      * The ENV property for the test user's LDAP username.
      */
     public static final String LDAP_USERNAME = "LDAP_USERNAME";

--- a/src/test/java/edu/ucla/library/prl/harvester/utils/TestUtils.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/utils/TestUtils.java
@@ -80,6 +80,11 @@ public final class TestUtils {
      */
     public static final String LDAP_PASSWORD = "LDAP_PASSWORD";
 
+    /**
+     * The ENV property property for the data provider's base URL.
+     */
+    public static final String TEST_PROVIDER_BASE_URL = "TEST_PROVIDER_BASE_URL";
+
     public static final UriTemplate INSTITUTION = UriTemplate.of("/institutions/{id}");
 
     public static final UriTemplate INSTITUTIONS = UriTemplate.of("/institutions");


### PR DESCRIPTION
Summary:
- Add env var to configure User-Agent header, with a default value of `PRL Harvester` if unset
- Add helper methods to Config class for those config options that both (a) are optional and have a default value, and (b) are read more than once in the codebase (polish)
- Move constants for the standard Postgres env vars to the IT where they are used, since they are never referenced in src/main; move other test env vars to TestUtils (polish)
- Improve alignment with principle of writing pure functions whenever possible, and DRY (polish)