### PR TITLE
[SERV-915] Improve space efficiency of HarvestServiceImpl

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ PGPASSWORD|The database password|No|pass
 PGPORT|The database port|No|5432
 PGUSER|The database username|No|user
 SOLR_CORE_URL|The Solr core URL|Yes|
+SOLR_UPDATE_MAX_BATCH_SIZE|The max batch size for Solr update queries|No|1000
 
 ## Running
 

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <libphonenumber.version>8.12.54</libphonenumber.version>
     <solrs.version>2.6.0</solrs.version>
     <xoai.version>4.2.0</xoai.version>
-    <guava.version>31.1-jre</guava.version>
+    <commons.collections4.version>4.4</commons.collections4.version>
     <jackson.version>2.14.2</jackson.version>
     <ldap.auth.version>4.4.0</ldap.auth.version>
 
@@ -241,9 +241,9 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-collections4</artifactId>
+      <version>${commons.collections4.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>

--- a/src/main/java/edu/ucla/library/prl/harvester/Config.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/Config.java
@@ -86,6 +86,11 @@ public final class Config {
     public static final String SOLR_CORE_URL = "SOLR_CORE_URL";
 
     /**
+     * The env property for the max batch size for Solr update queries.
+     */
+    public static final String SOLR_UPDATE_MAX_BATCH_SIZE = "SOLR_UPDATE_MAX_BATCH_SIZE";
+
+    /**
      * A logger.
      */
     private static final Logger LOGGER = LoggerFactory.getLogger(Config.class, MessageCodes.BUNDLE);
@@ -177,5 +182,15 @@ public final class Config {
      */
     public static int getOaipmhClientHttpTimeout(final JsonObject aConfig) {
         return aConfig.getInteger(Config.OAIPMH_CLIENT_HTTP_TIMEOUT, Constants.DEFAULT_OAIPMH_CLIENT_HTTP_TIMEOUT);
+    }
+
+    /**
+     * Gets the max batch size for Solr update queries.
+     *
+     * @param aConfig A configuration
+     * @return The max batch size
+     */
+    public static int getSolrUpdateMaxBatchSize(final JsonObject aConfig) {
+        return aConfig.getInteger(Config.SOLR_UPDATE_MAX_BATCH_SIZE, Constants.DEFAULT_SOLR_UPDATE_MAX_BATCH_SIZE);
     }
 }

--- a/src/main/java/edu/ucla/library/prl/harvester/Constants.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/Constants.java
@@ -27,6 +27,11 @@ public final class Constants {
     public static final int DEFAULT_OAIPMH_CLIENT_HTTP_TIMEOUT = 60_000;
 
     /**
+     * The default value for the max batch size for Solr update queries.
+     */
+    public static final Integer DEFAULT_SOLR_UPDATE_MAX_BATCH_SIZE = 1000;
+
+    /**
      * Constant classes should have private constructors.
      */
     private Constants() {

--- a/src/main/java/edu/ucla/library/prl/harvester/services/HarvestServiceImpl.java
+++ b/src/main/java/edu/ucla/library/prl/harvester/services/HarvestServiceImpl.java
@@ -143,7 +143,7 @@ public class HarvestServiceImpl implements HarvestService {
 
             startTime = OffsetDateTime.now();
 
-            LOGGER.debug(MessageCodes.PRL_008, aJob.toJson(), startTime);
+            LOGGER.debug(MessageCodes.PRL_008, aJob.toJson());
 
             // TODO: de-duplicate list of records (based on identifier; some sets may contain the same record)
             harvest = OaipmhUtils.listRecords(myVertx, baseURL, targetSets, aJob.getMetadataPrefix(),

--- a/src/main/resources/prl-harvester_messages.xml
+++ b/src/main/resources/prl-harvester_messages.xml
@@ -13,7 +13,7 @@
   <entry key="PRL_005">User '{}' connecting to test database at port '{}' with password: {}</entry>
   <entry key="PRL_006">Error during institution insert: {}</entry>
   <entry key="PRL_007">No institution found for ID: {}</entry>
-  <entry key="PRL_008">Starting job {} at {}</entry>
+  <entry key="PRL_008">Starting job {}</entry>
   <entry key="PRL_009">Error during job insert: {}</entry>
   <entry key="PRL_010">No job found for ID: {}</entry>
   <entry key="PRL_011">Institution found for fake ID: {}</entry>

--- a/src/main/resources/prl-harvester_messages.xml
+++ b/src/main/resources/prl-harvester_messages.xml
@@ -13,7 +13,7 @@
   <entry key="PRL_005">User '{}' connecting to test database at port '{}' with password: {}</entry>
   <entry key="PRL_006">Error during institution insert: {}</entry>
   <entry key="PRL_007">No institution found for ID: {}</entry>
-  <entry key="PRL_008">Starting job {}</entry>
+  <entry key="PRL_008">Started job {}</entry>
   <entry key="PRL_009">Error during job insert: {}</entry>
   <entry key="PRL_010">No job found for ID: {}</entry>
   <entry key="PRL_011">Institution found for fake ID: {}</entry>
@@ -54,5 +54,7 @@
   <entry key="PRL_046">Must provide non-empty list</entry>
   <entry key="PRL_047">[Bad Request] Validation error for body application/json: provided array should have size &gt;= 1</entry>
   <entry key="PRL_048">Could not find resource "{}": {}</entry>
+  <entry key="PRL_049">Finished job {}: {}</entry>
+  <entry key="PRL_050">Execution of job {} failed: {}</entry>
 
 </properties>

--- a/src/test/java/edu/ucla/library/prl/harvester/OaipmhUtilsFT.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/OaipmhUtilsFT.java
@@ -8,12 +8,9 @@ import static edu.ucla.library.prl.harvester.Constants.OAI_DC;
 
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
-
-import org.dspace.xoai.model.oaipmh.Record;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/edu/ucla/library/prl/harvester/OaipmhUtilsFT.java
+++ b/src/test/java/edu/ucla/library/prl/harvester/OaipmhUtilsFT.java
@@ -8,9 +8,12 @@ import static edu.ucla.library.prl.harvester.Constants.OAI_DC;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
+
+import org.dspace.xoai.model.oaipmh.Record;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -104,8 +107,19 @@ public class OaipmhUtilsFT {
             final VertxTestContext aContext) {
         OaipmhUtils.listRecords(aVertx, myTestDataProviderURL, aSets, OAI_DC, Optional.empty(),
                 myOaipmhClientHttpTimeout, myHarvesterUserAgent).onSuccess(records -> {
+                    final int recordCount;
+                    int runningRecordCount = 0;
+
+                    while (records.hasNext()) {
+                        records.next();
+
+                        runningRecordCount += 1;
+                    }
+
+                    recordCount = runningRecordCount;
+
                     aContext.verify(() -> {
-                        assertEquals(anExpectedRecordCount, records.toList().size());
+                        assertEquals(anExpectedRecordCount, recordCount);
                     }).completeNow();
                 });
     }


### PR DESCRIPTION
This places a configurable upper bound on the number of Solr documents instantiated per invocation of `HarvestServiceImpl#run`; previously it was unbounded, which could potentially use up all the heap space.

Tested locally with success on the especially large collection that revealed the problem.

Also adds a couple helpful logging statements.