### PR TITLE
[SERV-802] Don't touch Solr index on no-op job updates

### DIFF
--- a/src/main/frontend/src/components/JobItem.vue
+++ b/src/main/frontend/src/components/JobItem.vue
@@ -12,8 +12,8 @@ const props = defineProps({
     selectJobToUpdate: { type: Function },
     selectJobToRemove: { type: Function },
 })
-const isSelectiveHarvest = computed(() => (props.sets ? props.sets.length > 0 : false))
-const sortedSets = computed(() => (props.sets ? props.sets.slice().sort() : []))
+const isSelectiveHarvest = computed(() => props.sets.length > 0)
+const sortedSets = computed(() => props.sets.slice().sort())
 </script>
 
 <template>

--- a/src/main/java/edu/ucla/library/prl/harvester/Institution.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/Institution.java
@@ -22,6 +22,7 @@ import com.google.i18n.phonenumbers.Phonenumber.PhoneNumber;
 import info.freelibrary.util.IllegalArgumentI18nException;
 import info.freelibrary.util.Logger;
 import info.freelibrary.util.LoggerFactory;
+import info.freelibrary.util.StringUtils;
 
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.json.JsonObject;
@@ -33,6 +34,13 @@ import io.vertx.sqlclient.templates.SqlTemplate;
 @DataObject
 @SuppressWarnings("PMD.DataClass")
 public final class Institution {
+
+    /**
+     * The string template for the ID of a Solr doc representing an institution.
+     * <p>
+     * The template should be formatted with the institution ID.
+     */
+    public static final String SOLR_DOC_ID_TEMPLATE = "prl-harvester-institution-{}";
 
     /**
      * The JSON key for the ID.
@@ -272,8 +280,8 @@ public final class Institution {
         final SolrInputDocument doc = new SolrInputDocument();
 
         // Required fields
-        doc.setField(ID, String.format("prl-harvester-institution-%d", getID()
-                .orElseThrow(() -> new NoSuchElementException(LOGGER.getMessage(MessageCodes.PRL_022))).intValue()));
+        doc.setField(ID, StringUtils.format(SOLR_DOC_ID_TEMPLATE,
+                getID().orElseThrow(() -> new NoSuchElementException(LOGGER.getMessage(MessageCodes.PRL_022)))));
         doc.setField("prrla_member_title", getName());
         doc.setField("prrla_member_description", getDescription());
         doc.setField("prrla_member_location", getLocation());

--- a/src/main/java/edu/ucla/library/prl/harvester/handlers/AddJobsHandler.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/handlers/AddJobsHandler.java
@@ -75,7 +75,7 @@ public final class AddJobsHandler extends AbstractRequestHandler {
 
         return deserializationResult.compose(job -> {
             final URL baseURL = job.getRepositoryBaseURL();
-            final List<String> sets = job.getSets().orElse(List.of());
+            final List<String> sets = job.getSets();
 
             return OaipmhUtils
                     .validateIdentifiers(myVertx, baseURL, sets, myOaipmhClientHttpTimeout, myHarvesterUserAgent)

--- a/src/main/java/edu/ucla/library/prl/harvester/handlers/RemoveJobHandler.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/handlers/RemoveJobHandler.java
@@ -3,7 +3,6 @@ package edu.ucla.library.prl.harvester.handlers;
 
 import java.net.URL;
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 
 import org.apache.http.HttpStatus;
@@ -91,13 +90,13 @@ public final class RemoveJobHandler extends AbstractSolrAwareWriteOperationHandl
      * @return A Solr query that can be used to remove records from the given sets associated with the given institution
      */
     static Future<String> getRecordRemovalQuery(final Vertx aVertx, final String anInstitutionName, final URL aBaseURL,
-            final Optional<List<String>> aSets, final int aTimeout, final String aUserAgent) {
+            final List<String> aSets, final int aTimeout, final String aUserAgent) {
         final Future<List<String>> getSetsToRemove;
 
-        if (aSets.isPresent() && !aSets.get().isEmpty()) {
-            getSetsToRemove = Future.succeededFuture(aSets.get());
+        if (!aSets.isEmpty()) {
+            getSetsToRemove = Future.succeededFuture(aSets);
         } else {
-            // Missing or empty list means all sets in the repository
+            // Empty list means all sets in the repository
             getSetsToRemove =
                     OaipmhUtils.listSets(aVertx, aBaseURL, aTimeout, aUserAgent).map(OaipmhUtils::getSetSpecs);
         }

--- a/src/main/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreServiceImpl.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreServiceImpl.java
@@ -189,7 +189,7 @@ public class HarvestScheduleStoreServiceImpl implements HarvestScheduleStoreServ
 
             getJob(jobID).compose(job -> {
                 final Job withNewLastSuccessfulTime = new Job(job.getInstitutionID(), job.getRepositoryBaseURL(),
-                        job.getSets().orElse(null), job.getScheduleCronExpression(), jobResult.getStartTime());
+                        job.getSets(), job.getScheduleCronExpression(), jobResult.getStartTime());
 
                 return updateJob(jobID, withNewLastSuccessfulTime);
             });

--- a/src/main/java/edu/ucla/library/prl/harvester/services/HarvestServiceImpl.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/services/HarvestServiceImpl.java
@@ -125,9 +125,9 @@ public class HarvestServiceImpl implements HarvestService {
             final OffsetDateTime startTime;
             final Future<Stream<Record>> harvest;
 
-            if (aJob.getSets().isPresent() && !aJob.getSets().get().isEmpty()) {
+            if (!aJob.getSets().isEmpty()) {
                 // Harvest only the specified sets
-                targetSets = aJob.getSets().get();
+                targetSets = aJob.getSets();
             } else {
                 // Harvest all sets in the repository
                 targetSets = new LinkedList<>(setNameLookup.keySet());

--- a/src/main/resources/openapi.yaml
+++ b/src/main/resources/openapi.yaml
@@ -73,7 +73,6 @@ components:
           items:
             type: string
             description: An OAI-PMH setSpec
-          nullable: true
         scheduleCronExpression:
           type: string
           example: "0 5 * * 1"

--- a/src/test/java/edu/ucla/library/prl/harvester/JobTest.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/JobTest.java
@@ -91,11 +91,10 @@ public class JobTest {
         final OffsetDateTime exampleTimestamp = OffsetDateTime.parse("2000-01-01T00:00Z");
 
         return Stream.of( //
-                Arguments.of(1, exampleURL, null, exampleSchedule, null), //
-                Arguments.of(2, exampleURL, null, exampleSchedule, exampleTimestamp), //
-                Arguments.of(3, exampleURL, List.of(), exampleSchedule, exampleTimestamp), //
-                Arguments.of(4, exampleURL, exampleSets, exampleSchedule, null), //
-                Arguments.of(5, exampleURL, exampleSets, exampleSchedule, exampleTimestamp));
+                Arguments.of(1, exampleURL, List.of(), exampleSchedule, exampleTimestamp), //
+                Arguments.of(2, exampleURL, exampleSets, exampleSchedule, exampleTimestamp), //
+                Arguments.of(3, exampleURL, List.of(), exampleSchedule, null), //
+                Arguments.of(4, exampleURL, exampleSets, exampleSchedule, null));
     }
 
     /**

--- a/src/test/java/edu/ucla/library/prl/harvester/OaipmhUtilsFT.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/OaipmhUtilsFT.java
@@ -45,10 +45,6 @@ public class OaipmhUtilsFT {
      */
     private static final Logger LOGGER = LoggerFactory.getLogger(OaipmhUtils.class, MessageCodes.BUNDLE);
 
-    private static final String SET1 = "set1";
-
-    private static final String SET2 = "set2";
-
     private String myHarvesterUserAgent;
 
     private int myOaipmhClientHttpTimeout;
@@ -88,7 +84,8 @@ public class OaipmhUtilsFT {
                 .onSuccess(sets -> {
                     aContext.verify(() -> {
                         assertEquals(2, sets.size());
-                        assertTrue(OaipmhUtils.getSetSpecs(sets).containsAll(java.util.Set.of(SET1, SET2)));
+                        assertTrue(OaipmhUtils.getSetSpecs(sets)
+                                .containsAll(java.util.Set.of(TestUtils.SET1, TestUtils.SET2)));
                     }).completeNow();
                 }).onFailure(aContext::failNow);
     }
@@ -118,9 +115,9 @@ public class OaipmhUtilsFT {
      */
     static Stream<Arguments> testListRecords() {
         return Stream.of( //
-                Arguments.of(List.of(SET1), 2), //
-                Arguments.of(List.of(SET2), 3), //
-                Arguments.of(List.of(SET1, SET2), 5));
+                Arguments.of(List.of(TestUtils.SET1), 2), //
+                Arguments.of(List.of(TestUtils.SET2), 3), //
+                Arguments.of(List.of(TestUtils.SET1, TestUtils.SET2), 5));
     }
 
     /**
@@ -131,7 +128,9 @@ public class OaipmhUtilsFT {
      */
     @Test
     public final void testValidateIdentifiers(final Vertx aVertx, final VertxTestContext aContext) {
-        OaipmhUtils.validateIdentifiers(aVertx, myTestDataProviderURL, List.of(SET1, SET2), myOaipmhClientHttpTimeout,
+        final List<String> sets = List.of(TestUtils.SET1, TestUtils.SET2);
+
+        OaipmhUtils.validateIdentifiers(aVertx, myTestDataProviderURL, sets, myOaipmhClientHttpTimeout,
                 myHarvesterUserAgent).onSuccess(nil -> aContext.completeNow()).onFailure(aContext::failNow);
     }
 
@@ -144,6 +143,7 @@ public class OaipmhUtilsFT {
     @Test
     public final void testValidateIdentifiersInvalidBaseURL(final Vertx aVertx, final VertxTestContext aContext) {
         final URL invalidOaipmhBaseURL;
+        final List<String> sets = List.of(TestUtils.SET1, TestUtils.SET2);
 
         try {
             invalidOaipmhBaseURL = new URL("http://example.com");
@@ -152,7 +152,7 @@ public class OaipmhUtilsFT {
             return;
         }
 
-        OaipmhUtils.validateIdentifiers(aVertx, invalidOaipmhBaseURL, List.of(SET1, SET2), myOaipmhClientHttpTimeout,
+        OaipmhUtils.validateIdentifiers(aVertx, invalidOaipmhBaseURL, sets, myOaipmhClientHttpTimeout,
                 myHarvesterUserAgent).onFailure(details -> {
                     aContext.verify(() -> {
                         assertEquals(LOGGER.getMessage(MessageCodes.PRL_024, invalidOaipmhBaseURL),

--- a/src/test/java/edu/ucla/library/prl/harvester/services/HarvestJobSchedulerServiceIT.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/services/HarvestJobSchedulerServiceIT.java
@@ -180,7 +180,7 @@ public class HarvestJobSchedulerServiceIT {
                     final JobResult jobResult = new JobResult(message.body());
                     final CompositeFuture queryBackingServices =
                             CompositeFuture.all(myHarvestScheduleStoreServiceProxy.getJob(jobResult.getJobID()),
-                                    TestUtils.getAllDocuments(mySolrClient));
+                                    TestUtils.getItemRecordDocuments(mySolrClient));
 
                     queryBackingServices.onSuccess(results -> {
                         final Job job = results.resultAt(0);
@@ -240,7 +240,7 @@ public class HarvestJobSchedulerServiceIT {
                     final JobResult jobResult = new JobResult(message.body());
                     final CompositeFuture queryBackingServices =
                             CompositeFuture.all(myHarvestScheduleStoreServiceProxy.getJob(jobResult.getJobID()),
-                                    TestUtils.getAllDocuments(mySolrClient));
+                                    TestUtils.getItemRecordDocuments(mySolrClient));
 
                     queryBackingServices.onSuccess(results -> {
                         final Job job = results.resultAt(0);
@@ -313,7 +313,7 @@ public class HarvestJobSchedulerServiceIT {
                     final JobResult jobResult = new JobResult(message.body());
                     final CompositeFuture queryBackingServices =
                             CompositeFuture.all(myHarvestScheduleStoreServiceProxy.getJob(jobResult.getJobID()),
-                                    TestUtils.getAllDocuments(mySolrClient));
+                                    TestUtils.getItemRecordDocuments(mySolrClient));
 
                     queryBackingServices.onSuccess(results -> {
                         final Job job = results.resultAt(0);

--- a/src/test/java/edu/ucla/library/prl/harvester/services/HarvestJobSchedulerServiceIT.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/services/HarvestJobSchedulerServiceIT.java
@@ -25,8 +25,6 @@ import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import org.quartz.CronExpression;
-
 import com.google.i18n.phonenumbers.NumberParseException;
 
 import info.freelibrary.util.Logger;
@@ -270,8 +268,8 @@ public class HarvestJobSchedulerServiceIT {
                 final Job job;
 
                 try {
-                    job = new Job(institutionID, myTestProviderBaseURL, List.of(SET1), getFutureCronExpression(5),
-                            null);
+                    job = new Job(institutionID, myTestProviderBaseURL, List.of(SET1),
+                            TestUtils.getFutureCronExpression(5), null);
                 } catch (final ParseException details) {
                     return Future.failedFuture(details);
                 }
@@ -402,22 +400,6 @@ public class HarvestJobSchedulerServiceIT {
     }
 
     /**
-     * Gets a Cron expression that will match some time in the future.
-     *
-     * @param aSecondsLater The number of seconds in the future to create an hourly Cron expression for
-     * @return The Cron expression
-     * @throws ParseException
-     */
-    private static CronExpression getFutureCronExpression(final long aSecondsLater) throws ParseException {
-        final OffsetDateTime futureTime = OffsetDateTime.now().plusSeconds(aSecondsLater);
-        final String cron = String.format("%d %d * * * ?", futureTime.getSecond(), futureTime.getMinute());
-
-        LOGGER.debug(MessageCodes.PRL_033, aSecondsLater, cron);
-
-        return new CronExpression(cron);
-    }
-
-    /**
      * @return A Future that succeeds if a random institution was added to the database
      */
     private Future<Integer> addInstitution() {
@@ -442,7 +424,7 @@ public class HarvestJobSchedulerServiceIT {
         final Job job;
 
         try {
-            job = new Job(anInstitutionID, myTestProviderBaseURL, aSets, getFutureCronExpression(5), null);
+            job = new Job(anInstitutionID, myTestProviderBaseURL, aSets, TestUtils.getFutureCronExpression(5), null);
         } catch (final ParseException details) {
             return Future.failedFuture(details);
         }

--- a/src/test/java/edu/ucla/library/prl/harvester/services/HarvestJobSchedulerServiceIT.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/services/HarvestJobSchedulerServiceIT.java
@@ -365,7 +365,7 @@ public class HarvestJobSchedulerServiceIT {
         final Checkpoint removedJobDidNotExecute = aContext.checkpoint();
 
         // Add jobs before instantiation of the service
-        addInstitution().compose(institutionID -> addJob(institutionID, null)).compose(jobID -> {
+        addInstitution().compose(institutionID -> addJob(institutionID, List.of())).compose(jobID -> {
             final OffsetDateTime now = OffsetDateTime.now().withNano(0);
             // After this time, we can be reasonably certain that the canceled job won't run
             final OffsetDateTime whenWeWillKnow = now.plusSeconds(10);

--- a/src/test/java/edu/ucla/library/prl/harvester/services/HarvestJobSchedulerServiceIT.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/services/HarvestJobSchedulerServiceIT.java
@@ -62,14 +62,6 @@ public class HarvestJobSchedulerServiceIT {
     private static final Logger LOGGER =
             LoggerFactory.getLogger(HarvestJobSchedulerServiceIT.class, MessageCodes.BUNDLE);
 
-    private static final String SET1 = "set1";
-
-    private static final String SET2 = "set2";
-
-    private static final int SET1_RECORD_COUNT = 2;
-
-    private static final int SET2_RECORD_COUNT = 3;
-
     private JsonObject myConfig;
 
     private Pool myDbConnectionPool;
@@ -164,9 +156,10 @@ public class HarvestJobSchedulerServiceIT {
     @Timeout(value = 15, timeUnit = TimeUnit.SECONDS)
     public void testInstantiationExistingJob(final Vertx aVertx, final VertxTestContext aContext) {
         final Checkpoint serviceSaved = aContext.checkpoint();
+        final List<String> bothSets = List.of(TestUtils.SET1, TestUtils.SET2);
 
         // Add jobs before instantiation of the service
-        addInstitution().compose(institutionID -> addJob(institutionID, List.of(SET1, SET2))).compose(jobID -> {
+        addInstitution().compose(institutionID -> addJob(institutionID, bothSets)).compose(jobID -> {
             final Checkpoint jobResultReceived = aContext.checkpoint();
 
             LOGGER.debug(MessageCodes.PRL_030);
@@ -185,7 +178,8 @@ public class HarvestJobSchedulerServiceIT {
                         final SolrDocumentList solrDocs = results.resultAt(1);
 
                         aContext.verify(() -> {
-                            assertEquals(SET1_RECORD_COUNT + SET2_RECORD_COUNT, jobResult.getRecordCount());
+                            assertEquals(TestUtils.SET1_RECORD_COUNT + TestUtils.SET2_RECORD_COUNT,
+                                    jobResult.getRecordCount());
                             assertEquals(jobResult.getRecordCount(), solrDocs.getNumFound());
                             assertEquals(0, jobResult.getDeletedRecordCount());
                             assertTrue(job.getLastSuccessfulRun().isPresent());
@@ -245,7 +239,7 @@ public class HarvestJobSchedulerServiceIT {
                         final SolrDocumentList solrDocs = results.resultAt(1);
 
                         aContext.verify(() -> {
-                            assertEquals(SET1_RECORD_COUNT, jobResult.getRecordCount());
+                            assertEquals(TestUtils.SET1_RECORD_COUNT, jobResult.getRecordCount());
                             assertEquals(jobResult.getRecordCount(), solrDocs.getNumFound());
                             assertEquals(0, jobResult.getDeletedRecordCount());
                             assertTrue(job.getLastSuccessfulRun().isPresent());
@@ -268,7 +262,7 @@ public class HarvestJobSchedulerServiceIT {
                 final Job job;
 
                 try {
-                    job = new Job(institutionID, myTestProviderBaseURL, List.of(SET1),
+                    job = new Job(institutionID, myTestProviderBaseURL, List.of(TestUtils.SET1),
                             TestUtils.getFutureCronExpression(5), null);
                 } catch (final ParseException details) {
                     return Future.failedFuture(details);
@@ -299,7 +293,7 @@ public class HarvestJobSchedulerServiceIT {
         final Checkpoint serviceSaved = aContext.checkpoint();
 
         // Add jobs before instantiation of the service
-        addInstitution().compose(institutionID -> addJob(institutionID, List.of(SET2))).compose(jobID -> {
+        addInstitution().compose(institutionID -> addJob(institutionID, List.of(TestUtils.SET2))).compose(jobID -> {
             final Checkpoint jobResultReceived = aContext.checkpoint(1);
 
             LOGGER.debug(MessageCodes.PRL_030);
@@ -318,7 +312,7 @@ public class HarvestJobSchedulerServiceIT {
                         final SolrDocumentList solrDocs = results.resultAt(1);
 
                         aContext.verify(() -> {
-                            assertEquals(SET2_RECORD_COUNT, jobResult.getRecordCount());
+                            assertEquals(TestUtils.SET2_RECORD_COUNT, jobResult.getRecordCount());
                             assertEquals(jobResult.getRecordCount(), solrDocs.getNumFound());
                             assertEquals(0, jobResult.getDeletedRecordCount());
                             assertTrue(job.getLastSuccessfulRun().isPresent());
@@ -343,7 +337,7 @@ public class HarvestJobSchedulerServiceIT {
 
                 serviceSaved.flag();
 
-                return updateJob(jobID, List.of(SET2));
+                return updateJob(jobID, List.of(TestUtils.SET2));
             }).onSuccess(result -> {
                 LOGGER.info(MessageCodes.PRL_032);
             });

--- a/src/test/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreServiceIT.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/services/HarvestScheduleStoreServiceIT.java
@@ -180,7 +180,7 @@ public class HarvestScheduleStoreServiceIT {
 
             for (final int institutionID : anInstitutionIDs) {
                 final Job job = new Job(institutionID, new URL(StringUtils.format("http://acme{}.edu/", institutionID)),
-                        null, new CronExpression(SAMPLE_CRON), null);
+                        List.of(), new CronExpression(SAMPLE_CRON), null);
 
                 jobs.add(job);
             }
@@ -515,8 +515,8 @@ public class HarvestScheduleStoreServiceIT {
 
         myScheduleStoreProxy.getJob(jobID).onSuccess(original -> {
             try {
-                final Job modified = new Job(original.getInstitutionID(), new URL(UPDATE_URL),
-                        original.getSets().orElse(null), original.getScheduleCronExpression(), OffsetDateTime.now());
+                final Job modified = new Job(original.getInstitutionID(), new URL(UPDATE_URL), original.getSets(),
+                        original.getScheduleCronExpression(), OffsetDateTime.now());
 
                 myScheduleStoreProxy.updateJob(jobID, modified).onSuccess(result -> {
                     myScheduleStoreProxy.getJob(jobID).onSuccess(updated -> {
@@ -546,7 +546,7 @@ public class HarvestScheduleStoreServiceIT {
 
         myScheduleStoreProxy.getJob(jobID).onSuccess(original -> {
             try {
-                final Job modified = new Job(badInstID, new URL(UPDATE_URL), original.getSets().orElse(null),
+                final Job modified = new Job(badInstID, new URL(UPDATE_URL), original.getSets(),
                         original.getScheduleCronExpression(), OffsetDateTime.now());
 
                 myScheduleStoreProxy.updateJob(jobID, modified).onFailure(details -> {

--- a/src/test/java/edu/ucla/library/prl/harvester/services/HarvestServiceIT.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/services/HarvestServiceIT.java
@@ -275,7 +275,7 @@ public class HarvestServiceIT {
      */
     private Future<Tuple2<JobResult, SolrDocumentList>> runJobAndCheckSolr(final Job aJob) {
         return myHarvestServiceProxy.run(aJob).compose(jobResult -> {
-            return TestUtils.getAllDocuments(mySolrClient).map(queryResults -> {
+            return TestUtils.getItemRecordDocuments(mySolrClient).map(queryResults -> {
                 return Tuple.of(jobResult, queryResults);
             });
         });

--- a/src/test/java/edu/ucla/library/prl/harvester/services/HarvestServiceIT.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/services/HarvestServiceIT.java
@@ -201,8 +201,8 @@ public class HarvestServiceIT {
                 Arguments.of(List.of(), schedule, null, 5, 0), //
                 Arguments.of(List.of("undefined"), schedule, null, 0, 0), //
                 Arguments.of(List.of(set1, "nil"), schedule, null, 2, 0), //
-                Arguments.of(null, schedule, OffsetDateTime.now().minusHours(1), 5, 0), //
-                Arguments.of(null, schedule, OffsetDateTime.now().plusHours(1), 0, 0));
+                Arguments.of(List.of(), schedule, OffsetDateTime.now().minusHours(1), 5, 0), //
+                Arguments.of(List.of(), schedule, OffsetDateTime.now().plusHours(1), 0, 0));
     }
 
     /**

--- a/src/test/java/edu/ucla/library/prl/harvester/utils/TestUtils.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/utils/TestUtils.java
@@ -499,4 +499,20 @@ public final class TestUtils {
             return new NoSuchElementException(LOGGER.getMessage(MessageCodes.PRL_023));
         });
     }
+
+    /**
+     * Gets a Cron expression that will match some time in the future.
+     *
+     * @param aSecondsLater The number of seconds in the future to create an hourly Cron expression for
+     * @return The Cron expression
+     * @throws ParseException
+     */
+    public static CronExpression getFutureCronExpression(final long aSecondsLater) throws ParseException {
+        final OffsetDateTime futureTime = OffsetDateTime.now().plusSeconds(aSecondsLater);
+        final String cron = String.format("%d %d * * * ?", futureTime.getSecond(), futureTime.getMinute());
+
+        LOGGER.debug(MessageCodes.PRL_033, aSecondsLater, cron);
+
+        return new CronExpression(cron);
+    }
 }

--- a/src/test/java/edu/ucla/library/prl/harvester/utils/TestUtils.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/utils/TestUtils.java
@@ -445,6 +445,24 @@ public final class TestUtils {
     }
 
     /**
+     * Constructs some assertions for the item record docs in the Solr index.
+     *
+     * @param aSolrClient A Solr client
+     * @param anExpectedRecordCount The number of item record docs that should exist
+     * @return A Future that resolves to a Runnable consisting of the assertions
+     */
+    public static Future<Runnable> getSolrItemRecordAssertions(final JavaAsyncSolrClient aSolrClient,
+            final int anExpectedRecordCount) {
+        return getItemRecordDocuments(aSolrClient).map(result -> {
+            final Runnable assertions = () -> {
+                assertEquals(anExpectedRecordCount, result.getNumFound());
+            };
+
+            return assertions;
+        });
+    }
+
+    /**
      * @param aRows Database query results
      * @param anExpectedRowAsJson The JSON representation that exactly one of the rows should have
      * @return Whether there exists a row that matches the expected JSON representation

--- a/src/test/java/edu/ucla/library/prl/harvester/utils/TestUtils.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/utils/TestUtils.java
@@ -104,6 +104,10 @@ public final class TestUtils {
 
     public static final String SET2 = "set2";
 
+    public static final int SET1_RECORD_COUNT = 2;
+
+    public static final int SET2_RECORD_COUNT = 3;
+
     private static final Random RANDOMIZER = new Random();
 
     private static final PhoneNumberUtil PHONE_NUMBER_UTIL = PhoneNumberUtil.getInstance();

--- a/src/test/java/edu/ucla/library/prl/harvester/utils/TestUtils.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/utils/TestUtils.java
@@ -133,7 +133,7 @@ public final class TestUtils {
 
     private static final String SOLR_ID_EXCLUDE = "id:(-{})";
 
-    private static final String INSTITUTION_DOC_ID_PATTERN = "prl-harvester-institution-*";
+    private static final String INSTITUTION_DOC_ID_PATTERN = StringUtils.format(Institution.SOLR_DOC_ID_TEMPLATE, "*");
 
     private static final Logger LOGGER = LoggerFactory.getLogger(TestUtils.class, MessageCodes.BUNDLE);
 


### PR DESCRIPTION
Cause: logic errors in UpdateJobHandler::updateSolr (which was sometimes calling OaipmhUtils::listSets twice, among other things; facilitated in part due to confusion caused by SERV-772).